### PR TITLE
Track file directory in make output

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -26,44 +26,46 @@ LDLIBS   =
 LDFLAGS  = -nostdlib -T malta.ld
 LD_EMBED =
 
+DIR = $(patsubst $(TOPDIR)/%,%,$(CURDIR)/)
+
 define emit_dep_rule
 CFILE = $(1)
 DFILE = .$(patsubst %.S,%.D,$(patsubst %.c,%.D,$(1)))
 $$(DFILE): $$(CFILE)
-	@echo "[DEP] $$@"
+	@echo "[DEP] $$(DIR)$$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -MM -MG $$^ -o $$@
 endef
 
 %.S: %.c
-	@echo "[CC] $< -> $@"
+	@echo "[CC] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -S -o $@ $<
 
 %.ko: %.c
-	@echo "[CC] $< -> $@"
+	@echo "[CC] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -D_KERNELSPACE -c -o $@ $<
 
 %.o: %.c
-	@echo "[CC] $< -> $@"
+	@echo "[CC] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
 %.o: %.S
-	@echo "[AS] $< -> $@"
+	@echo "[AS] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
 %.elf:	%.ko
-	@echo "[LD] $(filter %.ko,$^) -> $@"
+	@echo "[LD] $(addprefix $(DIR),$(filter %.ko,$^)) -> $(DIR)$@"
 	$(CC) $(LDFLAGS) $(filter %.ko,$^) -Wl,-Map=$@.map $(LDLIBS) $(LD_EMBED) -o $@
 
 %.test: %.c
-	@echo "[HOSTCC] $< -> $@"
+	@echo "[HOSTCC] $(DIR)$< -> $(DIR)$@"
 	$(HOSTCC) $(CFLAGS) $(CPPFLAGS) -D_USERSPACE -o $@ $<
 
 %.a:
-	@echo "[AR] $^ -> $@"
+	@echo "[AR] $(addprefix $(DIR),$^) -> $(DIR)$@"
 	$(AR) rs $@ $^
 
 %.h: %.o
-	@echo "[ASSYM] $<"
+	@echo "[ASSYM] $(DIR)$<"
 	$(GENASSYM) $<
 
 .PHONY: all clean

--- a/user/Makefile
+++ b/user/Makefile
@@ -7,18 +7,18 @@ LDFLAGS  = -nostdlib -T mimiker.ld -G0
 
 # Compiling the program source
 prog.o: prog.c
-	@echo "[CC] $< -> $@"
+	@echo "[CC] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 # Linking the program according to the provided script
 prog.uelf: prog.o start.o mimiker.ld
-	@echo "[LD] $< -> $@"
+	@echo "[LD] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(LDFLAGS) start.o -Wl,-Map=$@.map -o $@ $<
 
 # Treating the liked program as binary data, placing it in .rodata
 # section, and embedding into an object file
 prog.uelf.o: prog.uelf Makefile
-	@echo "[LD] $< -> $@"
+	@echo "[LD] $(DIR)$< -> $(DIR)$@"
 	$(OBJCOPY) -I binary --rename-section .data=.rodata,contents,readonly,data -O elf32-little --alt-machine-code=8 $< $@
 
 


### PR DESCRIPTION
This branch improves `make` output, so that processed files are represented by their path, not just their name. Current output is confusing for files from different directories that share identical names.

Old output format (fragments):
```
[CC] thread.c -> thread.o
[CC] pcpu.c -> pcpu.o
[AS] start.S -> start.o
[LD] prog.o -> prog.uelf
[CC] thread.c -> thread.ko
```

New output format:
```
[CC] sys/thread.c -> sys/thread.o
[CC] sys/pcpu.c -> sys/pcpu.o
[AS] user/start.S -> user/start.o
[LD] user/prog.o -> user/prog.uelf
[CC] thread.c -> thread.ko
```

This works even for multi-level recursive Makefiles. It also works when `make` is called in a subdirectory.