### PR TITLE
Serious typeo in sched_switch code (& and ==)

### DIFF
--- a/sys/sched.c
+++ b/sys/sched.c
@@ -54,7 +54,7 @@ void sched_switch(thread_t *newtd) {
 
   td->td_flags &= ~(TDF_SLICEEND | TDF_NEEDSWITCH);
 
-  if (td->td_state && TDS_RUNNING)
+  if (td->td_state == TDS_RUNNING)
     sched_add(td);
 
   if (newtd == NULL) {

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -54,7 +54,7 @@ void sched_switch(thread_t *newtd) {
 
   td->td_flags &= ~(TDF_SLICEEND | TDF_NEEDSWITCH);
 
-  if (td->td_state & TDS_RUNNING)
+  if (td->td_state && TDS_RUNNING)
     sched_add(td);
 
   if (newtd == NULL) {


### PR DESCRIPTION
Shouldn't this be "==" instead of "&" ?

By the way, since me and @rafalcieslak managed to find some bugs in @cahirwpz implementation, wouldn't it be good idea to make pull requests so everyone can do code review?