### PR TITLE
Add turnstile data structure

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -17,6 +17,7 @@ typedef struct vm_map vm_map_t;
 typedef struct thread {
   TAILQ_ENTRY(thread) td_runq;   /* a link on run queue */
   TAILQ_ENTRY(thread) td_sleepq; /* a link on sleep queue */
+  TAILQ_ENTRY(thread) td_lock;    /* a link on turnstile */
   const char *td_name;
   /* thread state */
   enum { TDS_INACTIVE = 0x0, TDS_WAITING, TDS_READY, TDS_RUNNING } td_state;

--- a/include/turnstile.h
+++ b/include/turnstile.h
@@ -1,0 +1,19 @@
+#ifndef __TURNSTILE_H__
+#define __TURNSTILE_H__
+#include <queue.h>
+#include <thread.h>
+
+typedef struct { TAILQ_HEAD(, thread) td_queue; } turnstile_t;
+
+/* Initialize turnstile. */
+void turnstile_init(turnstile_t *);
+
+/* This puts currently running thread on the turnstile,
+ * puts it in waiting state and yields. While waiting on turnstile
+ * thread cannot be run. This function is done under critical section. */
+void turnstile_wait(turnstile_t *);
+
+/* Removes first thread from the turnstile and puts it into run queue.
+ * This function is done under critical section. */
+void turnstile_signal(turnstile_t *);
+#endif /* __TURNSTILE_H__ */

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -2,7 +2,7 @@
 
 SOURCES_C = callout.c clock.c exception.c exec.c interrupt.c malloc.c	\
 	    pci_ids.c physmem.c runq.c sched.c sleepq.c startup.c			\
-	    thread.c vm_map.c vm_object.c vm_pager.c pcpu.c
+	    thread.c turnstile.c vm_map.c vm_object.c vm_pager.c pcpu.c
 SOURCES_ASM = 
 
 all: $(DEPFILES) libsys.a 

--- a/sys/turnstile.c
+++ b/sys/turnstile.c
@@ -3,13 +3,13 @@
 #include <sched.h>
 #include <turnstile.h>
 
-void turnstile_init(turnstile_t *turnstile) {
-  TAILQ_INIT(&turnstile->td_queue);
+void turnstile_init(turnstile_t *ts) {
+  TAILQ_INIT(&ts->td_queue);
 }
 
 void turnstile_wait(turnstile_t *ts) {
   cs_enter();
-  struct thread *td = thread_self();
+  thread_t *td = thread_self();
   TAILQ_INSERT_TAIL(&ts->td_queue, td, td_lock);
   td->td_state = TDS_WAITING;
   cs_leave();
@@ -18,7 +18,7 @@ void turnstile_wait(turnstile_t *ts) {
 
 void turnstile_signal(turnstile_t *ts) {
   cs_enter();
-  struct thread *newtd = TAILQ_FIRST(&ts->td_queue);
+  thread_t *newtd = TAILQ_FIRST(&ts->td_queue);
   if (newtd) {
     TAILQ_REMOVE(&ts->td_queue, newtd, td_lock);
     sched_add(newtd);

--- a/sys/turnstile.c
+++ b/sys/turnstile.c
@@ -1,0 +1,27 @@
+#include <sync.h>
+#include <queue.h>
+#include <sched.h>
+#include <turnstile.h>
+
+void turnstile_init(turnstile_t *turnstile) {
+  TAILQ_INIT(&turnstile->td_queue);
+}
+
+void turnstile_wait(turnstile_t *ts) {
+  cs_enter();
+  struct thread *td = thread_self();
+  TAILQ_INSERT_TAIL(&ts->td_queue, td, td_lock);
+  td->td_state = TDS_WAITING;
+  cs_leave();
+  sched_yield();
+}
+
+void turnstile_signal(turnstile_t *ts) {
+  cs_enter();
+  struct thread *newtd = TAILQ_FIRST(&ts->td_queue);
+  if (newtd) {
+    TAILQ_REMOVE(&ts->td_queue, newtd, td_lock);
+    sched_add(newtd);
+  }
+  cs_leave();
+}


### PR DESCRIPTION
Add basic turnstile data structure. I decided to implement all I need to get the blocking mutexes done. And it turns out I needed only turnstile_wait and turnstile_signal. I'm still unsure about it working but I spent some time on testing implementation of turnstile using mutexes on other branch and everything seems to be ok. I'd like this and mutexes to be merged ASAP, so I can spill mutexes around the code and we can start testing if this implementation is correct. In other branch I plan to add some debugging commands to make life for potential debugging person easier.

This is very tiny, but it's all that is necessary to implement blocking mutexes. Since we don't really have high-level scheduler which reassigns priorities, we don't really have priorities and we don't need to solve priority inversion by hand. I decided not to implement keeping turnstile inside thread structure (FreeBSD memory optimisation) because I find correctness of mutexes more important than unnecessary at-the-moment optimization (this isn't however very difficult to implement). 