### PR TITLE
ge_table is now array of addresses

### DIFF
--- a/interrupts.c
+++ b/interrupts.c
@@ -114,6 +114,8 @@ void kernel_oops() {
   int code = (mips32_get_c0(C0_CAUSE) & CR_X_MASK) >> CR_X_SHIFT;
 
   kprintf("[oops] %s at $%08x!\n", exceptions[code], mips32_get_c0(C0_ERRPC));
+  if (code == EXC_ADEL || code == EXC_ADES)
+    kprintf("[oops] Caused by reference to $%08x!\n", mips32_get_c0(C0_BADVADDR));
 
   panic("Unhandled exception");
 }

--- a/interrupts.c
+++ b/interrupts.c
@@ -4,28 +4,6 @@
 
 extern const char _ebase[];
 
-void intr_init() {
-  /*
-   * Enable Vectored Interrupt Mode as described in „MIPS32® 24KETM Processor
-   * Core Family Software User’s Manual”, chapter 6.3.1.2.
-   */
-
-  /* The location of exception vectors is set to EBase. */
-  mips32_set_c0(C0_EBASE, _ebase);
-  mips32_bc_c0(C0_STATUS, SR_BEV);
-  /* Use the special interrupt vector at EBase + 0x200. */
-  mips32_bs_c0(C0_CAUSE, CR_IV);
-  /* Set vector spacing for 0x20. */
-  mips32_set_c0(C0_INTCTL, INTCTL_VS_32);
-
-  /*
-   * Mask out software and hardware interrupts. 
-   * You should enable them one by one in driver initialization code.
-   */
-  mips32_set_c0(C0_STATUS, mips32_get_c0(C0_STATUS) & ~SR_IPL_MASK);
-
-  intr_enable();
-}
 
 static intr_event_t *events[8];
 
@@ -80,6 +58,7 @@ void intr_event_execute_handlers(intr_event_t *ie) {
 #endif
 }
 
+
 static const char *exceptions[32] = {
   [EXC_INTR] = "Interrupt",
   [EXC_MOD]  = "TLB modification exception",
@@ -105,9 +84,8 @@ void tlb_exception_handler()
   int code = (mips32_get_c0(C0_CAUSE) & CR_X_MASK) >> CR_X_SHIFT;
 
   kprintf("[tlb] %s at $%08x!\n", exceptions[code], mips32_get_c0(C0_ERRPC));
+  kprintf("[tlb] Caused by reference to $%08x!\n", mips32_get_c0(C0_BADVADDR));
 
-  if (code == EXC_ADEL || code == EXC_ADES)
-    kprintf("[tlb] Caused by reference to $%08x!\n", mips32_get_c0(C0_BADVADDR));
   panic("[tlb] TLB exception handler unimplemented\n");
 }
 
@@ -118,4 +96,56 @@ void kernel_oops() {
 
   if (code == EXC_ADEL || code == EXC_ADES)
     kprintf("[oops] Caused by reference to $%08x!\n", mips32_get_c0(C0_BADVADDR));
+
+  panic("Unhandled exception");
+}
+
+/* Following is general exception table. General exception handler has 
+ * very little space to use. So it loads address of handler from here 
+ * All functions being jumped to, should have ((interrupt)) attribute, 
+ * unless some exception is unhandled, then these functions should panic the kernel. 
+ * For exact meanings of exception handlers numbers please check 
+ * 5.23 Table of MIPS32 4KEc User's Manual. */
+uint32_t general_exception_table[32];
+
+void intr_init() {
+  /*
+   * Enable Vectored Interrupt Mode as described in „MIPS32® 24KETM Processor
+   * Core Family Software User’s Manual”, chapter 6.3.1.2.
+   */
+
+  /* The location of exception vectors is set to EBase. */
+  mips32_set_c0(C0_EBASE, _ebase);
+  mips32_bc_c0(C0_STATUS, SR_BEV);
+  /* Use the special interrupt vector at EBase + 0x200. */
+  mips32_bs_c0(C0_CAUSE, CR_IV);
+  /* Set vector spacing for 0x20. */
+  mips32_set_c0(C0_INTCTL, INTCTL_VS_32);
+
+  /*
+   * Mask out software and hardware interrupts. 
+   * You should enable them one by one in driver initialization code.
+   */
+  mips32_set_c0(C0_STATUS, mips32_get_c0(C0_STATUS) & ~SR_IPL_MASK);
+
+
+  /* Prepare general exception table with proper exception handler addresses. */
+  general_exception_table[EXC_INTR] =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_MOD]  =   (uint32_t)tlb_exception_handler;
+  general_exception_table[EXC_TLBL] =   (uint32_t)tlb_exception_handler;
+  general_exception_table[EXC_TLBS] =   (uint32_t)tlb_exception_handler; 
+  general_exception_table[EXC_ADEL] =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_ADES] =   (uint32_t)kernel_oops; 
+  general_exception_table[EXC_IBE]  =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_DBE]  =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_BP]   =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_RI]   =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_CPU]  =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_OVF]  =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_TRAP] =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_FPE]  =   (uint32_t)kernel_oops;
+  general_exception_table[EXC_WATCH] =  (uint32_t)kernel_oops;
+  general_exception_table[EXC_MCHECK] = (uint32_t)kernel_oops;
+
+  intr_enable();
 }

--- a/intr.S
+++ b/intr.S
@@ -34,21 +34,23 @@ general_exception:
         andi    $k0, $k0, CR_X_MASK
         srl     $k0, $k0, CR_X_SHIFT
         li      $k1, EXC_SYS
-        beq     $k1, $k0, 1f
+        beq     $k1, $k0, 2f
         nop
 
         la      $k1, general_exception_table
-        sll     $k0, $k0, 2                           /* Multiply exc_code by 4 */  
-        add     $k1, $k1, $k0                         /* Add exc_code */  
-        lw      $k1, 0($k1)                           /* Compute address of proper handler in ge table */
-        jr      $k1                                   /* Jump to handler */ 
+        sll     $k0, $k0, 2   /* Multiply exc_code by sizeof(void *) */  
+        add     $k1, $k1, $k0 /* Add exc_code */  
+        lw      $k1, 0($k1)   /* Load the address of a handler */
+        beqz    $k1, 1f       /* If NULL then call kernel_oops */
+        nop
+        jr      $k1           /* Jump to handler */ 
         nop
 
-        jal     kernel_oops
+1:      jal     kernel_oops
         nop
 
         /* syscalls not implemented yet */
-1:      j       1b
+2:      j       2b
         nop
 
         .org 0x200
@@ -170,10 +172,3 @@ irq_handler:
         ei
 
         eret
-/* Following is general exception table. General exception handler has 
- * very little space to use. So it jumps here, and from here we jump 
- * instantly to proper hander. All functions being jumped to, should 
- * have ((interrupt)) attribute, unless some exception is unhandled,
- * then these functions should panic the kernel. For exact meanings of
- * exception handlers numbers please check 5.23 Table of MIPS32 4KE User's Manual. */
-

--- a/intr.S
+++ b/intr.S
@@ -20,8 +20,8 @@
 
         .org 0x0
 tlb_refill:
-        j tlb_exception_handler
-        nop
+        sw $k0, 0($zero)
+        eret
 
         .org 0x100
 cache_error:
@@ -37,10 +37,11 @@ general_exception:
         beq     $k1, $k0, 1f
         nop
 
-        sll     $k0, $k0, 1            /* Multiply cause by two */
-        la      $k1, ge_table          /* Compute address of proper handler in ge table */
-        add     $k1, $k1, $k0
-        jr      $k1                    /* Jump to handler */ 
+        la      $k1, general_exception_table
+        sll     $k0, $k0, 2                           /* Multiply exc_code by 4 */  
+        add     $k1, $k1, $k0                         /* Add exc_code */  
+        lw      $k1, 0($k1)                           /* Compute address of proper handler in ge table */
+        jr      $k1                                   /* Jump to handler */ 
         nop
 
         jal     kernel_oops
@@ -176,55 +177,3 @@ irq_handler:
  * then these functions should panic the kernel. For exact meanings of
  * exception handlers numbers please check 5.23 Table of MIPS32 4KE User's Manual. */
 
-ge_table:
-        j       kernel_oops /* 0 */
-        nop
-        j       tlb_exception_handler /* 1 */
-        nop
-        j       tlb_exception_handler /* 2 */
-        nop
-        j       tlb_exception_handler /* 3 */
-        nop
-        j       kernel_oops /* 4 */
-        nop
-        j       kernel_oops /* 5 */
-        nop
-        j       kernel_oops /* 6 */
-        nop
-        j       kernel_oops /* 7 */
-        nop
-        j       kernel_oops /* 8 */
-        nop
-        j       kernel_oops /* 9 */
-        nop
-        j       kernel_oops /* 10 */
-        nop
-        j       kernel_oops /* 11 */
-        nop
-        j       kernel_oops /* 12 */
-        nop
-        j       kernel_oops /* 13 */
-        nop
-        nop           /* 14, reserved */
-        nop
-        nop           /* 15, reserved */
-        nop
-        j       kernel_oops /* 16 */
-        nop
-        j       kernel_oops /* 17 */
-        nop
-        j       kernel_oops /* 18 */
-        nop
-        nop           /* 19, reserved */
-        nop
-        nop           /* 20, reserved */
-        nop
-        nop           /* 21, reserved */
-        nop
-        nop           /* 22, reserved */
-        nop
-        nop           /* 23, reserved */
-        nop
-        j       kernel_oops /* 24, reserved */
-        nop
-        nop

--- a/intr.S
+++ b/intr.S
@@ -20,8 +20,8 @@
 
         .org 0x0
 tlb_refill:
-        sw $k0, 0($zero)
-        eret
+        j kernel_oops
+        nop
 
         .org 0x100
 cache_error:


### PR DESCRIPTION
Look at title for more description.
@cahirwpz Please review this code. I'm bad assembly programmer, so I'd rather make sure everything works, before this goes to repo.

Besides I think irq_handler asm code can be simplified and we can directly jump to proper functions. I guess it is enough to mark proper functions with ((interrupt)) attribute. For example we could remove entire 'irq_handler' label in intr.S and then mark hardclock with ((attribute)), and other functions aswell. Note that there are more awesome properties of attributes, for more information check here: 

https://gcc.gnu.org/onlinedocs/gcc/MIPS-Function-Attributes.html