### PR TITLE
Exclude toolchain path from tags file search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ cscope:
 	cscope -b include/*.h ./*.[cS] 
 
 tags:
-	find -iname '*.[ch]' | ctags --language-force=c -L-
-	find -iname '*.[ch]' | ctags --language-force=c -L- -e -f etags
-	find -iname '*.S' | ctags -a --language-force=asm -L-
-	find -iname '*.S' | ctags -a --language-force=asm -L- -e -f etags
+	find -iname '*.[ch]' -not -path "*/toolchain/*" | ctags --language-force=c -L-
+	find -iname '*.[ch]' -not -path "*/toolchain/*" | ctags --language-force=c -L- -e -f etags
+	find -iname '*.S' -not -path "*/toolchain/*" | ctags -a --language-force=asm -L-
+	find -iname '*.S' -not -path "*/toolchain/*" | ctags -a --language-force=asm -L- -e -f etags
 	find $(SYSROOT)/mips-mti-elf/include -type f -iname 'mips*' \
 		| ctags -a --language-force=c -L-
 	find $(SYSROOT)/mips-mti-elf/include -type f -iname 'mips*' \


### PR DESCRIPTION
By default, the new toolchain builder downloads all sources to `./toolchain/mips/.build/src`. We don't want to pull tags from these sources, not only they are irrelevant, but it also takes a very long time to `make tags`.