### PR TITLE
Use global var instead of C0_USERLOCAL for improved portability.

### DIFF
--- a/mips/exc.S
+++ b/mips/exc.S
@@ -11,6 +11,8 @@
         .globl kern_exc_leave
         .local user_exc_enter
         .local kern_exc_enter
+        .extern _current_thread
+
 
 # [$k0] must be set to value of C0_STATUS
 exc_enter:
@@ -20,7 +22,8 @@ exc_enter:
 
 user_exc_enter:
         # Fetch the context from thread control block.
-        mfc0    $k0, C0_USERLOCAL
+        la      $k0, _current_thread
+        lw      $k0, 0($k0)
         addu    $k0, TD_UCTX
 
         # Save all user registers...
@@ -88,7 +91,8 @@ user_exc_enter:
 
 user_exc_leave:
         # Fetch the context from thread control block.
-        mfc0    $k0, C0_USERLOCAL
+        la      $k0, _current_thread
+        lw      $k0, 0($k0)
         addu    $k0, TD_UCTX
 
         # Update status register held in user context (interrupt mask).
@@ -205,7 +209,8 @@ kern_exc_enter:
         la      $gp, _gp
 
         # Save stack frame pointer into td_frame.
-        mfc0    $t0, C0_USERLOCAL
+        la      $t0, _current_thread
+        lw      $t0, 0($t0)
         sw      $sp, TD_KFRAME($t0)
 
         # Call C interrupt handler routine.
@@ -213,7 +218,8 @@ kern_exc_enter:
         nop
 
         # Interrupts may be enabled here and that's ok.
-        mfc0    $t0, C0_USERLOCAL
+        la      $t0, _current_thread
+        lw      $t0, 0($t0)
         lw      $t1, TD_FLAGS($t0)
         andi    $t1, TDF_NEEDSWITCH
         beqz    $t1, 1f

--- a/mips/switch.S
+++ b/mips/switch.S
@@ -8,6 +8,7 @@
 
         .global ctx_switch
         .local  ctx_resume
+        .extern _current_thread
 
 #
 # void ctx_switch(thread_t *from, thread_t *to)
@@ -36,7 +37,8 @@ LEAF(ctx_switch)
 ctx_resume:
         addu    $a1, TD_KCTX
         LOAD_REG($t0, TCB, $a1)
-        mtc0    $t0, C0_USERLOCAL
+        la      $t1, _current_thread
+        sw      $t0, 0($t1)
         LOAD_REG($ra, PC, $a1)
         LOAD_REG($fp, FP, $a1)
         LOAD_REG($sp, SP, $a1)

--- a/mips/thread.c
+++ b/mips/thread.c
@@ -1,6 +1,8 @@
 #include <mips/mips.h>
 #include <thread.h>
 
+thread_t* _current_thread = NULL;
+
 thread_t *thread_self() {
-  return (thread_t *)mips32_get_c0(C0_USERLOCAL);
+  return _current_thread;
 }


### PR DESCRIPTION
A regular global variable is less cool, but much more portable then a c0 USERLOCAL register..

USERLOCAL behaves weird on QEMU and this is one of the changes needed for running mimiker on QEMU.