### PR TITLE
Templates for get_elf_image and generic ./user Makefile

### DIFF
--- a/sys/exec.c
+++ b/sys/exec.c
@@ -9,19 +9,25 @@
 #include <errno.h>
 #include <mips/stack.h>
 
-extern uint8_t _binary_prog_uelf_start[];
-extern uint8_t _binary_prog_uelf_size[];
-extern uint8_t _binary_prog_uelf_end[];
+#define EMBED_ELF_DECLARE(name)                                                \
+  extern uint8_t _binary_##name##_uelf_start[];                                \
+  extern uint8_t _binary_##name##_uelf_size[];                                 \
+  extern uint8_t _binary_##name##_uelf_end[];
+
+EMBED_ELF_DECLARE(prog);
 
 int get_elf_image(const exec_args_t *args, uint8_t **out_image,
                   size_t *out_size) {
-  if (strcmp(args->prog_name, "prog") == 0) {
-    *out_image = _binary_prog_uelf_start;
-    *out_size = (size_t)_binary_prog_uelf_size;
-    return 0;
-  } else {
-    return -ENOENT;
+
+#define EMBED_ELF_BY_NAME(name)                                                \
+  if (strcmp(args->prog_name, #name) == 0) {                                   \
+    *out_image = _binary_##name##_uelf_start;                                  \
+    *out_size = (size_t)_binary_##name##_uelf_size;                            \
+    return 0;                                                                  \
   }
+
+  EMBED_ELF_BY_NAME(prog);
+  return -ENOENT;
 }
 
 int do_exec(const exec_args_t *args) {

--- a/user/Makefile
+++ b/user/Makefile
@@ -2,25 +2,32 @@ all: prog.uelf.o
 
 include ../Makefile.common
 
+PROGRAMS_C = prog.c
+
 CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding -G0
 LDFLAGS  = -nostdlib -T mimiker.ld -G0
 
+PROGRAMS_OBJS = $(PROGRAMS_C:%.c=%.o)
+PROGRAMS_UELFS = $(PROGRAMS_C:%.c=%.uelf)
+PROGRAMS_UELF_OS = $(PROGRAMS_C:%.c=%.uelf.o)
+
+all: $(PROGRAMS_UELF_OS) $(PROGRAMS_UELFS)
+
 # Compiling the program source
-prog.o: prog.c
+%.o: %.c
 	@echo "[CC] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 # Linking the program according to the provided script
-prog.uelf: prog.o start.o mimiker.ld
+%.uelf: %.o start.o mimiker.ld
 	@echo "[LD] $(DIR)$< -> $(DIR)$@"
-	$(CC) $(LDFLAGS) start.o -Wl,-Map=$@.map -o $@ $<
+	$(CC) $(LDFLAGS) start.o -o $@ $<
 
 # Treating the liked program as binary data, placing it in .rodata
 # section, and embedding into an object file
-prog.uelf.o: prog.uelf Makefile
+%.uelf.o: %.uelf Makefile
 	@echo "[LD] $(DIR)$< -> $(DIR)$@"
 	$(OBJCOPY) -I binary --rename-section .data=.rodata,contents,readonly,data -O elf32-little --alt-machine-code=8 $< $@
 
-
 clean:
-	rm -f *.o prog.uelf.o prog.uelf prog.o prog.uelf.map
+	rm -f $(PROGRAMS_UELF_OS) $(PROGRAMS_UELFS) $(PROGRAMS_OBJS)


### PR DESCRIPTION
These proposed changes simplify adding multiple user programs to `./user`, by implementing a generic `Makefile` and templates for selecting embedded elf image in `get_elf_image`.