### PR TITLE
Remove asid from vm_map and pmap interface

### DIFF
--- a/include/mips/mips.h
+++ b/include/mips/mips.h
@@ -21,7 +21,7 @@
 #define MIPS_KSEG1_START 0xa0000000
 #define MIPS_KSEG2_START 0xc0000000
 #define MIPS_PHYS_MASK   0x1fffffff
-
+#define MAX_ASID C0_ENTRYHI_ASID_MASK
 #ifndef __ASSEMBLER__
 
 /*

--- a/include/pmap.h
+++ b/include/pmap.h
@@ -20,7 +20,7 @@ typedef struct {
   asid_t asid;
 } pmap_t;
 
-void pmap_setup(pmap_t *pmap, pmap_type_t type, asid_t asid);
+void pmap_setup(pmap_t *pmap, pmap_type_t type);
 void pmap_reset(pmap_t *);
 
 bool pmap_is_mapped(pmap_t *pmap, vm_addr_t vaddr);

--- a/include/vm_map.h
+++ b/include/vm_map.h
@@ -42,7 +42,7 @@ vm_map_t *get_active_vm_map(pmap_type_t type);
 vm_map_t *get_active_vm_map_by_addr(vm_addr_t addr);
 
 void vm_map_init();
-vm_map_t *vm_map_new(vm_map_type_t t, asid_t asid);
+vm_map_t *vm_map_new(vm_map_type_t t);
 void vm_map_delete(vm_map_t *vm_map);
 
 vm_map_entry_t *vm_map_find_entry(vm_map_t *vm_map, vm_addr_t vaddr);

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -23,7 +23,6 @@
 #define PTF_SIZE (PTF_ENTRIES * sizeof(pte_t))
 #define PT_ENTRIES (PD_ENTRIES * PTF_ENTRIES)
 #define PT_SIZE (PT_ENTRIES * sizeof(pte_t))
-#define MAX_ASID 255
 
 static const vm_addr_t PT_HOLE_START =
   PT_BASE + MIPS_KSEG0_START / PTF_ENTRIES;

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -23,6 +23,7 @@
 #define PTF_SIZE (PTF_ENTRIES * sizeof(pte_t))
 #define PT_ENTRIES (PD_ENTRIES * PTF_ENTRIES)
 #define PT_SIZE (PT_ENTRIES * sizeof(pte_t))
+#define MAX_ASID 255
 
 static const vm_addr_t PT_HOLE_START =
   PT_BASE + MIPS_KSEG0_START / PTF_ENTRIES;
@@ -34,6 +35,7 @@ static bool is_valid(pte_t pte) {
 }
 
 static pmap_t *active_pmap[PMAP_LAST];
+static asid_t asid_counter;
 
 typedef struct {
   vm_addr_t start, end;
@@ -44,14 +46,23 @@ static pmap_range_t pmap_range[PMAP_LAST] = {
   [PMAP_USER] = {0x00000000, MIPS_KSEG0_START} /* useg */
 };
 
-void pmap_setup(pmap_t *pmap, pmap_type_t type, asid_t asid) {
+static asid_t get_new_asid()
+{
+    if(asid_counter < MAX_ASID)
+        return asid_counter++; //TODO this needs to be atomic increment
+    else
+        panic("Out of asids!");
+}
+
+void pmap_setup(pmap_t *pmap, pmap_type_t type) {
   pmap->type = type;
   pmap->pte = (pte_t *)PT_BASE;
   pmap->pde_page = pm_alloc(1);
   pmap->pde = (pte_t *)pmap->pde_page->vaddr;
   pmap->start = pmap_range[type].start;
   pmap->end = pmap_range[type].end;
-  pmap->asid = asid;
+  pmap->asid = get_new_asid();
+  assert(type != PMAP_KERNEL || pmap->asid == 0); //kernel pmap has asid 0
   log("Page directory table allocated at %08lx", (intptr_t)pmap->pde);
   TAILQ_INIT(&pmap->pte_pages);
 

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -45,12 +45,11 @@ static pmap_range_t pmap_range[PMAP_LAST] = {
   [PMAP_USER] = {0x00000000, MIPS_KSEG0_START} /* useg */
 };
 
-static asid_t get_new_asid()
-{
-    if(asid_counter < MAX_ASID)
-        return asid_counter++; //TODO this needs to be atomic increment
-    else
-        panic("Out of asids!");
+static asid_t get_new_asid() {
+  if (asid_counter < MAX_ASID)
+    return asid_counter++; // TODO this needs to be atomic increment
+  else
+    panic("Out of asids!");
 }
 
 void pmap_setup(pmap_t *pmap, pmap_type_t type) {

--- a/pmap.c
+++ b/pmap.c
@@ -52,8 +52,8 @@ static void change_pmap() {
   pmap_t pmap1;
   pmap_t pmap2;
   
-  pmap_setup(&pmap1, PMAP_USER, 7);
-  pmap_setup(&pmap2, PMAP_USER, 42);
+  pmap_setup(&pmap1, PMAP_USER);
+  pmap_setup(&pmap2, PMAP_USER);
   
 
   vm_addr_t start = 0x1001000;

--- a/sys/vm_map.c
+++ b/sys/vm_map.c
@@ -42,16 +42,16 @@ void vm_map_init() {
   vm_page_t *pg = pm_alloc(2);
   kmalloc_init(mpool);
   kmalloc_add_arena(mpool, pg->vaddr, PG_SIZE(pg));
-  vm_map_t *map = vm_map_new(PMAP_KERNEL, 0);
+  vm_map_t *map = vm_map_new(PMAP_KERNEL);
   set_active_vm_map(map);
 }
 
-vm_map_t *vm_map_new(vm_map_type_t type, asid_t asid) {
+vm_map_t *vm_map_new(vm_map_type_t type) {
   vm_map_t *map = kmalloc(mpool, sizeof(vm_map_t), M_ZERO);
 
   TAILQ_INIT(&map->list);
   SPLAY_INIT(&map->tree);
-  pmap_setup(&map->pmap, type, asid);
+  pmap_setup(&map->pmap, type);
   map->nentries = 0;
   return map;
 }

--- a/vm_map.c
+++ b/vm_map.c
@@ -4,7 +4,7 @@
 #include <vm_map.h>
 
 static void paging_on_demand_and_memory_protection_demo() {
-  set_active_vm_map(vm_map_new(PMAP_USER, 10));
+  set_active_vm_map(vm_map_new(USER_VM_MAP));
 
   vm_map_t *kmap = get_active_vm_map(PMAP_KERNEL);
   vm_map_t *umap = get_active_vm_map(PMAP_USER);


### PR DESCRIPTION
While working on changing vm_map for user threads i realised it is better to keep asids away from interface. In future, when we have processes we might want to create asid or pid allocator, but for now simple incrementation until we run out of asids should be enough.