### PR TITLE
Initial gdb commands for thread debugging

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,3 +1,5 @@
 target remote localhost:1234
 break main
 continue
+
+source threads-gdb.py

--- a/threads-gdb.py
+++ b/threads-gdb.py
@@ -1,7 +1,7 @@
 import gdb
 
-def print_thread(thr):
-    print(thr['td_name'])
+def pretty_thread(thr):
+    return str(thr['td_name'].string())
 
 def collect_values_from_tq(tq,field):
     tq_it = tq['tqh_first']
@@ -33,27 +33,19 @@ class KernelThreads (gdb.Command):
             raise gdb.GdbError("kernel-threads takes no arguments")
         runnable = get_runnable_threads()
         if runnable:
-            print("runnable_threads:")
-            for t in runnable:
-                print_thread(t)
+            print "runnable_threads: ", map(pretty_thread, runnable)
         else:
-            print("no runnable threads")
-        print("current_thread:")
-        print_thread(current_thread())
+            print "no runnable threads"
+        print "current_thread: ", pretty_thread(current_thread())
 
 class CtxSwitchTracerBP (gdb.Breakpoint):
     def __init__(self):
         super(CtxSwitchTracerBP, self).__init__('ctx_switch')
 
     def stop(self):
-        print('context switch')
         frm = gdb.parse_and_eval('(struct thread*)$a0').dereference()
         to = gdb.parse_and_eval('(struct thread*)$a1').dereference()
-        print('old thread: ')
-        print_thread(frm)
-
-        print('new thread: ')
-        print_thread(to)
+        print 'context switch from ', pretty_thread(frm), ' to ', pretty_thread(to)
         return False
 
 class CtxSwitchTracer (gdb.Command):

--- a/threads-gdb.py
+++ b/threads-gdb.py
@@ -1,0 +1,46 @@
+import gdb
+
+def print_thread(thr):
+    print(thr['td_name'])
+
+def collect_values_from_tq(tq,field):
+    tq_it = tq['tqh_first']
+    ret = []
+    while tq_it != 0:
+        tq_it = tq_it.dereference() #tq_it is now value
+        ret.append(tq_it)
+        tq_it = tq_it[field]['tqe_next']
+    return ret
+
+def get_runnable_threads():
+    runq = gdb.parse_and_eval('runq.rq_queues')
+    rq_size = gdb.parse_and_eval('sizeof(runq.rq_queues)/sizeof(runq.rq_queues[0])')
+    threads = []
+    for i in range(0,rq_size):
+        threads = threads + collect_values_from_tq(runq[i], 'td_runq')
+    return threads
+
+def current_thread():
+    return gdb.parse_and_eval('thread_self()')
+
+class KernelThreads (gdb.Command):
+    def __init__(self):
+        super(KernelThreads, self).__init__("kernel-threads", gdb.COMMAND_USER)
+    def invoke(self, args, from_tty):
+        argv = gdb.string_to_argv(args)
+        if len(argv) != 0:
+            raise gdb.GdbError("kernel-threads takes no arguments")
+        runnable = get_runnable_threads()
+        if runnable:
+            print("runnable_threads:")
+            for t in runnable:
+                print_thread(t)
+        else:
+            print("no runnable threads")
+        print("current_thread:")
+        print_thread(current_thread())
+
+
+
+KernelThreads()
+


### PR DESCRIPTION
Since I'm stuck debugging turnstiles I decided to implement some debugging framework to help me with it. Toolchain gdb doesn't support python by default so I had to compile my own with python support. This is example on how to use python API to get some commands into gdb. I added just one which is 'kernel-threads' which prints runnable threads and currently running one. I'll find commands which track context_switches and new threads appearing in kernel useful and I'll definitely add them. They are mostly for my use, but someone might find them helpful.