### PR TITLE
User mode programs

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -1,5 +1,29 @@
 #include <common.h>
 #include <exec.h>
+#include <thread.h>
+#include <sched.h>
+
+void program_thread_1() {
+  exec_args_t exec_args;
+  exec_args.prog_name = "prog";
+  exec_args.argv = (char *[]){"argument1", "ARGUMENT2", "a-r-g-u-m-e-n-t-3"};
+  exec_args.argc = 3;
+  do_exec(&exec_args);
+}
+void program_thread_2() {
+  exec_args_t exec_args;
+  exec_args.prog_name = "prog";
+  exec_args.argv = (char *[]){"String passed as argument."};
+  exec_args.argc = 1;
+  do_exec(&exec_args);
+}
+void program_thread_3() {
+  exec_args_t exec_args;
+  exec_args.prog_name = "prog";
+  exec_args.argv = (char *[]){"Totally different string."};
+  exec_args.argc = 1;
+  do_exec(&exec_args);
+}
 
 int main() {
   /* This is a simple demonstration of the exec functionality. It
@@ -19,13 +43,15 @@ int main() {
    * .bss.
    */
 
-  exec_args_t exec_args;
-  exec_args.prog_name = "prog";
-  const char *argv[] = {"argument1", "ARGUMENT2", "a-r-g-u-m-e-n-t-3"};
-  exec_args.argv = (char **)argv;
-  exec_args.argc = 3;
+  thread_t *td1 = thread_create("user_thread1", program_thread_1);
+  thread_t *td2 = thread_create("user_thread2", program_thread_2);
+  thread_t *td3 = thread_create("user_thread3", program_thread_3);
 
-  do_exec(&exec_args);
+  sched_add(td1);
+  sched_add(td2);
+  sched_add(td3);
+
+  sched_run();
 
   return 0;
 }

--- a/exec.c
+++ b/exec.c
@@ -10,6 +10,7 @@ void program_thread_1() {
   exec_args.argc = 3;
   do_exec(&exec_args);
 }
+
 void program_thread_2() {
   exec_args_t exec_args;
   exec_args.prog_name = "prog";
@@ -17,6 +18,7 @@ void program_thread_2() {
   exec_args.argc = 1;
   do_exec(&exec_args);
 }
+
 void program_thread_3() {
   exec_args_t exec_args;
   exec_args.prog_name = "prog";

--- a/include/context.h
+++ b/include/context.h
@@ -31,8 +31,7 @@ noreturn void ctx_boot(thread_t *td);
  * only when the @from context is resumed. */
 void ctx_switch(thread_t *from, thread_t *to);
 
-/* This procedure prepares user thread context without actually
-   switching to it. */
-void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer);
+/* Prepare user context for given thread. */
+void uctx_init(thread_t *td, vm_addr_t pc, vm_addr_t sp);
 
 #endif // __CONTEXT_H__

--- a/include/context.h
+++ b/include/context.h
@@ -31,4 +31,8 @@ noreturn void ctx_boot(thread_t *td);
  * only when the @from context is resumed. */
 void ctx_switch(thread_t *from, thread_t *to);
 
+/* This procedure is similar to fork_trampoline. It prepares user
+   thread context and then switches to it, entering user-mode. */
+noreturn void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer);
+
 #endif // __CONTEXT_H__

--- a/include/context.h
+++ b/include/context.h
@@ -31,8 +31,8 @@ noreturn void ctx_boot(thread_t *td);
  * only when the @from context is resumed. */
 void ctx_switch(thread_t *from, thread_t *to);
 
-/* This procedure is similar to fork_trampoline. It prepares user
-   thread context and then switches to it, entering user-mode. */
-noreturn void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer);
+/* This procedure prepares user thread context without actually
+   switching to it. */
+void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer);
 
 #endif // __CONTEXT_H__

--- a/include/vm_map.h
+++ b/include/vm_map.h
@@ -31,7 +31,7 @@ typedef struct vm_map {
  *
  * vm_map_entry_t* vm_map_allocate_space(vm_map_t* map, size_t length) */
 
-void vm_map_activate(vm_map_t *map);
+vm_map_t *vm_map_activate(vm_map_t *map);
 vm_map_t *get_user_vm_map();
 vm_map_t *get_kernel_vm_map();
 vm_map_t *get_active_vm_map_by_addr(vm_addr_t addr);

--- a/mips/context.c
+++ b/mips/context.c
@@ -32,16 +32,10 @@ void ctx_init(thread_t *td, void (*target)()) {
 }
 
 void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer) {
-
   thread_t *td = thread_self();
-  td->td_uctx.gp = 0;
+  bzero(&td->td_uctx, sizeof(exc_frame_t));
+  td->td_uctx.gp = 0; /* Explicit. */
   td->td_uctx.pc = entry_point;
   td->td_uctx.sp = stack_pointer;
-  td->td_uctx.ra = 0;
-  /* TODO: Is there any reason to clear other registers? */
-
-  /* This will apply context, enter user mode and re-enable interrupts. */
-  user_exc_leave();
-
-  __builtin_unreachable();
+  td->td_uctx.ra = 0; /* Explicit. */
 }

--- a/mips/context.c
+++ b/mips/context.c
@@ -31,11 +31,11 @@ void ctx_init(thread_t *td, void (*target)()) {
   kframe->sr = (reg_t)sr;
 }
 
-void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer) {
-  thread_t *td = thread_self();
+void uctx_init(thread_t *td, vm_addr_t pc, vm_addr_t sp) {
   bzero(&td->td_uctx, sizeof(exc_frame_t));
+
   td->td_uctx.gp = 0; /* Explicit. */
-  td->td_uctx.pc = entry_point;
-  td->td_uctx.sp = stack_pointer;
+  td->td_uctx.pc = pc;
+  td->td_uctx.sp = sp;
   td->td_uctx.ra = 0; /* Explicit. */
 }

--- a/mips/context.c
+++ b/mips/context.c
@@ -30,3 +30,22 @@ void ctx_init(thread_t *td, void (*target)()) {
   kframe->sp = (reg_t)sp;
   kframe->sr = (reg_t)sr;
 }
+
+void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer) {
+  /* We are starting machine-specific thread context setup and
+     switch. It would be very unfortunate if threads switched before
+     we are done. */
+  intr_disable();
+
+  thread_t *td = thread_self();
+  td->td_uctx.gp = 0;
+  td->td_uctx.pc = entry_point;
+  td->td_uctx.sp = stack_pointer;
+  td->td_uctx.ra = 0;
+  /* TODO: Is there any reason to clear other registers? */
+
+  /* This will apply context, enter user mode and re-enable interrupts. */
+  user_exc_leave();
+
+  __builtin_unreachable();
+}

--- a/mips/context.c
+++ b/mips/context.c
@@ -32,10 +32,6 @@ void ctx_init(thread_t *td, void (*target)()) {
 }
 
 void ctx_init_usermode(vm_addr_t entry_point, vm_addr_t stack_pointer) {
-  /* We are starting machine-specific thread context setup and
-     switch. It would be very unfortunate if threads switched before
-     we are done. */
-  intr_disable();
 
   thread_t *td = thread_self();
   td->td_uctx.gp = 0;

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -5,6 +5,7 @@
 #include <mips/tlb.h>
 #include <pcpu.h>
 #include <pmap.h>
+#include <sync.h>
 #include <vm_map.h>
 
 #define PTE_MASK 0xfffff000
@@ -289,8 +290,10 @@ void pmap_protect(pmap_t *pmap, vm_addr_t start, vm_addr_t end,
  */
 
 void pmap_activate(pmap_t *pmap) {
+  cs_enter();
   PCPU_GET(curpmap) = pmap;
   mips32_set_c0(C0_ENTRYHI, pmap ? pmap->asid : 0);
+  cs_leave();
 }
 
 pmap_t *get_kernel_pmap() {

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -135,6 +135,12 @@ int do_exec(const exec_args_t *args) {
         kprintf("[exec] Exec failed: Segment p_vaddr is not page alligned\n");
         goto exec_fail;
       }
+      if (ph->p_memsz == 0) {
+        /* Avoid creating empty vm_map entries for segments that
+           occupy no space in memory, as they might overlap with
+           subsequent segments. */
+        continue;
+      }
       vm_addr_t start = ph->p_vaddr;
       vm_addr_t end = roundup(ph->p_vaddr + ph->p_memsz, PAGESIZE);
       /* TODO: What if segments overlap? */

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -7,6 +7,7 @@
 #include <thread.h>
 #include <string.h>
 #include <errno.h>
+#include <sync.h>
 #include <mips/stack.h>
 
 extern uint8_t _binary_prog_uelf_start[];
@@ -86,13 +87,16 @@ int do_exec(const exec_args_t *args) {
     return -ENOEXEC;
   }
 
-  /* TODO: Get current process description structure */
+  thread_t *td = thread_self();
 
-  /* The current vmap should be taken from the process description! */
-  vm_map_t *old_vmap = get_user_vm_map();
-  /* We may not destroy the current vm map, because exec can still
-   * fail, and in that case we must be able to return to the
-   * original address space
+  /* Please don't switch to other threads while we prepare the address
+     space, because switching threads switches user vm space */
+  cs_enter();
+
+  vm_map_t *old_vmap = td->td_uspace;
+  /* We can not destroy the current vm map, because exec can still
+   * fail, and in that case we must be able to return to the original
+   * address space
    */
 
   vm_map_t *vmap = vm_map_new();
@@ -183,25 +187,21 @@ int do_exec(const exec_args_t *args) {
 
   vm_map_dump(vmap);
 
+  /* vmap is ready, it is safe now to switch threads. */
+  cs_leave();
+
   /* At this point we are certain that exec suceeds.
    * We can safely destroy the previous vm map. */
 
-  /* This condition will be unnecessary when we take the vmap info
-   * from thread struct. The user thread calling exec() WILL
-   * certainly have an existing vmap before exec()ing. */
+  /* This condition is necessary, because exec() serves not just as a
+     syscall handler, but it can also be called by a kernel thread
+     (e.g. to start PID 1). */
   if (old_vmap)
     vm_map_delete(old_vmap);
 
-  /* TODO: Assign the new vm map to the process structure */
-
-  thread_t *th = thread_self();
-  th->td_kctx.gp = 0;
-  th->td_kctx.pc = eh->e_entry;
-  th->td_kctx.sp = stack_bottom;
-  /* TODO: Since there is no process structure yet, this call starts
-   * the user code in kernel mode. $sp is set according to data
-   * prepared by prepare_program_stack. Setting $ra is irrelevant,
-   * as the ctx_switch procedure overwrites it anyway. */
+  /* Assigning a vm_mp to td_uspace effectively turns this thread into
+     a user thread, if it already weren't one. */
+  td->td_uspace = vmap;
 
   /* Forcefully apply changed context.
    * This might be also done by yielding to the scheduler, but it
@@ -209,8 +209,7 @@ int do_exec(const exec_args_t *args) {
    * harder, as it difficult to pinpoint the exact time when we
    * enter the user code */
   kprintf("[exec] Entering e_entry NOW\n");
-  thread_t junk;
-  ctx_switch(&junk, th);
+  ctx_init_usermode(eh->e_entry, stack_bottom);
 
   /*NOTREACHED*/
   __builtin_unreachable();
@@ -221,6 +220,8 @@ exec_fail:
   /* Return to the previous map, unmodified by exec */
   if (old_vmap)
     vm_map_activate(old_vmap);
+
+  cs_leave();
 
   return -EINVAL;
 }

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -209,13 +209,10 @@ int do_exec(const exec_args_t *args) {
      a user thread, if it already weren't one. */
   td->td_uspace = vmap;
 
-  /* Forcefully apply changed context.
-   * This might be also done by yielding to the scheduler, but it
-   * does not work if we are the only thread, and makes debugging
-   * harder, as it difficult to pinpoint the exact time when we
-   * enter the user code */
   kprintf("[exec] Entering e_entry NOW\n");
   ctx_init_usermode(eh->e_entry, stack_bottom);
+  /* This will apply context, enter user mode and re-enable interrupts. */
+  user_exc_leave();
 
   /*NOTREACHED*/
   __builtin_unreachable();

--- a/sys/vm_map.c
+++ b/sys/vm_map.c
@@ -10,11 +10,17 @@
 
 static vm_map_t kspace;
 
-void vm_map_activate(vm_map_t *map) {
+vm_map_t *vm_map_activate(vm_map_t *map) {
+  vm_map_t *old;
+
   cs_enter();
-  thread_self()->td_uspace = map;
+  thread_t *td = thread_self();
+  old = td->td_uspace;
+  td->td_uspace = map;
   pmap_activate(map ? map->pmap : NULL);
   cs_leave();
+
+  return old;
 }
 
 vm_map_t *get_user_vm_map() { return thread_self()->td_uspace; }

--- a/user/prog.c
+++ b/user/prog.c
@@ -1,33 +1,30 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define BYTES(x) (sizeof(x) / sizeof(char))
-
-#define STRING "This is an example string."
-#define STRING_SIZE (BYTES(STRING))
-#define TEXTAREA_SIZE ((STRING_SIZE - 1) * 3 + 1)
-// This should land in .rodata, accessed by a pointer in .data
-const char *string = STRING;
+#define TEXTAREA_SIZE 100
 // This should land in .bss, accessed by a pointer in .data
 char textarea[TEXTAREA_SIZE];
 
-char arguments_received[1000];
-
-uint32_t leaf() {
-  return 0xdad0face;
+void abort() {
+  while (1)
+    ; /* Sigh. */
 }
 
-void stack_test_func(uint32_t *arg) {
-  *arg = leaf();
+size_t my_strlen(const char *str) {
+  size_t n = 0;
+  while (*(str++))
+    n++;
+  return n;
 }
 
-void marquee() {
+void marquee(const char *string) {
   uint32_t o = 0;
+  size_t n = my_strlen(string);
   while (1) {
     o++;
     // Copy string three times with changing offsets
     for (int i = 0; i < TEXTAREA_SIZE - 1; i++) {
-      textarea[i] = string[(i + o) % (STRING_SIZE - 1)];
+      textarea[i] = string[(i + o) % n];
     }
     // Null-terminate
     textarea[TEXTAREA_SIZE - 1] = 0;
@@ -35,11 +32,11 @@ void marquee() {
 }
 
 int main(int argc, char **argv) {
-  // As currently there is no feasible way of outputting text, break
-  // with debugger here to see argc/argv!
+  /* TODO: Actually, the 0-th argument should be the program name. */
+  if (argc < 1)
+    abort();
 
-  uint32_t stack_variable = 0x42424242;
-  stack_test_func(&stack_variable);
-  marquee();
+  marquee(argv[0]);
+
   return 0;
 }


### PR DESCRIPTION
This branch concludes changes to `do_exec()` that are required to correctly start multiple user-mode threads. It implements `ctx_init_usermode` which is semantically similar to `fork_trampoline`, gets `exec()` to store `vmap` to thread structure and switch to usermode when switching to loaded program, cleans up `exec()` from machine-specific code and provides a simple demonstration.

My recommended quick-test procedure (until we have a "print" syscall):
1) Load `exec.elf` in debugger
2) `add-symbol-file user/prog.uelf 0x00400000`
3) `continue` multiple times to step through all `main()`s
4) Interrupt the execution `^C`, print `textarea`, continue further.
5) Interrupt again. Unless you are unlucky, a different user thread is now active, and it wrote different values to `textarea`.
6) Repeat to observe threads getting switched.