### PR TITLE
Basic atomic operations (compare and swap, atomic store)

### DIFF
--- a/include/atomic.h
+++ b/include/atomic.h
@@ -1,0 +1,25 @@
+#ifndef __ATOMIC_H__
+#define __ATOMIC_H__
+
+#include <stdc.h>
+
+/*
+ * Atomically compare the value stored at *p with cmpval and if the
+ * two values are equal, update the value of *p with newval. Returns
+ * zero if the compare failed, nonzero otherwise.
+ * Pseudocode:
+ * if *p == cmpval:
+ *  *p = newval
+ *  return true
+ * else:
+ *  return false
+ */
+int atomic_cmp_exchange(volatile uint32_t *p, uint32_t cmpval, uint32_t newval);
+
+/* Atomically stores value stored in val on the memory address p.
+ * Pseudocode:
+ * *p = val
+ * */
+void atomic_store(volatile uint32_t *p, uint32_t val);
+
+#endif /* __ATOMIC_H__ */

--- a/mips/Makefile
+++ b/mips/Makefile
@@ -1,6 +1,6 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-SOURCES_C = clock.c context.c cpu.c intr.c pci.c physmem.c pmap.c	\
+SOURCES_C = atomic.c clock.c context.c cpu.c intr.c pci.c physmem.c pmap.c	\
 	    stack.c sync.c tlb.c uart_cbus.c
 SOURCES_ASM = boot.S exc.S switch.S syscall.S tlb_ops.S ebase.S
 

--- a/mips/atomic.c
+++ b/mips/atomic.c
@@ -1,8 +1,8 @@
 #include <atomic.h>
 
 #define __MIPS_PLATFORM_SYNC_NOPS ""
-static __inline void mips_sync(void) {
-  __asm __volatile(".set noreorder\n"
+static inline void mips_sync(void) {
+  asm volatile(".set noreorder\n"
                    "\tsync\n" __MIPS_PLATFORM_SYNC_NOPS ".set reorder\n"
                    :
                    :
@@ -13,7 +13,7 @@ static inline uint32_t atomic_cmpset_32(volatile uint32_t *p, uint32_t cmpval,
                                         uint32_t newval) {
   uint32_t ret;
 
-  __asm __volatile("1:\tll %0, %4\n\t"  /* load old value */
+  asm volatile("1:\tll %0, %4\n\t"  /* load old value */
                    "bne %0, %2, 2f\n\t" /* compare */
                    "move %0, %3\n\t"    /* value to store */
                    "sc %0, %1\n\t"      /* attempt to store */
@@ -46,11 +46,11 @@ static inline void atomic_store_rel_32(volatile uint32_t *p, uint32_t v) {
   *p = v;
 }
 
-int atomic_cmp_exchange(__volatile uint32_t *p, uint32_t cmpval,
+int atomic_cmp_exchange(volatile uint32_t *p, uint32_t cmpval,
                         uint32_t newval) {
   return atomic_cmpset_acq_32(p, cmpval, newval);
 }
 
-void atomic_store(__volatile uint32_t *p, uint32_t val) {
+void atomic_store(volatile uint32_t *p, uint32_t val) {
   atomic_store_rel_32(p, val);
 }

--- a/mips/atomic.c
+++ b/mips/atomic.c
@@ -1,12 +1,10 @@
 #include <atomic.h>
 
-#define __MIPS_PLATFORM_SYNC_NOPS ""
 static inline void mips_sync(void) {
   asm volatile(".set noreorder\n"
-                   "\tsync\n" __MIPS_PLATFORM_SYNC_NOPS ".set reorder\n"
-                   :
-                   :
-                   : "memory");
+               "\tsync\n"
+               ".set reorder\n" ::
+                 : "memory");
 }
 
 static inline uint32_t atomic_cmpset_32(volatile uint32_t *p, uint32_t cmpval,
@@ -14,17 +12,17 @@ static inline uint32_t atomic_cmpset_32(volatile uint32_t *p, uint32_t cmpval,
   uint32_t ret;
 
   asm volatile("1:\tll %0, %4\n\t"  /* load old value */
-                   "bne %0, %2, 2f\n\t" /* compare */
-                   "move %0, %3\n\t"    /* value to store */
-                   "sc %0, %1\n\t"      /* attempt to store */
-                   "beqz %0, 1b\n\t"    /* if it failed, spin */
-                   "j 3f\n\t"
-                   "2:\n\t"
-                   "li %0, 0\n\t"
-                   "3:\n"
-                   : "=&r"(ret), "=m"(*p)
-                   : "r"(cmpval), "r"(newval), "m"(*p)
-                   : "memory");
+               "bne %0, %2, 2f\n\t" /* compare */
+               "move %0, %3\n\t"    /* value to store */
+               "sc %0, %1\n\t"      /* attempt to store */
+               "beqz %0, 1b\n\t"    /* if it failed, spin */
+               "j 3f\n\t"
+               "2:\n\t"
+               "li %0, 0\n\t"
+               "3:\n"
+               : "=&r"(ret), "=m"(*p)
+               : "r"(cmpval), "r"(newval), "m"(*p)
+               : "memory");
   return ret;
 }
 

--- a/mips/atomic.c
+++ b/mips/atomic.c
@@ -1,0 +1,56 @@
+#include <atomic.h>
+
+#define __MIPS_PLATFORM_SYNC_NOPS ""
+static __inline void mips_sync(void) {
+  __asm __volatile(".set noreorder\n"
+                   "\tsync\n" __MIPS_PLATFORM_SYNC_NOPS ".set reorder\n"
+                   :
+                   :
+                   : "memory");
+}
+
+static inline uint32_t atomic_cmpset_32(volatile uint32_t *p, uint32_t cmpval,
+                                        uint32_t newval) {
+  uint32_t ret;
+
+  __asm __volatile("1:\tll %0, %4\n\t"  /* load old value */
+                   "bne %0, %2, 2f\n\t" /* compare */
+                   "move %0, %3\n\t"    /* value to store */
+                   "sc %0, %1\n\t"      /* attempt to store */
+                   "beqz %0, 1b\n\t"    /* if it failed, spin */
+                   "j 3f\n\t"
+                   "2:\n\t"
+                   "li %0, 0\n\t"
+                   "3:\n"
+                   : "=&r"(ret), "=m"(*p)
+                   : "r"(cmpval), "r"(newval), "m"(*p)
+                   : "memory");
+  return ret;
+}
+
+/*
+ * Atomically compare the value stored at *p with cmpval and if the
+ * two values are equal, update the value of *p with newval. Returns
+ * zero if the compare failed, nonzero otherwise.
+ */
+static inline uint32_t atomic_cmpset_acq_32(volatile uint32_t *p,
+                                            uint32_t cmpval, uint32_t newval) {
+  int retval;
+  retval = atomic_cmpset_32(p, cmpval, newval);
+  mips_sync();
+  return (retval);
+}
+
+static inline void atomic_store_rel_32(volatile uint32_t *p, uint32_t v) {
+  mips_sync();
+  *p = v;
+}
+
+int atomic_cmp_exchange(__volatile uint32_t *p, uint32_t cmpval,
+                        uint32_t newval) {
+  return atomic_cmpset_acq_32(p, cmpval, newval);
+}
+
+void atomic_store(__volatile uint32_t *p, uint32_t val) {
+  atomic_store_rel_32(p, val);
+}


### PR DESCRIPTION
This PR adds atomic operations stolen from FreeBSD. They are used to implement mutexes on other branch, thus tested and proved to be working.