### PR TITLE
Fixed C0_PAGEMASK garbage values in tlb_overwrite_random()

### DIFF
--- a/mips/tlb_ops.S
+++ b/mips/tlb_ops.S
@@ -92,7 +92,7 @@ LEAF(tlb_overwrite_random)
 	mfc0	v0, C0_INDEX
 	mtc0	a1, C0_ENTRYLO0
 	mtc0	a2, C0_ENTRYLO1
-	mtc0	a3, C0_PAGEMASK
+	mtc0	$0, C0_PAGEMASK
 
 	ehb		                # mtc0, hazard on tlbwi
 	bltz	v0, 1f	                # no matching entry


### PR DESCRIPTION
tlb_overwrite_random() assumed to be given a forth argument to write to C0_PAGEMASK
but C function declaration did not reflect this argument and was called without it.
the PageMask register might be overwritten with garbage data