### PR TITLE
Fixed pmap_type/vm_map_type confusion

### DIFF
--- a/include/vm_map.h
+++ b/include/vm_map.h
@@ -9,7 +9,7 @@
  * That's because in current implementation page table is always located in
  * KSEG2, while user vm_map address range contains no KSEG2 */
 
-typedef enum { KERNEL_VM_MAP, USER_VM_MAP } vm_map_type_t;
+typedef enum { KERNEL_VM_MAP, USER_VM_MAP, VM_MAP_TYPE_LAST } vm_map_type_t;
 
 typedef struct vm_map_entry vm_map_entry_t;
 
@@ -26,6 +26,7 @@ struct vm_map_entry {
 typedef struct vm_map {
   TAILQ_HEAD(, vm_map_entry) list;
   SPLAY_HEAD(vm_map_tree, vm_map_entry) tree;
+  vm_map_type_t type;
   size_t nentries;
   pmap_t pmap;
 } vm_map_t;
@@ -38,7 +39,7 @@ typedef struct vm_map {
  * vm_map_entry_t* vm_map_allocate_space(vm_map_t* map, size_t length) */
 
 void set_active_vm_map(vm_map_t *map);
-vm_map_t *get_active_vm_map(pmap_type_t type);
+vm_map_t *get_active_vm_map(vm_map_type_t type);
 vm_map_t *get_active_vm_map_by_addr(vm_addr_t addr);
 
 void vm_map_init();

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -89,13 +89,13 @@ int do_exec(const exec_args_t *args) {
   /* TODO: Get current process description structure */
 
   /* The current vmap should be taken from the process description! */
-  vm_map_t *old_vmap = get_active_vm_map(PMAP_USER);
+  vm_map_t *old_vmap = get_active_vm_map(USER_VM_MAP);
   /* We may not destroy the current vm map, because exec can still
    * fail, and in that case we must be able to return to the
    * original address space
    */
 
-  vm_map_t *vmap = vm_map_new(PMAP_USER);
+  vm_map_t *vmap = vm_map_new(USER_VM_MAP);
   /* Note: we do not claim ownership of the map */
   set_active_vm_map(vmap);
 

--- a/vm_map.c
+++ b/vm_map.c
@@ -6,8 +6,8 @@
 static void paging_on_demand_and_memory_protection_demo() {
   set_active_vm_map(vm_map_new(USER_VM_MAP));
 
-  vm_map_t *kmap = get_active_vm_map(PMAP_KERNEL);
-  vm_map_t *umap = get_active_vm_map(PMAP_USER);
+  vm_map_t *kmap = get_active_vm_map(KERNEL_VM_MAP);
+  vm_map_t *umap = get_active_vm_map(USER_VM_MAP);
 
   log("Kernel physical map : %08lx-%08lx", kmap->pmap.start, kmap->pmap.end);
   log("User physical map   : %08lx-%08lx", umap->pmap.start, umap->pmap.end);


### PR DESCRIPTION
As of now, `pmap_type_t` and `vm_map_type_t` are used interchangeably. It works, because these two enums are identical, but it is a confusing example of implicit type conversions - and `clang` is very annoyed by how we confuse these types.

This branch fixes type sanity, by refactoring `vm_map` interface so that it only uses `vm_map_type`, and fixing enum values used on calls to `vm_map` functions.
