### PR TITLE
Added qemu support to lauch script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ language: c
 compiler: gcc
 before_install:
  - sudo apt-get -qq update
- - sudo apt-get install -y qemu-system-mips ctags cscope wget
+ - sudo apt-get install -y qemu-system-mips ctags cscope wget python3-pip
+ - sudo pip3 install -I pexpect
  - TOOLCHAIN=`mktemp -d toolchain.XXXXXX`
  - cd ${TOOLCHAIN}
  - wget -c http://codescape-mips-sdk.imgtec.com/components/toolchain/2016.05-03/Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz
  - tar -xf Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz
  - export PATH=$PATH:$(pwd)/mips-mti-elf/2016.05-03/bin
  - cd ..
-script: make 
+script:
+ - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_install:
  - cd ..
 script:
  - make
+ - ./rtc.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ before_install:
  - cd ..
 script:
  - make
- - ./rtc.test

--- a/launch
+++ b/launch
@@ -34,7 +34,8 @@ OVPSIM_OVERRIDES = {
     "uartCBUS/portnum": PORT
 }
 QEMUSIM = "qemu-system-mipsel"
-QEMUSIM_OPTIONS = ['-nographic', '-machine', 'malta', '-nodefaults']
+QEMUSIM_OPTIONS = ['-nographic', '-nodefaults', '-machine', 'malta',
+                   '-cpu', '24Kf']
 
 DEBUGGERS = {
     'gdb'   : '%(triplet)s-gdb %(kernel)s',
@@ -65,7 +66,8 @@ if __name__ == "__main__":
                         help='Start simulation under gdb.')
     parser.add_argument('-D', metavar='DEBUGGER', type=str, dest='debugger',
                         choices=DEBUGGERS.keys(), default=DEFAULT_DEBUGGER,
-                        help='Debugger to use. Implies -d. Available options: '+
+                        help='Debugger to use. Implies -d.\
+                        Available options: ' +
                         ', '.join(DEBUGGERS.keys()) + ". Default: " +
                         DEFAULT_DEBUGGER + ".")
     parser.add_argument('-t', '--test', action='store_true',
@@ -104,6 +106,7 @@ if __name__ == "__main__":
         QEMUSIM_OPTIONS += ['-s', '-S']
 
     opts += SIMS_OPTIONS[args.simulator]
+    print(" ".join([SIMS[args.simulator]] + opts))
     try:
         os.remove('uartCBUS.log')
         os.remove('uartTTY0.log')

--- a/launch
+++ b/launch
@@ -16,10 +16,14 @@ if shutil.which('mipsel-unknown-elf-gcc') is None:
 else:
     TRIPLET = 'mipsel-unknown-elf'
 PORT = 8000
+try:
+    OVPSIM = os.path.join(os.environ['IMPERAS_VLNV'],
+                          OVPSIM_VENDOR, 'platform', OVPSIM_PLATFORM,
+                          'platform.%s.exe' % os.environ['IMPERAS_ARCH'])
+except:
+    # print("OVPSim not found")
+    OVPSIM = None
 
-OVPSIM = os.path.join(os.environ['IMPERAS_VLNV'],
-                      OVPSIM_VENDOR, 'platform', OVPSIM_PLATFORM,
-                      'platform.%s.exe' % os.environ['IMPERAS_ARCH'])
 
 OVPSIM_OPTIONS = ['--root', '/dev/null', '--nographics', '--wallclock']
 OVPSIM_OVERRIDES = {
@@ -29,6 +33,8 @@ OVPSIM_OVERRIDES = {
     "uartCBUS/console": 1,
     "uartCBUS/portnum": PORT
 }
+QEMUSIM = "qemu-system-mipsel"
+QEMUSIM_OPTIONS = ['-nographic', '-machine', 'malta', '-nodefaults']
 
 DEBUGGERS = {
     'gdb'   : '%(triplet)s-gdb %(kernel)s',
@@ -40,6 +46,16 @@ DEBUGGERS = {
 DEFAULT_DEBUGGER = 'cgdb'
 assert(DEFAULT_DEBUGGER in DEBUGGERS)
 
+SIMS = {
+    'ovp': OVPSIM,
+    'qemu': QEMUSIM
+}
+DEFAULT_SIM = 'ovp'
+assert(DEFAULT_SIM in SIMS)
+SIMS_OPTIONS = {
+    'ovp': OVPSIM_OPTIONS,
+    'qemu': QEMUSIM_OPTIONS
+}
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Launch OVPsim with Malta board.')
@@ -49,42 +65,57 @@ if __name__ == "__main__":
                         help='Start simulation under gdb.')
     parser.add_argument('-D', metavar='DEBUGGER', type=str, dest='debugger',
                         choices=DEBUGGERS.keys(), default=DEFAULT_DEBUGGER,
-                        help='Debugger to use. Implies -d. Available options: ' +
+                        help='Debugger to use. Implies -d. Available options: '+
                         ', '.join(DEBUGGERS.keys()) + ". Default: " +
                         DEFAULT_DEBUGGER + ".")
     parser.add_argument('-t', '--test', action='store_true',
                         help='Use current stdin & stdout for simulated UART.')
+    parser.add_argument('-s', '--simulator', metavar='SIMULATOR', type=str,
+                        choices=SIMS.keys(), default=DEFAULT_SIM,
+                        help='Simulator to use. Available options: ' +
+                        ', '.join(SIMS.keys()) + ". Default: " +
+                        DEFAULT_SIM + ".")
 
     args = parser.parse_args()
 
     if args.debugger != DEFAULT_DEBUGGER:
         args.debug = True
-
+    if SIMS[args.simulator] is None:
+        raise Exception("Set simulator is not found")
     if args.test:
         OVPSIM_OVERRIDES["uartCBUS/console"] = 0
+        QEMUSIM_OPTIONS += ['-serial', 'null', '-serial', 'null']
+        QEMUSIM_OPTIONS += ['-monitor', 'stdio']
+        QEMUSIM_OPTIONS += ['-serial', 'tcp:127.0.0.1:%d,server,nowait' % PORT]
+    else:
+        QEMUSIM_OPTIONS += ['-serial', 'none']
+        QEMUSIM_OPTIONS += ['-serial', 'null', '-serial', 'null']
+        QEMUSIM_OPTIONS += ['-serial', 'stdio']
 
     if not os.path.isfile(args.kernel):
         raise SystemExit("%s: file does not exist!" % args.kernel)
 
     opts = ['--kernel', args.kernel]
-    opts += OVPSIM_OPTIONS
-    for item in OVPSIM_OVERRIDES.items():
-        opts += ['--override', '%s=%s' % item]
+    if args.simulator == 'ovp':
+        for item in OVPSIM_OVERRIDES.items():
+            opts += ['--override', '%s=%s' % item]
     if args.debug:
-        opts += ['--port', '1234']
+        OVPSIM_OPTIONS += ['--port', '1234']
+        QEMUSIM_OPTIONS += ['-s', '-S']
 
+    opts += SIMS_OPTIONS[args.simulator]
     try:
         os.remove('uartCBUS.log')
         os.remove('uartTTY0.log')
         os.remove('uartTTY1.log')
     except OSError:
         pass
-
     if args.debug:
-        dbgcmd = DEBUGGERS[args.debugger] % {'kernel': args.kernel, 'triplet': TRIPLET}
+        dbgcmd = DEBUGGERS[args.debugger] % {'kernel': args.kernel,
+                                             'triplet': TRIPLET}
         dbgcmd = shlex.split(dbgcmd)
 
-        sim = subprocess.Popen([OVPSIM] + opts,
+        sim = subprocess.Popen([SIMS[args.simulator]] + opts,
                                start_new_session=True)
         gdb = subprocess.Popen(dbgcmd, start_new_session=True)
         while True:
@@ -95,8 +126,12 @@ if __name__ == "__main__":
             except KeyboardInterrupt:
                 gdb.send_signal(signal.SIGINT)
     elif args.test:
-        sim = popen_spawn.PopenSpawn([OVPSIM] + opts)
-        sim.expect("Waiting for connection on port %d" % PORT, timeout=5)
+        sim = popen_spawn.PopenSpawn([SIMS[args.simulator]] + opts)
+        if args.simulator == 'ovp':
+            sim.expect("Waiting for connection on port %d" % PORT, timeout=5)
+        elif args.simulator == 'qemu':
+            sim.expect("QEMU 2.5.0 monitor", timeout=5)
+            pass
         nc = subprocess.Popen(['nc', 'localhost', str(PORT)])
         while True:
             try:
@@ -105,7 +140,7 @@ if __name__ == "__main__":
             except KeyboardInterrupt:
                 sim.kill(signal.SIGINT)
     else:
-        sim = subprocess.Popen([OVPSIM] + opts)
+        sim = subprocess.Popen([SIMS[args.simulator]] + opts)
         try:
             sim.wait()
         except KeyboardInterrupt:

--- a/launch
+++ b/launch
@@ -9,118 +9,152 @@ import shlex
 import shutil
 from pexpect import popen_spawn
 
-OVPSIM_VENDOR = 'mips.ovpworld.org'
-OVPSIM_PLATFORM = 'MipsMalta/1.0'
-if shutil.which('mipsel-unknown-elf-gcc') is None:
-    TRIPLET = 'mips-mti-elf'
-else:
-    TRIPLET = 'mipsel-unknown-elf'
 PORT = 8000
-try:
-    OVPSIM = os.path.join(os.environ['IMPERAS_VLNV'],
-                          OVPSIM_VENDOR, 'platform', OVPSIM_PLATFORM,
-                          'platform.%s.exe' % os.environ['IMPERAS_ARCH'])
-except:
-    # print("OVPSim not found")
-    OVPSIM = None
-
-
-OVPSIM_OPTIONS = ['--root', '/dev/null', '--nographics', '--wallclock']
-OVPSIM_OVERRIDES = {
-    "mipsle1/vectoredinterrupt": 1,
-    "mipsle1/srsctlHSS": 1,
-    "rtc/timefromhost": 1,
-    "uartCBUS/console": 1,
-    "uartCBUS/portnum": PORT
-}
-QEMUSIM = "qemu-system-mipsel"
-QEMUSIM_OPTIONS = ['-nographic', '-nodefaults', '-machine', 'malta',
-                   '-cpu', '24Kf']
 
 DEBUGGERS = {
-    'gdb'   : '%(triplet)s-gdb %(kernel)s',
-    'cgdb'  : 'cgdb -d %(triplet)s-gdb %(kernel)s',
-    'ddd'   : 'ddd --debugger %(triplet)s-gdb %(kernel)s',
+    'gdb': '%(triplet)s-gdb %(kernel)s',
+    'cgdb': 'cgdb -d %(triplet)s-gdb %(kernel)s',
+    'ddd': 'ddd --debugger %(triplet)s-gdb %(kernel)s',
     'gdbtui': '%(triplet)s-gdb -tui',
-    'emacs' : 'emacsclient -c -e \'(gdb "%(triplet)s-gdb -i=mi %(kernel)s")\''
+    'emacs': 'emacsclient -c -e \'(gdb "%(triplet)s-gdb -i=mi %(kernel)s")\''
 }
 DEFAULT_DEBUGGER = 'cgdb'
 assert(DEFAULT_DEBUGGER in DEBUGGERS)
 
-SIMS = {
-    'ovp': OVPSIM,
-    'qemu': QEMUSIM
-}
-DEFAULT_SIM = 'ovp'
-assert(DEFAULT_SIM in SIMS)
-SIMS_OPTIONS = {
-    'ovp': OVPSIM_OPTIONS,
-    'qemu': QEMUSIM_OPTIONS
-}
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description='Launch OVPsim with Malta board.')
-    parser.add_argument('kernel', metavar='KERNEL', type=str,
-                        help='Kernel file in ELF format.')
-    parser.add_argument('-d', '--debug', action='store_true',
-                        help='Start simulation under gdb.')
-    parser.add_argument('-D', metavar='DEBUGGER', type=str, dest='debugger',
-                        choices=DEBUGGERS.keys(), default=DEFAULT_DEBUGGER,
-                        help='Debugger to use. Implies -d.\
-                        Available options: ' +
-                        ', '.join(DEBUGGERS.keys()) + ". Default: " +
-                        DEFAULT_DEBUGGER + ".")
-    parser.add_argument('-t', '--test', action='store_true',
-                        help='Use current stdin & stdout for simulated UART.')
-    parser.add_argument('-s', '--simulator', metavar='SIMULATOR', type=str,
-                        choices=SIMS.keys(), default=DEFAULT_SIM,
-                        help='Simulator to use. Available options: ' +
-                        ', '.join(SIMS.keys()) + ". Default: " +
-                        DEFAULT_SIM + ".")
 
-    args = parser.parse_args()
+def find_triplet():
+    for triplet in ['mips-mti-elf', 'mipsel-unknown-elf']:
+        if shutil.which(triplet + '-gcc'):
+            return triplet
 
-    if args.debugger != DEFAULT_DEBUGGER:
-        args.debug = True
-    if SIMS[args.simulator] is None:
-        raise Exception("Set simulator is not found")
-    if args.test:
-        OVPSIM_OVERRIDES["uartCBUS/console"] = 0
-        QEMUSIM_OPTIONS += ['-serial', 'null', '-serial', 'null']
-        QEMUSIM_OPTIONS += ['-monitor', 'stdio']
-        QEMUSIM_OPTIONS += ['-serial', 'tcp:127.0.0.1:%d,server,nowait' % PORT]
-    else:
-        QEMUSIM_OPTIONS += ['-serial', 'none']
-        QEMUSIM_OPTIONS += ['-serial', 'null', '-serial', 'null']
-        QEMUSIM_OPTIONS += ['-serial', 'stdio']
+    raise SystemExit('No cross compiler found!')
 
-    if not os.path.isfile(args.kernel):
-        raise SystemExit("%s: file does not exist!" % args.kernel)
 
-    opts = ['--kernel', args.kernel]
-    if args.simulator == 'ovp':
-        for item in OVPSIM_OVERRIDES.items():
-            opts += ['--override', '%s=%s' % item]
-    if args.debug:
-        OVPSIM_OPTIONS += ['--port', '1234']
-        QEMUSIM_OPTIONS += ['-s', '-S']
+def configure_ovpsim(args):
+    OVPSIM_OVERRIDES = {
+        'mipsle1/vectoredinterrupt': 1,
+        'mipsle1/srsctlHSS': 1,
+        'rtc/timefromhost': 1,
+        'uartCBUS/console': 1,
+        'uartCBUS/portnum': PORT
+    }
 
-    opts += SIMS_OPTIONS[args.simulator]
-    print(" ".join([SIMS[args.simulator]] + opts))
     try:
         os.remove('uartCBUS.log')
         os.remove('uartTTY0.log')
         os.remove('uartTTY1.log')
     except OSError:
         pass
-    if args.debug:
-        dbgcmd = DEBUGGERS[args.debugger] % {'kernel': args.kernel,
-                                             'triplet': TRIPLET}
-        dbgcmd = shlex.split(dbgcmd)
 
-        sim = subprocess.Popen([SIMS[args.simulator]] + opts,
-                               start_new_session=True)
-        gdb = subprocess.Popen(dbgcmd, start_new_session=True)
+    options = ['--root', '/dev/null',
+               '--nographics',
+               '--wallclock',
+               '--kernel', args.kernel]
+
+    if args.test:
+        OVPSIM_OVERRIDES['uartCBUS/console'] = 0
+
+    for item in OVPSIM_OVERRIDES.items():
+        options += ['--override', '%s=%s' % item]
+
+    if args.debug:
+        options += ['--port', '1234']
+
+    return options
+
+
+def configure_qemu(args):
+    options = ['-nographic',
+               '-nodefaults',
+               '-machine', 'malta',
+               '-cpu', '24Kf',
+               '-kernel', args.kernel]
+
+    if args.test:
+        options += ['-serial', 'null',
+                    '-serial', 'null',
+                    '-monitor', 'stdio',
+                    '-serial', 'tcp:127.0.0.1:%d,server,nowait' % PORT]
+    else:
+        options += ['-serial', 'none',
+                    '-serial', 'null',
+                    '-serial', 'null',
+                    '-serial', 'stdio']
+
+    if args.debug:
+        options += ['-s', '-S']
+
+    return options
+
+
+def find_simulator():
+    sim_choices = {}
+    sim_default = None
+
+    if shutil.which('qemu-system-mipsel'):
+        sim_choices['qemu'] = ['qemu-system-mipsel', configure_qemu]
+        sim_default = 'qemu'
+
+    try:
+        OVPSIM_VENDOR = 'mips.ovpworld.org'
+        OVPSIM_PLATFORM = 'MipsMalta/1.0'
+        IMPERAS_VLNV = os.environ['IMPERAS_VLNV']
+        IMPERAS_ARCH = os.environ['IMPERAS_ARCH']
+
+        ovpsim_path = os.path.join(
+            IMPERAS_VLNV, OVPSIM_VENDOR, 'platform', OVPSIM_PLATFORM,
+            'platform.%s.exe' % IMPERAS_ARCH)
+        sim_choices['ovpsim'] = [ovpsim_path, configure_ovpsim]
+        sim_default = 'ovpsim'
+    except KeyError:
+        pass
+
+    if not sim_default:
+        raise SystemExit('No simulator found!')
+
+    return sim_default, sim_choices
+
+
+if __name__ == '__main__':
+    triplet = find_triplet()
+    sim_default, sim_choices = find_simulator()
+
+    parser = argparse.ArgumentParser(
+        description='Launch kernel in Malta board simulator.')
+    parser.add_argument('kernel', metavar='KERNEL', type=str,
+                        help='Kernel file in ELF format.')
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='Start simulation under gdb.')
+    parser.add_argument('-D', '--debugger', metavar='DEBUGGER', type=str,
+                        choices=DEBUGGERS.keys(), default=DEFAULT_DEBUGGER,
+                        help=('Debugger to use. Implies -d. ' +
+                              'Available options: %s. Default: %s.' %
+                              (', '.join(DEBUGGERS.keys()), DEFAULT_DEBUGGER)))
+    parser.add_argument('-S', '--simulator', metavar='SIMULATOR', type=str,
+                        choices=sim_choices.keys(), default=sim_default,
+                        help=('Simulator to use. ' +
+                              'Available options: %s. Default: %s.' %
+                              (', '.join(sim_choices.keys()), sim_default)))
+    parser.add_argument('-t', '--test', action='store_true',
+                        help='Use current stdin & stdout for simulated UART.')
+
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.kernel):
+        raise SystemExit('%s: file does not exist!' % args.kernel)
+
+    if args.debugger != DEFAULT_DEBUGGER:
+        args.debug = True
+
+    sim_cmd, sim_opts = sim_choices[args.simulator]
+    sim_cmd = [sim_cmd] + sim_opts(args)
+
+    if args.debug:
+        dbg_cmd = shlex.split(DEBUGGERS[args.debugger] %
+                              {'kernel': args.kernel, 'triplet': triplet})
+
+        sim = subprocess.Popen(sim_cmd, start_new_session=True)
+        gdb = subprocess.Popen(dbg_cmd, start_new_session=True)
         while True:
             try:
                 gdb.wait()
@@ -129,12 +163,11 @@ if __name__ == "__main__":
             except KeyboardInterrupt:
                 gdb.send_signal(signal.SIGINT)
     elif args.test:
-        sim = popen_spawn.PopenSpawn([SIMS[args.simulator]] + opts)
-        if args.simulator == 'ovp':
-            sim.expect("Waiting for connection on port %d" % PORT, timeout=5)
+        sim = popen_spawn.PopenSpawn(sim_cmd)
+        if args.simulator == 'ovpsim':
+            sim.expect('Waiting for connection on port %d' % PORT, timeout=5)
         elif args.simulator == 'qemu':
-            sim.expect("QEMU 2.5.0 monitor", timeout=5)
-            pass
+            sim.expect('QEMU .* monitor', timeout=5)
         nc = subprocess.Popen(['nc', 'localhost', str(PORT)])
         while True:
             try:
@@ -143,7 +176,7 @@ if __name__ == "__main__":
             except KeyboardInterrupt:
                 sim.kill(signal.SIGINT)
     else:
-        sim = subprocess.Popen([SIMS[args.simulator]] + opts)
+        sim = subprocess.Popen(sim_cmd)
         try:
             sim.wait()
         except KeyboardInterrupt:

--- a/rtc.test
+++ b/rtc.test
@@ -13,9 +13,9 @@ def parseTime(child):
         return None
     return datetime.datetime(*(tm_time[0:6]))
 
-child = pexpect.spawn('./launch', ['-t', 'rtc.elf'])
+child = pexpect.spawn('./launch', ['rtc.elf','-s','qemu'])
 pattern = "Time is ([0-9]{2}:[0-9]{2}:[0-9]{2})"
-assert(child.expect([pexpect.EOF, pattern], timeout=5))
+assert(child.expect([pexpect.EOF, pattern], timeout=15))
 # throw away first result – why?
 assert(child.expect([pexpect.EOF, pattern], timeout=5))
 t1 = parseTime(child)

--- a/rtc.test
+++ b/rtc.test
@@ -13,9 +13,9 @@ def parseTime(child):
         return None
     return datetime.datetime(*(tm_time[0:6]))
 
-child = pexpect.spawn('./launch', ['rtc.elf','-s','qemu'])
+child = pexpect.spawn('./launch', ['-t', 'rtc.elf'])
 pattern = "Time is ([0-9]{2}:[0-9]{2}:[0-9]{2})"
-assert(child.expect([pexpect.EOF, pattern], timeout=15))
+assert(child.expect([pexpect.EOF, pattern], timeout=5))
 # throw away first result – why?
 assert(child.expect([pexpect.EOF, pattern], timeout=5))
 t1 = parseTime(child)


### PR DESCRIPTION
QEMU works most of the time. In `rtc.elf`even first printed time is correct(OVPsim).
But sometimes (30% of runs) mimiker stops/crashes before main. Even errors are non-deterministic.
Last printfed message is `[startup] subsystems initialized` or `[thread] Activating 'main' {0x802be030} thread!`. When run with debugger attached it stops just after `kmalloc_init(td_pool)` in `thread_init`.
QEMU likes to exit with different messages: one of them is
 `dma: command fc not supported`
`dma: command ff not supported`
`qemu: unsupported keyboard cmd=0x78`
`qemu: unsupported keyboard cmd=0x14`
`qemu: unsupported keyboard cmd=0x10`
`qemu: unsupported keyboard cmd=0x80`
and another one
`PFLASH: Possible BUG - Write block confirm`.
When started with debugger only second one appears.
I'm not sure if we should merge this, but I would be happy if somebody could check if this is either mimiker's or qemu's fault.