### PR TITLE
Hello world

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-TESTS = callout.elf malloc.elf physmem.elf pmap.elf rtc.elf sched.elf \
-	sleepq.elf syscall.elf thread.elf vm_map.elf exec.elf
+TESTS = callout.elf malloc.elf physmem.elf pmap.elf rtc.elf sched.elf	\
+	sleepq.elf syscall.elf thread.elf vm_map.elf exec.elf				\
+	exec_syscall.elf
 SOURCES_C = 
 SOURCES_ASM = 
 
@@ -12,7 +13,7 @@ include Makefile.common
 LDLIBS += -Lsys -Lmips -Lstdc \
 	  -Wl,--start-group -lsys -lmips -lstdc -lgcc -Wl,--end-group
 
-LD_EMBED = user/prog.uelf.o
+LD_EMBED = user/prog.uelf.o user/syscall_test.uelf.o
 
 # Kernel runtime files
 KRT = stdc mips sys user
@@ -28,6 +29,7 @@ physmem.elf: physmem.ko $(KRT)
 sched.elf: sched.ko $(KRT)
 sleepq.elf: sleepq.ko $(KRT)
 exec.elf: exec.ko $(KRT)
+exec_syscall.elf: exec_syscall.ko $(KRT)
 
 libkernel.a: $(DEPFILES) $(OBJECTS)
 

--- a/exec_syscall.c
+++ b/exec_syscall.c
@@ -4,8 +4,8 @@
 int main() {
   exec_args_t exec_args;
   exec_args.prog_name = "syscall_test";
-  exec_args.argv = (char *[]){};
-  exec_args.argc = 0;
+  exec_args.argv = (char *[]){"syscall_test"};
+  exec_args.argc = 1;
 
   do_exec(&exec_args);
 

--- a/exec_syscall.c
+++ b/exec_syscall.c
@@ -1,0 +1,13 @@
+#include <common.h>
+#include <exec.h>
+
+int main() {
+  exec_args_t exec_args;
+  exec_args.prog_name = "syscall_test";
+  exec_args.argv = (char *[]){};
+  exec_args.argc = 0;
+
+  do_exec(&exec_args);
+
+  return 0;
+}

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -1,0 +1,19 @@
+#ifndef __SYSCALL_H__
+#define __SYSCALL_H__
+
+#include <stdint.h>
+#include <mips/mips.h>
+
+#define SYSCALL_ARGS_MAX 4
+
+/* Low syscall codes reserved for actual ABI. */
+#define SYS_UARTPRINT_CHAR 1001
+
+typedef struct syscall_args {
+  uint32_t code;
+  reg_t args[SYSCALL_ARGS_MAX];
+} syscall_args_t;
+
+void sys_uart_print_char(syscall_args_t *sa);
+
+#endif // __SYSCALL_H__

--- a/include/syscall.h
+++ b/include/syscall.h
@@ -8,6 +8,7 @@
 
 /* Low syscall codes reserved for actual ABI. */
 #define SYS_UARTPRINT_CHAR 1001
+#define SYS_UARTPRINT_STR 1002
 
 typedef struct syscall_args {
   uint32_t code;
@@ -15,5 +16,6 @@ typedef struct syscall_args {
 } syscall_args_t;
 
 void sys_uart_print_char(syscall_args_t *sa);
+void sys_uart_print_str(syscall_args_t *sa);
 
 #endif // __SYSCALL_H__

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -82,10 +82,11 @@ void syscall_handler(exc_frame_t *frame) {
           (frame->sr & SR_KSU_MASK) ? "user" : "kernel");
 
   /* TODO: We need a syscall lookup table. This is temporary, since it
-     didn't make sense to create the table just for a single simple
-     syscall. */
+     didn't make sense to create the table just this prototype. */
   if (args.code == SYS_UARTPRINT_CHAR)
     sys_uart_print_char(&args);
+  if (args.code == SYS_UARTPRINT_STR)
+    sys_uart_print_str(&args);
 
   /* we need to fix return address to point to next instruction */
   frame->pc += 4;

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -2,6 +2,7 @@
 #include <mips/exc.h>
 #include <mips/mips.h>
 #include <pmap.h>
+#include <syscall.h>
 
 extern const char _ebase[];
 
@@ -62,9 +63,30 @@ void kernel_oops(exc_frame_t *frame) {
   panic("Unhandled exception");
 }
 
+void cpu_get_syscall_args(const exc_frame_t *frame, syscall_args_t *args) {
+  args->code = frame->v0;
+  args->args[0] = frame->a0;
+  args->args[1] = frame->a1;
+  args->args[2] = frame->a2;
+  args->args[3] = frame->a3;
+}
+
 void syscall_handler(exc_frame_t *frame) {
-  kprintf("[syscall] entered #%d from %s mode!\n", frame->v0,
+
+  /* Eventually we will want a platform-independent syscall entry, so
+     argument retrieval is done separately */
+  syscall_args_t args;
+  cpu_get_syscall_args(frame, &args);
+
+  kprintf("[syscall] entered #%d from %s mode!\n", (int)args.code,
           (frame->sr & SR_KSU_MASK) ? "user" : "kernel");
+
+  /* TODO: We need a syscall lookup table. This is temporary, since it
+     didn't make sense to create the table just for a single simple
+     syscall. */
+  if (args.code == SYS_UARTPRINT_CHAR)
+    sys_uart_print_char(&args);
+
   /* we need to fix return address to point to next instruction */
   frame->pc += 4;
 }

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -2,7 +2,8 @@
 
 SOURCES_C = callout.c clock.c exception.c exec.c interrupt.c malloc.c	\
 	    pci_ids.c physmem.c runq.c sched.c sleepq.c startup.c			\
-	    thread.c vm_map.c vm_object.c vm_pager.c pcpu.c
+	    sys_uartprint.c thread.c vm_map.c vm_object.c vm_pager.c		\
+	    pcpu.c
 SOURCES_ASM = 
 
 all: $(DEPFILES) libsys.a 

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -15,6 +15,7 @@
   extern uint8_t _binary_##name##_uelf_end[];
 
 EMBED_ELF_DECLARE(prog);
+EMBED_ELF_DECLARE(syscall_test);
 
 int get_elf_image(const exec_args_t *args, uint8_t **out_image,
                   size_t *out_size) {
@@ -27,6 +28,7 @@ int get_elf_image(const exec_args_t *args, uint8_t **out_image,
   }
 
   EMBED_ELF_BY_NAME(prog);
+  EMBED_ELF_BY_NAME(syscall_test);
   return -ENOENT;
 }
 

--- a/sys/sys_uartprint.c
+++ b/sys/sys_uartprint.c
@@ -5,3 +5,10 @@ void sys_uart_print_char(syscall_args_t *sa) {
   char c = sa->args[0];
   kprintf("%c", c);
 }
+
+void sys_uart_print_str(syscall_args_t *sa) {
+  /* TODO: Copy string from user space? Is that even necessary for
+     this case? */
+  char *c = (char *)sa->args[0];
+  kprintf("%s", c);
+}

--- a/sys/sys_uartprint.c
+++ b/sys/sys_uartprint.c
@@ -1,0 +1,7 @@
+#include <syscall.h>
+#include <stdc.h>
+
+void sys_uart_print_char(syscall_args_t *sa) {
+  char c = sa->args[0];
+  kprintf("%c", c);
+}

--- a/user/Makefile
+++ b/user/Makefile
@@ -2,7 +2,7 @@ all: prog.uelf.o
 
 include ../Makefile.common
 
-PROGRAMS_C = prog.c
+PROGRAMS_C = prog.c syscall_test.c
 
 CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding -G0
 LDFLAGS  = -nostdlib -T mimiker.ld -G0

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -1,0 +1,17 @@
+
+void syscall_uart_print_char(char c) {
+  asm volatile("move $a0, %0\n"
+               "move $v0, 1001\n"
+               "syscall"
+               :
+               : "r"(c));
+}
+
+int main(int argc, char **argv) {
+  const char *str = "Hello world from a user program!\n";
+  const char *c = str;
+  while (*c)
+    syscall_uart_print_char(*c);
+  while (1)
+    ;
+}

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -1,17 +1,28 @@
 
 void syscall_uart_print_char(char c) {
   asm volatile("move $a0, %0\n"
-               "lui $v0, 1001\n"
+               "li $v0, 1001\n"
+               "syscall"
+               :
+               : "r"(c));
+}
+
+void syscall_uart_print_str(const char *c) {
+  asm volatile("move $a0, %0\n"
+               "li $v0, 1002\n"
                "syscall"
                :
                : "r"(c));
 }
 
 int main(int argc, char **argv) {
+  /* Char-by-char output */
   const char *str = "Hello world from a user program!\n";
   const char *c = str;
   while (*c)
-    syscall_uart_print_char(*c);
+    syscall_uart_print_char(*c++);
+  /* String output */
+  syscall_uart_print_str(str);
   while (1)
     ;
 }

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -1,7 +1,7 @@
 
 void syscall_uart_print_char(char c) {
   asm volatile("move $a0, %0\n"
-               "move $v0, 1001\n"
+               "lui $v0, 1001\n"
                "syscall"
                :
                : "r"(c));


### PR DESCRIPTION
This proposal implements the bare minimum required for user-space programs to output some text via UART, for debugging purposes. It does not incorporate an elegant system call handler table, nor universal procedures for copying system call arguments - which I believe should be done as a separate change.

A lot of changes I did here may be done in various ways (I tried to make this change minimal), so I'm looking for feedback.

I chose arbitrary high syscall numbers 1001 and 1002, as to not interfere with any reserved value.

A new demonstration program is included, which prints out a "Hello world" when started.