### PR TITLE
Enabled libc for user programs

### DIFF
--- a/user/Makefile
+++ b/user/Makefile
@@ -6,6 +6,7 @@ PROGRAMS_C = prog.c
 
 CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding
 LDFLAGS  = -nostdlib -T mimiker.ld
+LDLIBS   = -lc
 
 PROGRAMS_OBJS = $(PROGRAMS_C:%.c=%.o)
 PROGRAMS_UELFS = $(PROGRAMS_C:%.c=%.uelf)
@@ -21,7 +22,7 @@ all: $(PROGRAMS_UELF_OS) $(PROGRAMS_UELFS)
 # Linking the program according to the provided script
 %.uelf: %.o start.o mimiker.ld
 	@echo "[LD] $(DIR)$< -> $(DIR)$@"
-	$(CC) $(LDFLAGS) start.o -o $@ $<
+	$(CC) $(LDFLAGS) start.o -o $@ $< $(LDLIBS)
 
 # Treating the liked program as binary data, placing it in .rodata
 # section, and embedding into an object file

--- a/user/Makefile
+++ b/user/Makefile
@@ -3,6 +3,7 @@ all: prog.uelf.o
 include ../Makefile.common
 
 PROGRAMS_C = prog.c
+SYSCALLS_C = syscalls.c
 
 CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding
 LDFLAGS  = -nostdlib -T mimiker.ld
@@ -20,9 +21,9 @@ all: $(PROGRAMS_UELF_OS) $(PROGRAMS_UELFS)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 # Linking the program according to the provided script
-%.uelf: %.o start.o mimiker.ld
+%.uelf: %.o start.o mimiker.ld syscalls.o
 	@echo "[LD] $(DIR)$< -> $(DIR)$@"
-	$(CC) $(LDFLAGS) start.o -o $@ $< $(LDLIBS)
+	$(CC) $(LDFLAGS) start.o -o $@ $< syscalls.o $(LDLIBS)
 
 # Treating the liked program as binary data, placing it in .rodata
 # section, and embedding into an object file

--- a/user/Makefile
+++ b/user/Makefile
@@ -5,9 +5,9 @@ include ../Makefile.common
 PROGRAMS_C = prog.c
 SYSCALLS_C = syscalls.c
 
-CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding
+CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding -mhard-float
 LDFLAGS  = -nostdlib -T mimiker.ld
-LDLIBS   = -lc
+LDLIBS   = -lc -lgcc
 
 PROGRAMS_OBJS = $(PROGRAMS_C:%.c=%.o)
 PROGRAMS_UELFS = $(PROGRAMS_C:%.c=%.uelf)

--- a/user/prog.c
+++ b/user/prog.c
@@ -1,17 +1,14 @@
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #define TEXTAREA_SIZE 100
 // This should land in .bss, accessed by a pointer in .data
 char textarea[TEXTAREA_SIZE];
 /* The string wil land in .rodata, but str will be stored in .sdata! */
 char *str = "A hard-coded string.";
-
-void abort() {
-  while (1)
-    ; /* Sigh. */
-}
 
 // Copy warped string with changing offsets
 void marquee(const char *string, int offset) {
@@ -26,6 +23,17 @@ int main(int argc, char **argv) {
   /* TODO: Actually, the 0-th argument should be the program name. */
   if (argc < 1)
     abort();
+
+  /* Test some libstd functions. They will all fail, because system calls are
+     not hooked up yet, but this should at least compile and link
+     successfully. */
+  printf("Hello libc!");
+
+  int *ptr = malloc(10 * sizeof(int));
+  free(ptr);
+
+  FILE *f = fopen("/etc/passwd", "rw");
+  fclose(f);
 
   uint32_t o = 0;
   while (1) {

--- a/user/prog.c
+++ b/user/prog.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #define TEXTAREA_SIZE 100
 // This should land in .bss, accessed by a pointer in .data
@@ -12,16 +13,9 @@ void abort() {
     ; /* Sigh. */
 }
 
-size_t my_strlen(const char *str) {
-  size_t n = 0;
-  while (*(str++))
-    n++;
-  return n;
-}
-
 // Copy warped string with changing offsets
 void marquee(const char *string, int offset) {
-  size_t n = my_strlen(string);
+  size_t n = strlen(string);
   for (int i = 0; i < TEXTAREA_SIZE - 1; i++) {
     textarea[i] = string[(i + offset) % n];
   }

--- a/user/syscalls.c
+++ b/user/syscalls.c
@@ -1,6 +1,3 @@
-/* unistd provides prototypes for syscall hooks. Including this file makes
-   compiler emit errors should we implement a non-confirming hook. */
-#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <sys/time.h>
@@ -8,6 +5,12 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <errno.h>
+
+#ifdef __NEWLIB__
+/* unistd provides prototypes for syscall hooks. Including this file makes
+   compiler emit errors should we implement a non-confirming hook. */
+#include <unistd.h>
+#endif
 
 void _exit(int __status) {
   /* Exit may not return! */

--- a/user/syscalls.c
+++ b/user/syscalls.c
@@ -1,0 +1,113 @@
+/* unistd provides prototypes for syscall hooks. Including this file makes
+   compiler emit errors should we implement a non-confirming hook. */
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/times.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <errno.h>
+
+void _exit(int __status) {
+  /* Exit may not return! */
+  while (1)
+    ;
+}
+
+int open(const char *pathname, int flags, ...) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int close(int __fildes) {
+  errno = ENOSYS;
+  return -1;
+}
+
+ssize_t read(int __fd, void *__buf, size_t __nbyte) {
+  errno = ENOSYS;
+  return -1;
+}
+
+ssize_t write(int __fd, const void *__buf, size_t __nbyte) {
+  errno = ENOSYS;
+  return -1;
+}
+
+_off_t lseek(int __fildes, _off_t __offset, int __whence) {
+  errno = ENOSYS;
+  return (off_t)-1;
+}
+
+int link(const char *__path1, const char *__path2) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int symlink(const char *__name1, const char *__name2) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int unlink(const char *path) {
+  errno = ENOSYS;
+  return -1;
+}
+
+ssize_t readlink(const char *__restrict __path, char *__restrict __buf,
+                 size_t __buflen) {
+  errno = ENOSYS;
+  return -1;
+}
+
+pid_t getpid() {
+  /* getpid never fails. */
+  return 0;
+}
+
+int kill(pid_t pid, int sig) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int fstat(int fd, struct stat *buf) {
+  errno = ENOSYS;
+  return -1;
+}
+
+void *sbrk(ptrdiff_t increment) {
+  errno = ENOSYS;
+  return (void *)-1;
+}
+
+int isatty(int __fildes) {
+  /* isatty never fails, so just pretend nothing is a TTY. */
+  errno = 0;
+  return 0;
+}
+
+pid_t fork() {
+  errno = ENOSYS;
+  return -1;
+}
+
+int execve(const char *__path, char *const __argv[], char *const __envp[]) {
+  errno = ENOSYS;
+  return -1;
+}
+
+pid_t wait(int *status) {
+  errno = ENOSYS;
+  return -1;
+}
+
+clock_t times(struct tms *buf) {
+  errno = ENOSYS;
+  return (clock_t)-1;
+}
+
+int gettimeofday(struct timeval *__restrict __p, void *__restrict __tz) {
+  errno = ENOSYS;
+  return -1;
+}

--- a/user/syscalls.c
+++ b/user/syscalls.c
@@ -1,15 +1,14 @@
-#include <sys/stat.h>
-#include <sys/wait.h>
-#include <sys/time.h>
-#include <sys/times.h>
-#include <fcntl.h>
-#include <signal.h>
 #include <errno.h>
 
 #ifdef __NEWLIB__
 /* unistd provides prototypes for syscall hooks. Including this file makes
    compiler emit errors should we implement a non-confirming hook. */
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/time.h>
+#include <sys/times.h>
 #endif
 
 void _exit(int __status) {

--- a/user/syscalls.c
+++ b/user/syscalls.c
@@ -5,10 +5,16 @@
    compiler emit errors should we implement a non-confirming hook. */
 #include <unistd.h>
 #include <fcntl.h>
-#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/times.h>
+#else
+/* These are for the old toolchain. */
+struct stat;
+struct tms;
+struct timeval;
+#include <sys/types.h>
 #endif
 
 void _exit(int __status) {


### PR DESCRIPTION
Thanks to crosstool-ng already building newlib for us, it turned out that enabling libc is as simple as adding `-lc` to linker flags - so this branch has a working libc demo.

Note that disabling `-nostdlib` is not the same as adding `-ld`. In particular, `-nostdlib` pulls `crti.o` and `crtbegin.o` from compiler's resources, and we are definitely not at the point where we might use them instead of our own `start.S`.

I'll continue working on this branch to add system call wrappers stubs. Kernel-side system call support will be done in a separate branch.