### PR TITLE
Fix for user threads never getting preempted

### DIFF
--- a/mips/exc.S
+++ b/mips/exc.S
@@ -86,8 +86,16 @@ user_exc_enter:
 
         # Interrupts may be enabled here and that's ok.
 
+        LOAD_PCPU($t0)
+        lw      $t0, PCPU_CURTHREAD($t0)
+        lw      $t1, TD_FLAGS($t0)
+        andi    $t1, TDF_NEEDSWITCH
+        beqz    $t1, 1f
+        move    $a0, $sp
+        jal     exc_before_leave
+
         # Disable interrupts till ERET.
-        di
+1:      di
 
 user_exc_leave:
         # Fetch the context from thread control block.


### PR DESCRIPTION
The finalization for for `kernel_exc_enter` already checks whether the current threads `TD_NEEDSSWITCH`, and switches context if it does. This patch adds the same logic to `user_exc_enter`. Without this fix any thread running in user mode may be interrupted, but the scheduler never gets a chance to preempt it.

This is part of preparation for experimental usermode support I'm working on.
