### PR TITLE
Enabled _gp support for usermode programs

### DIFF
--- a/user/Makefile
+++ b/user/Makefile
@@ -4,8 +4,8 @@ include ../Makefile.common
 
 PROGRAMS_C = prog.c
 
-CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding -G0
-LDFLAGS  = -nostdlib -T mimiker.ld -G0
+CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding
+LDFLAGS  = -nostdlib -T mimiker.ld
 
 PROGRAMS_OBJS = $(PROGRAMS_C:%.c=%.o)
 PROGRAMS_UELFS = $(PROGRAMS_C:%.c=%.uelf)

--- a/user/mimiker.ld
+++ b/user/mimiker.ld
@@ -6,6 +6,7 @@ PHDRS
     text   PT_LOAD FLAGS(5); /* read-only, executable */
     data   PT_LOAD FLAGS(6); /* read-write */
     rodata PT_LOAD FLAGS(4); /* read-only */
+    sdata  PT_LOAD FLAGS(6); /* read-write */
     bss    PT_LOAD FLAGS(6); /* read-write */
 }
 SECTIONS
@@ -20,7 +21,6 @@ SECTIONS
     .data :
     {
         *(.data .data.*)
-        *(.sdata .sdata.*)
         . = ALIGN(4);
     } : data
 
@@ -31,6 +31,14 @@ SECTIONS
         *(.rodata .rodata.*)
         . = ALIGN(4);
     } : rodata
+
+    . = ALIGN(4096);
+
+    _gp = ALIGN(16) + 0x7ff0;
+    .sdata :
+    {
+        *(.sdata .sdata.*)
+    } : sdata
 
     . = ALIGN(4096);
     .bss :
@@ -52,4 +60,3 @@ SECTIONS
 	}
 
 }
-

--- a/user/prog.c
+++ b/user/prog.c
@@ -4,6 +4,8 @@
 #define TEXTAREA_SIZE 100
 // This should land in .bss, accessed by a pointer in .data
 char textarea[TEXTAREA_SIZE];
+/* The string wil land in .rodata, but str will be stored in .sdata! */
+char *str = "A hard-coded string.";
 
 void abort() {
   while (1)
@@ -17,18 +19,13 @@ size_t my_strlen(const char *str) {
   return n;
 }
 
-void marquee(const char *string) {
-  uint32_t o = 0;
+// Copy warped string with changing offsets
+void marquee(const char *string, int offset) {
   size_t n = my_strlen(string);
-  while (1) {
-    o++;
-    // Copy string three times with changing offsets
-    for (int i = 0; i < TEXTAREA_SIZE - 1; i++) {
-      textarea[i] = string[(i + o) % n];
-    }
-    // Null-terminate
-    textarea[TEXTAREA_SIZE - 1] = 0;
+  for (int i = 0; i < TEXTAREA_SIZE - 1; i++) {
+    textarea[i] = string[(i + offset) % n];
   }
+  textarea[TEXTAREA_SIZE - 1] = 0;
 }
 
 int main(int argc, char **argv) {
@@ -36,7 +33,13 @@ int main(int argc, char **argv) {
   if (argc < 1)
     abort();
 
-  marquee(argv[0]);
+  uint32_t o = 0;
+  while (1) {
+    o++;
+    /* Test both the passed argument, and data accessed with $gp */
+    marquee(argv[0], o);
+    marquee(str, o);
+  }
 
   return 0;
 }

--- a/user/start.S
+++ b/user/start.S
@@ -16,6 +16,9 @@ NESTED(_start, CALLFRAME_SIZE, $ra)
     sw $ra,4($sp)
     sw $sp,0($sp)
 
+    # Prepare $gp
+    la $gp, _gp
+
     # Grab argc from below stack
     lw $a0,8($sp)
     # Prepare argv pointing at argument vector below stack


### PR DESCRIPTION
This branch enables small-data section and prepares `$gp` for usermode programs. Some details are explained in the discussion [here](https://github.com/cahirwpz/mimiker/pull/107#issuecomment-259316612). The updated test `prog.c` verifies that data can be successfully accessed with the `gp`.

I mentioned that while testing this I encountered a serious bug with context saving; I did not - it was my test that was incorrect.