### PR TITLE
Pmap remove pde

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -36,7 +36,7 @@ typedef struct vm_page {
     } obj;
     struct {
       TAILQ_ENTRY(vm_page) list;
-      uint16_t entries_cnt; /* number of active entries in pmap */
+      uint16_t valid_cnt; /* number of valid entries in pmap */
       uint16_t pde_index; /* pde index this page is associated with */
     } pt;
   };

--- a/include/vm.h
+++ b/include/vm.h
@@ -36,6 +36,8 @@ typedef struct vm_page {
     } obj;
     struct {
       TAILQ_ENTRY(vm_page) list;
+      uint16_t entries_cnt; /* number of active entries in pmap */
+      uint16_t pde_index; /* pde index this page is associated with */
     } pt;
   };
   vm_addr_t vm_offset;          /* offset to page in vm_object */

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -44,6 +44,15 @@ static pmap_range_t pmap_range[PMAP_LAST] = {
   [PMAP_USER] = {0x00000000, MIPS_KSEG0_START} /* useg */
 };
 
+vm_page_t *pmap_find_pde_page(pmap_t *pmap, uint16_t pde_index) {
+  vm_page_t *it;
+  TAILQ_FOREACH(it, &pmap->pte_pages, pt.list) {
+    if(it->pt.pde_index == pde_index)
+      return it;
+  }
+  return NULL;
+}
+
 void pmap_setup(pmap_t *pmap, pmap_type_t type, asid_t asid) {
   pmap->type = type;
   pmap->pte = (pte_t *)PT_BASE;

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -110,6 +110,8 @@ static void pmap_add_pde(pmap_t *pmap, vm_addr_t vaddr) {
   assert (!is_valid(PDE_OF(pmap, vaddr)));
 
   vm_page_t *pg = pm_alloc(1);
+  pg->pt.pde_index = PDE_INDEX(vaddr);
+  pg->pt.valid_cnt = 0;
   TAILQ_INSERT_TAIL(&pmap->pte_pages, pg, pt.list);
   log("Page table fragment %08lx allocated at %08lx", 
       PTF_ADDR_OF(vaddr), pg->paddr);

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -121,8 +121,12 @@ static void pmap_add_pde(pmap_t *pmap, vm_addr_t vaddr) {
     pte[i] = PTE_GLOBAL;
 }
 
-/* TODO: implement */
-void pmap_remove_pde(pmap_t *pmap, vm_addr_t vaddr);
+static void pmap_remove_pde(pmap_t *pmap, vm_page_t *pg) {
+    assert(pg->pt.valid_cnt == 0);
+    int pde_index = pg->pt.pde_index;
+    pmap->pde[pde_index] = 0;
+    TAILQ_REMOVE(&pmap->pte_pages, pg, pt.list);
+}
 
 #if 0
 /* Used if CPU implements RI and XI bits in ENTRYLO. */
@@ -160,6 +164,7 @@ static void pmap_set_pte(pmap_t *pmap, vm_addr_t vaddr, pm_addr_t paddr,
       ((prot & PTE_VALID) >> ENTRYLO0_V_SHIFT);
   if(diff) {
     vm_page_t *pg = pmap_find_pde_page(pmap, PDE_INDEX(vaddr));
+    assert(pg);
     pg->pt.valid_cnt += diff;
   }
 
@@ -167,7 +172,6 @@ static void pmap_set_pte(pmap_t *pmap, vm_addr_t vaddr, pm_addr_t paddr,
     (pmap->type == PMAP_KERNEL ? PTE_GLOBAL : 0);
   log("Add mapping for page %08lx (PTE at %08lx)",
       (vaddr & PTE_MASK), (intptr_t)&PTE_OF(pmap, vaddr));
-
 
   /* invalidate corresponding entry in tlb */
   tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
@@ -181,7 +185,11 @@ static void pmap_clear_pte(pmap_t *pmap, vm_addr_t vaddr) {
   /* invalidate corresponding entry in tlb */
   tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
 
-  /* TODO: Deallocate empty page table fragment by calling pmap_remove_pde. */
+  /* remove pde page if possible */
+  vm_page_t *pg = pmap_find_pde_page(pmap, PDE_INDEX(vaddr));
+  if(!pg->pt.valid_cnt) {
+    pmap_remove_pde(pmap, pg);
+  }
 }
 
 /* TODO: what about caches? */


### PR DESCRIPTION
I had a problem with debugging which turned out not to be a bug in my code but... in Makefile, after running `make clean` and `make` code started to work, someone (possibly having more experience in writing Makefiles) needs to look into Makefile because this consumed few hours of my time.

I'm still not 100% sure that code works, this needs some kind of testing, and I'll work on it. There are few points to make:

- Number of mapped entries is number of valid entries. When there are no valid PTE entries on PDE page I assume that PDE page can be deleted.
- Since I decided to count valid entries I needed space to do so. I had couple of ideas like
 - Add array with PDE_SIZE entries which would keep count for every PDE entry. This is obviously wrong because this would eat A LOT of space and increase initialization time.
 - Add extra structure which would keep reference to allocated page along with the count. I didn't like this idea, because this required me to manage memory of extra structure which i don't like doing (and pmap doesn't have any memory pool).
- The best Idea I could come up with was add extra fields in `vm_page`, note that because it is inside union, there is basically no extra space overhead.