### PR TITLE
New toolchain support in make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SOURCES_ASM =
 all: tags cscope mips stdc sys $(TESTS)
 
 include Makefile.common
+$(info Using CC: $(CC))
 
 LDLIBS += -Lsys -Lmips -Lstdc \
 	  -Wl,--start-group -lsys -lmips -lstdc -lgcc -Wl,--end-group

--- a/Makefile.common
+++ b/Makefile.common
@@ -29,7 +29,7 @@ SYSROOT  = $(realpath $(dir $(shell which $(P)gcc))/..)
 GENASSYM = $(TOPDIR)/script/genassym.py $(NM)
 
 ASFLAGS  =
-CFLAGS   = -std=gnu11 -Og -Wall -Werror -Wno-format -fno-builtin -ffreestanding
+CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -ffreestanding
 CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDLIBS   =
 LDFLAGS  = -nostdlib -T malta.ld

--- a/Makefile.common
+++ b/Makefile.common
@@ -6,7 +6,16 @@ SOURCES = $(SOURCES_C) $(SOURCES_ASM)
 OBJECTS = $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o)
 DEPFILES = $(SOURCES_C:%.c=.%.D) $(SOURCES_ASM:%.S=.%.D)
 
-P        = mips-mti-elf-
+TRIPLET_CUSTOM  = mipsel-unknown-elf-
+TRIPLET_IMGTECH = mips-mti-elf-
+
+CUSTOM_TOOLCHAIN_FOUND = $(shell which $(TRIPLET_CUSTOM)gcc > /dev/null; echo $$?)
+# If custom toolchain is available, use it. Otherwise fall back to ImgTech's.
+ifeq ($(CUSTOM_TOOLCHAIN_FOUND),0)
+	P = $(TRIPLET_CUSTOM)
+else
+	P = $(TRIPLET_IMGTECH)
+endif
 CC       = $(P)gcc -mips32r2 -EL -g
 AR       = $(P)ar
 AS       = $(P)as -mips32r2 -EL -g
@@ -20,8 +29,8 @@ SYSROOT  = $(realpath $(dir $(shell which $(P)gcc))/..)
 GENASSYM = $(TOPDIR)/script/genassym.py $(NM)
 
 ASFLAGS  =
-CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -ffreestanding
-CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
+CFLAGS   = -std=gnu11 -Og -Wall -fno-builtin -ffreestanding
+CPPFLAGS = -Wall -DDEBUG -I$(TOPDIR)/include
 LDLIBS   =
 LDFLAGS  = -nostdlib -T malta.ld
 LD_EMBED =

--- a/Makefile.common
+++ b/Makefile.common
@@ -29,8 +29,8 @@ SYSROOT  = $(realpath $(dir $(shell which $(P)gcc))/..)
 GENASSYM = $(TOPDIR)/script/genassym.py $(NM)
 
 ASFLAGS  =
-CFLAGS   = -std=gnu11 -Og -Wall -fno-builtin -ffreestanding
-CPPFLAGS = -Wall -DDEBUG -I$(TOPDIR)/include
+CFLAGS   = -std=gnu11 -Og -Wall -Werror -Wno-format -fno-builtin -ffreestanding
+CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDLIBS   =
 LDFLAGS  = -nostdlib -T malta.ld
 LD_EMBED =

--- a/include/common.h
+++ b/include/common.h
@@ -7,8 +7,8 @@
 #include <stdalign.h>    /* alignof, alignas */
 #include <stdnoreturn.h> /* noreturn */
 
-typedef uintptr_t vm_addr_t;
-typedef uintptr_t pm_addr_t;
+typedef unsigned long vm_addr_t;
+typedef unsigned long pm_addr_t;
 
 /* Macros for counting and rounding. */
 #ifndef howmany

--- a/launch
+++ b/launch
@@ -6,11 +6,15 @@ import os.path
 import signal
 import subprocess
 import shlex
+import shutil
 from pexpect import popen_spawn
 
 OVPSIM_VENDOR = 'mips.ovpworld.org'
 OVPSIM_PLATFORM = 'MipsMalta/1.0'
-TRIPLET = 'mips-mti-elf'
+if shutil.which('mipsel-unknown-elf-gcc') is None:
+    TRIPLET = 'mips-mti-elf'
+else:
+    TRIPLET = 'mipsel-unknown-elf'
 PORT = 8000
 
 OVPSIM = os.path.join(os.environ['IMPERAS_VLNV'],

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -28,9 +28,9 @@
 #define PT_SIZE (PT_ENTRIES * sizeof(pte_t))
 
 #define PMAP_KERNEL_BEGIN MIPS_KSEG2_START
-#define PMAP_KERNEL_END   0xfffff000  /* kseg2 & kseg3 */
-#define PMAP_USER_BEGIN   0x00000000
-#define PMAP_USER_END     MIPS_KSEG0_START /* useg */
+#define PMAP_KERNEL_END 0xfffff000 /* kseg2 & kseg3 */
+#define PMAP_USER_BEGIN 0x00000000
+#define PMAP_USER_END MIPS_KSEG0_START /* useg */
 
 static const vm_addr_t PT_HOLE_START = PT_BASE + MIPS_KSEG0_START / PTF_ENTRIES;
 static const vm_addr_t PT_HOLE_END = PT_BASE + MIPS_KSEG2_START / PTF_ENTRIES;
@@ -64,7 +64,7 @@ static void pmap_setup(pmap_t *pmap, vm_addr_t start, vm_addr_t end) {
   pmap->start = start;
   pmap->end = end;
   pmap->asid = get_new_asid();
-  log("Page directory table allocated at %08lx", (intptr_t)pmap->pde);
+  log("Page directory table allocated at %08lx", (vm_addr_t)pmap->pde);
   TAILQ_INIT(&pmap->pte_pages);
 
   for (int i = 0; i < PD_ENTRIES; i++)
@@ -182,7 +182,7 @@ static void pmap_set_pte(pmap_t *pmap, vm_addr_t vaddr, pm_addr_t paddr,
   PTE_OF(pmap, vaddr) = PTE_PFN(paddr) | vm_prot_map[prot] |
                         (in_kernel_space(vaddr) ? PTE_GLOBAL : 0);
   log("Add mapping for page %08lx (PTE at %08lx)", (vaddr & PTE_MASK),
-      (intptr_t)&PTE_OF(pmap, vaddr));
+      (vm_addr_t)&PTE_OF(pmap, vaddr));
 
   /* invalidate corresponding entry in tlb */
   tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
@@ -192,7 +192,7 @@ static void pmap_set_pte(pmap_t *pmap, vm_addr_t vaddr, pm_addr_t paddr,
 static void pmap_clear_pte(pmap_t *pmap, vm_addr_t vaddr) {
   PTE_OF(pmap, vaddr) = 0;
   log("Remove mapping for page %08lx (PTE at %08lx)", (vaddr & PTE_MASK),
-      (intptr_t)&PTE_OF(pmap, vaddr));
+      (vm_addr_t)&PTE_OF(pmap, vaddr));
   /* invalidate corresponding entry in tlb */
   tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
 
@@ -204,7 +204,7 @@ static void pmap_change_pte(pmap_t *pmap, vm_addr_t vaddr, vm_prot_t prot) {
   PTE_OF(pmap, vaddr) =
     (PTE_OF(pmap, vaddr) & ~PTE_PROT_MASK) | vm_prot_map[prot];
   log("Change protection bits for page %08lx (PTE at %08lx)",
-      (vaddr & PTE_MASK), (intptr_t)&PTE_OF(pmap, vaddr));
+      (vaddr & PTE_MASK), (vm_addr_t)&PTE_OF(pmap, vaddr));
 
   /* invalidate corresponding entry in tlb */
   tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));

--- a/sys/callout.c
+++ b/sys/callout.c
@@ -41,12 +41,12 @@ void callout_setup(callout_t *handle, realtime_t time, timeout_t fn,
   handle->c_index = index;
   callout_set_pending(handle);
 
-  log("Add callout {%p} with wakeup at %ld.", handle, (size_t)handle->c_time);
+  log("Add callout {%p} with wakeup at %lld.", handle, handle->c_time);
   TAILQ_INSERT_TAIL(&ci.heads[index], handle, c_link);
 }
 
 void callout_stop(callout_t *handle) {
-  log("Remove callout {%p} at %ld.", handle, (size_t)handle->c_time);
+  log("Remove callout {%p} at %lld.", handle, handle->c_time);
   TAILQ_REMOVE(&ci.heads[handle->c_index], handle, c_link);
 }
 

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -43,7 +43,7 @@ int do_exec(const exec_args_t *args) {
     return -ENOENT;
   }
 
-  log("User ELF size: %ld", elf_size);
+  log("User ELF size: %d", elf_size);
 
   if (elf_size < sizeof(Elf32_Ehdr)) {
     log("Exec failed: ELF file is too small to contain a valid header");

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -43,7 +43,7 @@ int do_exec(const exec_args_t *args) {
     return -ENOENT;
   }
 
-  log("User ELF size: %d", elf_size);
+  log("User ELF size: %zu", elf_size);
 
   if (elf_size < sizeof(Elf32_Ehdr)) {
     log("Exec failed: ELF file is too small to contain a valid header");


### PR DESCRIPTION
This tiny change to `Makefile.common` enables the custom toolchain - **if available** at host. Since this would be a major breaking change for other contributors (and for travis), for some transitional period both toolchains are supported. Make simply checks whether `mipsel-unknown-elf-gcc` is available, and if not, it falls back to `mips-mti-elf-*`. In both cases compilation succeeds, and the produced kernel image operates normally.

Also I had to disable `-Wformat`. gcc 5.2 is very confused about one particular detail that appears in numerous places in our sources, namely printing a `vm_addr_t` (or similar address types) with a `%lx`. `vm_addr_t` is AKA `unsigned int`, so gcc complains that we should not use the `l` prefix for printing. I might go ahead and correct all `%lx` to `%x`, but since they are there *for some reason*, I assume we want such address types to be realized as `long`.