### PR TITLE
Introduced pcpu_t structure to hold global cpu state

### DIFF
--- a/include/mips/pcpu.h
+++ b/include/mips/pcpu.h
@@ -1,0 +1,13 @@
+#ifndef _MIPS_PCPU_H_
+#define _MIPS_PCPU_H_
+
+#ifdef __ASSEMBLER__
+
+#include <mips/asm.h>
+#include <mips/mips.h>
+
+#define GET_CPU_PCPU(reg)        LA reg, _pcpu_data
+#define PCPU_OFFSET(reg, member) PCPU_##member(reg)
+
+#endif // !__ASSEMBLER__
+#endif // _MIPS_PCPU_H_

--- a/include/mips/pcpu.h
+++ b/include/mips/pcpu.h
@@ -6,8 +6,8 @@
 #include <mips/asm.h>
 #include <mips/mips.h>
 
-#define GET_CPU_PCPU(reg)        LA reg, _pcpu_data
-#define PCPU_OFFSET(reg, member) PCPU_##member(reg)
+#define LOAD_PCPU(reg) \
+	LA reg, _pcpu_data
 
 #endif // !__ASSEMBLER__
 #endif // _MIPS_PCPU_H_

--- a/include/pcpu.h
+++ b/include/pcpu.h
@@ -1,0 +1,23 @@
+#ifndef _PCPU_H_
+#define _PCPU_H_
+
+#include <thread.h>
+
+typedef struct pcpu {
+    thread_t* current_thread;
+} pcpu_t;
+
+
+extern pcpu_t _pcpu_data[1];
+
+/* Read pcpu.h from FreeBSD for API reference */
+#define PCPU_ADD(member, value) (_pcpu_data->member += (value))
+#define PCPU_GET(member)        (_pcpu_data->member)
+#define PCPU_INC(member)        PCPU_ADD(member, 1)
+#define PCPU_PTR(member)        (&_pcpu_data->member)
+#define PCPU_SET(member, value) (_pcpu_data->member = (value))
+#define PCPU_LAZY_INC(member)   (++_pcpu_data->member)
+
+void pcpu_init(void);
+
+#endif /* _PCPU_H_ */

--- a/include/pcpu.h
+++ b/include/pcpu.h
@@ -4,19 +4,15 @@
 #include <thread.h>
 
 typedef struct pcpu {
-    thread_t* current_thread;
+    thread_t *curthread;
 } pcpu_t;
-
 
 extern pcpu_t _pcpu_data[1];
 
 /* Read pcpu.h from FreeBSD for API reference */
-#define PCPU_ADD(member, value) (_pcpu_data->member += (value))
 #define PCPU_GET(member)        (_pcpu_data->member)
-#define PCPU_INC(member)        PCPU_ADD(member, 1)
 #define PCPU_PTR(member)        (&_pcpu_data->member)
 #define PCPU_SET(member, value) (_pcpu_data->member = (value))
-#define PCPU_LAZY_INC(member)   (++_pcpu_data->member)
 
 void pcpu_init(void);
 

--- a/mips/exc.S
+++ b/mips/exc.S
@@ -1,4 +1,5 @@
 #include <mips/exc.h>
+#include <mips/pcpu.h>
 
 #include "genassym.h"
 
@@ -20,7 +21,8 @@ exc_enter:
 
 user_exc_enter:
         # Fetch the context from thread control block.
-        mfc0    $k0, C0_USERLOCAL
+        GET_CPU_PCPU($k0)
+        lw      $k0, PCPU_OFFSET($k0, CURRENT_THREAD)
         addu    $k0, TD_UCTX
 
         # Save all user registers...
@@ -88,7 +90,8 @@ user_exc_enter:
 
 user_exc_leave:
         # Fetch the context from thread control block.
-        mfc0    $k0, C0_USERLOCAL
+        GET_CPU_PCPU($k0)
+        lw      $k0, PCPU_OFFSET($k0, CURRENT_THREAD)
         addu    $k0, TD_UCTX
 
         # Update status register held in user context (interrupt mask).
@@ -205,7 +208,8 @@ kern_exc_enter:
         la      $gp, _gp
 
         # Save stack frame pointer into td_frame.
-        mfc0    $t0, C0_USERLOCAL
+        GET_CPU_PCPU($t0)
+        lw      $t0, PCPU_OFFSET($t0, CURRENT_THREAD)
         sw      $sp, TD_KFRAME($t0)
 
         # Call C interrupt handler routine.
@@ -213,7 +217,8 @@ kern_exc_enter:
         nop
 
         # Interrupts may be enabled here and that's ok.
-        mfc0    $t0, C0_USERLOCAL
+        GET_CPU_PCPU($t0)
+        lw      $t0, PCPU_OFFSET($t0, CURRENT_THREAD)
         lw      $t1, TD_FLAGS($t0)
         andi    $t1, TDF_NEEDSWITCH
         beqz    $t1, 1f

--- a/mips/exc.S
+++ b/mips/exc.S
@@ -21,8 +21,8 @@ exc_enter:
 
 user_exc_enter:
         # Fetch the context from thread control block.
-        GET_CPU_PCPU($k0)
-        lw      $k0, PCPU_OFFSET($k0, CURRENT_THREAD)
+        LOAD_PCPU($k0)
+        lw      $k0, PCPU_CURTHREAD($k0)
         addu    $k0, TD_UCTX
 
         # Save all user registers...
@@ -90,8 +90,8 @@ user_exc_enter:
 
 user_exc_leave:
         # Fetch the context from thread control block.
-        GET_CPU_PCPU($k0)
-        lw      $k0, PCPU_OFFSET($k0, CURRENT_THREAD)
+        LOAD_PCPU($k0)
+        lw      $k0, PCPU_CURTHREAD($k0)
         addu    $k0, TD_UCTX
 
         # Update status register held in user context (interrupt mask).
@@ -208,8 +208,8 @@ kern_exc_enter:
         la      $gp, _gp
 
         # Save stack frame pointer into td_frame.
-        GET_CPU_PCPU($t0)
-        lw      $t0, PCPU_OFFSET($t0, CURRENT_THREAD)
+        LOAD_PCPU($t0)
+        lw      $t0, PCPU_CURTHREAD($t0)
         sw      $sp, TD_KFRAME($t0)
 
         # Call C interrupt handler routine.
@@ -217,8 +217,8 @@ kern_exc_enter:
         nop
 
         # Interrupts may be enabled here and that's ok.
-        GET_CPU_PCPU($t0)
-        lw      $t0, PCPU_OFFSET($t0, CURRENT_THREAD)
+        LOAD_PCPU($t0)
+        lw      $t0, PCPU_CURTHREAD($t0)
         lw      $t1, TD_FLAGS($t0)
         andi    $t1, TDF_NEEDSWITCH
         beqz    $t1, 1f

--- a/mips/genassym.c
+++ b/mips/genassym.c
@@ -1,5 +1,6 @@
 #include <assym.h>
 #include <thread.h>
+#include <pcpu.h>
 #include <mips/ctx.h>
 #include <mips/exc.h>
 
@@ -77,3 +78,5 @@ ASSYM(EXC_BADVADDR, offsetof(exc_frame_t, badvaddr));
 ASSYM(EXC_CAUSE, offsetof(exc_frame_t, cause));
 
 ASSYM(EXC_FRAME_SIZE, sizeof(exc_frame_t) + CALLFRAME_SIZE);
+
+ASSYM(PCPU_CURRENT_THREAD, offsetof(pcpu_t, current_thread));

--- a/mips/genassym.c
+++ b/mips/genassym.c
@@ -79,4 +79,4 @@ ASSYM(EXC_CAUSE, offsetof(exc_frame_t, cause));
 
 ASSYM(EXC_FRAME_SIZE, sizeof(exc_frame_t) + CALLFRAME_SIZE);
 
-ASSYM(PCPU_CURRENT_THREAD, offsetof(pcpu_t, current_thread));
+ASSYM(PCPU_CURTHREAD, offsetof(pcpu_t, curthread));

--- a/mips/switch.S
+++ b/mips/switch.S
@@ -1,6 +1,7 @@
 #include <mips/asm.h>
 #include <mips/m32c0.h>
 #include <mips/ctx.h>
+#include <mips/pcpu.h>
 
 #include "genassym.h"
 
@@ -36,7 +37,8 @@ LEAF(ctx_switch)
 ctx_resume:
         addu    $a1, TD_KCTX
         LOAD_REG($t0, TCB, $a1)
-        mtc0    $t0, C0_USERLOCAL
+        GET_CPU_PCPU($t1)
+        sw      $t0, PCPU_OFFSET($t1, CURRENT_THREAD)
         LOAD_REG($ra, PC, $a1)
         LOAD_REG($fp, FP, $a1)
         LOAD_REG($sp, SP, $a1)

--- a/mips/switch.S
+++ b/mips/switch.S
@@ -37,8 +37,8 @@ LEAF(ctx_switch)
 ctx_resume:
         addu    $a1, TD_KCTX
         LOAD_REG($t0, TCB, $a1)
-        GET_CPU_PCPU($t1)
-        sw      $t0, PCPU_OFFSET($t1, CURRENT_THREAD)
+        LOAD_PCPU($t1)
+        sw      $t0, PCPU_CURTHREAD($t1)
         LOAD_REG($ra, PC, $a1)
         LOAD_REG($fp, FP, $a1)
         LOAD_REG($sp, SP, $a1)

--- a/mips/thread.c
+++ b/mips/thread.c
@@ -3,5 +3,5 @@
 #include <pcpu.h>
 
 thread_t *thread_self() {
-  return PCPU_GET(current_thread);
+  return PCPU_GET(curthread);
 }

--- a/mips/thread.c
+++ b/mips/thread.c
@@ -1,6 +1,7 @@
 #include <mips/mips.h>
 #include <thread.h>
+#include <pcpu.h>
 
 thread_t *thread_self() {
-  return (thread_t *)mips32_get_c0(C0_USERLOCAL);
+  return PCPU_GET(current_thread);
 }

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -2,7 +2,7 @@
 
 SOURCES_C = callout.c clock.c exception.c interrupt.c malloc.c pci_ids.c \
 	    physmem.c runq.c sched.c sleepq.c startup.c thread.c \
-	    vm_map.c vm_object.c vm_pager.c
+	    vm_map.c vm_object.c vm_pager.c pcpu.c
 SOURCES_ASM = 
 
 all: $(DEPFILES) libsys.a 

--- a/sys/pcpu.c
+++ b/sys/pcpu.c
@@ -1,0 +1,9 @@
+#include <stdc.h>
+#include <pcpu.h>
+
+pcpu_t _pcpu_data[1];
+
+void pcpu_init(void) {
+  memset(_pcpu_data, 0, sizeof(_pcpu_data));
+}
+

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -5,6 +5,7 @@
 #include <mips/tlb.h>
 #include <mips/clock.h>
 #include <interrupt.h>
+#include <pcpu.h>
 #include <malloc.h>
 #include <physmem.h>
 #include <pci.h>
@@ -36,6 +37,7 @@ int kernel_boot(int argc, char **argv, char **envp) {
   kprintf("\n");
 
   cpu_init();
+  pcpu_init();
   pci_init();
   pm_init();
   intr_init();


### PR DESCRIPTION
Initial proposal for the implementation of the pcpu_t structure used to hold global cpu state

* Used sys/mips/include/pcpu.h and sys/sys/pcpu.h as reference.
* Implemented both C and ASM api macros.
* In the future this will hold per-cpu cpu state, for now its a simple global cpu state structure.
* As of now, only `current_thread` is held in pcpu_t.