### PR TITLE
Improved emacs integration

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -1,0 +1,3 @@
+-I./include
+-I~/local/imgtec/Toolchains/mips-mti-elf/2015.06-05/mips-mti-elf/include
+-std=gnu11

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *~
 *.orig
 *.log
+*#
 
 # Linker output
 *.map
@@ -21,6 +22,7 @@
 # ctags & cscope files
 cscope.out
 tags
+etags
 *.taghl
 
 # generated assembly files

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,17 @@ cscope:
 
 tags:
 	find -iname '*.[ch]' | ctags --language-force=c -L-
+	find -iname '*.[ch]' | ctags --language-force=c -L- -e -f etags
 	find -iname '*.S' | ctags -a --language-force=asm -L-
+	find -iname '*.S' | ctags -a --language-force=asm -L- -e -f etags
 	find $(SYSROOT)/mips-mti-elf/include -type f -iname 'mips*' \
 		| ctags -a --language-force=c -L-
+	find $(SYSROOT)/mips-mti-elf/include -type f -iname 'mips*' \
+		| ctags -a --language-force=c -L- -e -f etags
 	find $(SYSROOT)/lib/gcc/mips-mti-elf/*/include -type f -iname '*.h' \
 		| ctags -a --language-force=c -L-
+	find $(SYSROOT)/lib/gcc/mips-mti-elf/*/include -type f -iname '*.h' \
+		| ctags -a --language-force=c -L- -e -f etags
 
 astyle:
 	astyle --options=astyle.options --recursive "*.h" "*.c" \


### PR DESCRIPTION
- Generating emacs-style tags file
- Added emacs backup files to gitignore
- Created a minimal .clang_complete which specifies standard and include
dirs for autocompletion and on-the-fly compilation checks