### PR TITLE
boot: use regular jr to transfer control to kernel_boot instead of eret

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ MIPS documentation:
 * [MIPS32® 24KEf™ Processor Core Datasheet](http://wiki.prplfoundation.org/w/images/9/9c/MD00446-2B-24KEF-DTS-02.00.pdf)
 * [Programming the MIPS32® 24KE™ Core Family](http://wiki.prplfoundation.org/w/images/2/20/MD00458-2B-24KEPRG-PRG-04.63.pdf)
 * [MIPS® YAMON™ User’s Manual](http://wiki.prplfoundation.org/w/images/b/b9/MD00008-2B-YAMON-USM-02.19.pdf)
+* [MIPS® YAMON™ Reference Manual](http://wiki.prplfoundation.org/w/images/8/80/MD00009-2B-YAMON-RFM-02.20.pdf)
 * [MIPS ABI Project](https://dmz-portal.mips.com/wiki/MIPS_ABI_Project)
 
 Hardware documentation:

--- a/mips/boot.S
+++ b/mips/boot.S
@@ -7,6 +7,7 @@
         .local kernel_go
 
 # Boot environment is described in MIPS® YAMON™ User's Manual, Chapter 5
+# ... and MIPS® YAMON™ Reference Manual, Chapter 8.3
 #
 # $a0 = argc
 # $a1 = argv
@@ -15,7 +16,8 @@
 #
 # $sp is initialized
 # $gp is not initialized
-# C0_STATUS(SR_IE) is cleared
+#
+# C0_STATUS is same as YAMON™ context, but interrupts are disabled.
 
 LEAF(_start)
         la      $t0, _memsize
@@ -31,17 +33,18 @@ clear_bss:
         addiu   $t0, 4
 
 kernel_go:
-	/*
-	* We will preserve SR_BEV settings for now, until we override it later on.
-	* SR_SR (Soft Reset bit) will be preserved as well to support reboot in the future.
-        */
+	# Let's preserve SR_BEV for now, until interrupts are propely set up
+	# later. SR_SR (Soft Reset) bit will be preserved as well to support
+	# reboot in the future.
         li      $t0, (SR_BEV | SR_SR)
         mfc0    $t1, C0_STATUS
         and     $t1, $t0
         mtc0    $t1, C0_STATUS
         ehb
 
-	/* Transfer control to `kernel_boot`, and hang if it returns */
+	# Transfer control to `kernel_boot` running in kernel mode with
+	# interrupts and FPU disabled.
+	# If kernel ever decides to return just loop forever.
         la      $ra, kernel_exit
         la      $t0, kernel_boot
         jr      $t0

--- a/mips/boot.S
+++ b/mips/boot.S
@@ -14,6 +14,8 @@
 # $a3 = memsize
 #
 # $sp is initialized
+# $gp is not initialized
+# C0_STATUS(SR_IE) is cleared
 
 LEAF(_start)
         la      $t0, _memsize
@@ -29,17 +31,21 @@ clear_bss:
         addiu   $t0, 4
 
 kernel_go:
-        # Status.ERL is set by the processor when a Reset, Soft Reset, NMI or
-        # Cache Error exception are taken. When ERL is set:
-        # - The processor is running in kernel mode
-        # - Hardware and software interrupts are disabled
-        # - The ERET instruction will use the return address held in ErrorEPC
-        #   instead of EPC
+	/*
+	* We will preserve SR_BEV settings for now, until we override it later on.
+	* SR_SR (Soft Reset bit) will be preserved as well to support reboot in the future.
+        */
+        li      $t0, (SR_BEV | SR_SR)
+        mfc0    $t1, C0_STATUS
+        and     $t1, $t0
+        mtc0    $t1, C0_STATUS
+        ehb
 
+	/* Transfer control to `kernel_boot`, and hang if it returns */
         la      $ra, kernel_exit
         la      $t0, kernel_boot
-        mtc0    $t0, C0_ERRPC    # Return from exception to kernel_boot
-        eret                     # exception => normal level (SR_ERL = 0)
+        jr      $t0
+        nop
 END(_start)
 
 LEAF(kernel_exit)


### PR DESCRIPTION
QEMU does not like c0_errpc and freaks out

Please report if this breaks your non-qemu emulator.
And if its does, we'll need to think if we want to solve this in different compilation targets or in startup runtime.