### PR TITLE
Fixed wrong bitmask in status register in user_exc_enter()

### DIFF
--- a/mips/exc.S
+++ b/mips/exc.S
@@ -73,7 +73,7 @@ user_exc_enter:
 
         # Turn off FPU, enter kernel mode,
         # drop exception level and disable interrupts.
-        li      $t1, ~(SR_CU1|SR_KSU_KERN|SR_EXL|SR_IE)
+        li      $t1, ~(SR_CU1|SR_KSU_MASK|SR_EXL|SR_IE)
         and     $t0, $t1
         mtc0    $t0, C0_STATUS
 


### PR DESCRIPTION
The status register SR_KSU bits are: 0 for kernel, 1 for supervisor, 2 for user
Before this commit, user_exc_enter() 'turned off' the kernel-bits instead of the user-bits