### PR TITLE
Fixed TLB entry not invalidated due to bad asid mask

### DIFF
--- a/include/mips/tlb.h
+++ b/include/mips/tlb.h
@@ -35,7 +35,7 @@
 #define PTE_ASID_MASK 0x000000ff
 
 #define PTE_VPN2(addr) ((addr) & PTE_VPN2_MASK)
-#define PTE_ASID(asid) ((asid) & PTE_VPN2_MASK)
+#define PTE_ASID(asid) ((asid) & PTE_ASID_MASK)
 
 #define PT_BASE MIPS_KSEG2_START
 


### PR DESCRIPTION
Hello

I'm using your platform as a reference in my own hobby educational OS and I've found this typo while debugging..
It seems to cause pmap_map() to fail invalidating TLB entries and this affects mapping a PFN1 page while PFN0 is already mapped or the other way around.