### PR TITLE
Remove mtx_t

### DIFF
--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,16 +1,4 @@
 #ifndef __MUTEX_H__
 #define __MUTEX_H__
 
-#include <common.h>
-#include <mips/cpu.h>
-#include <mips/mips.h>
-
-typedef volatile uintptr_t mtx_t;
-
-#define MTX_INITIALIZER 0
-
-#define mtx_lock(m) __extension__({ m = _mips_intdisable(); })
-
-#define mtx_unlock(m) __extension__({ _mips_intrestore(m); })
-
 #endif /* __MUTEX_H__ */

--- a/sys/malloc.c
+++ b/sys/malloc.c
@@ -9,20 +9,17 @@ extern uint8_t __ebss[];
 static struct {
   void *ptr; /* Pointer to the end of kernel's bss. */
   void *end; /* Limit for the end of kernel's bss. */
-  mtx_t lock;
   bool shutdown;
-} sbrk = {__ebss, __ebss + 512 * PAGESIZE, MTX_INITIALIZER, false};
+} sbrk = {__ebss, __ebss + 512 * PAGESIZE, false};
 
 void kernel_brk(void *addr) {
   if (sbrk.shutdown)
     panic("Trying to use kernel_brk after it's been shutdown!");
-  mtx_lock(sbrk.lock);
   void *ptr = sbrk.ptr;
   addr = (void *)((intptr_t)addr & -sizeof(uint64_t));
   assert((intptr_t)__ebss <= (intptr_t)addr);
   assert((intptr_t)addr <= (intptr_t)sbrk.end);
   sbrk.ptr = addr;
-  mtx_unlock(sbrk.lock);
   if (addr > ptr)
     bzero(ptr, (intptr_t)addr - (intptr_t)ptr);
 }
@@ -30,22 +27,18 @@ void kernel_brk(void *addr) {
 void *kernel_sbrk(size_t size) {
   if (sbrk.shutdown)
     panic("Trying to use kernel_sbrk after it's been shutdown!");
-  mtx_lock(sbrk.lock);
   void *ptr = sbrk.ptr;
   size = roundup(size, sizeof(uint64_t));
   assert(ptr + size <= sbrk.end);
   sbrk.ptr += size;
-  mtx_unlock(sbrk.lock);
   bzero(ptr, size);
   return ptr;
 }
 
 void *kernel_sbrk_shutdown() {
   assert(!sbrk.shutdown);
-  mtx_lock(sbrk.lock);
   sbrk.end = align(sbrk.ptr, PAGESIZE);
   sbrk.shutdown = true;
-  mtx_unlock(sbrk.lock);
   return sbrk.end;
 }
 


### PR DESCRIPTION
With upcoming turnstiles I find old mtx_t unnecessary. We should follow FreeBSD convention and make mtx_t good, old blocking mutex.