### PR TITLE
Syscalls vector and sys_write stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-TESTS = callout.elf malloc.elf physmem.elf pmap.elf rtc.elf sched.elf \
-	sleepq.elf syscall.elf thread.elf vm_map.elf exec.elf
+TESTS = callout.elf malloc.elf physmem.elf pmap.elf rtc.elf sched.elf		\
+	sleepq.elf syscall.elf thread.elf vm_map.elf exec.elf exec_syscall.elf
 SOURCES_C = 
 SOURCES_ASM = 
 
@@ -13,7 +13,7 @@ $(info Using CC: $(CC))
 LDLIBS += -Lsys -Lmips -Lstdc \
 	  -Wl,--start-group -lsys -lmips -lstdc -lgcc -Wl,--end-group
 
-LD_EMBED = user/prog.uelf.o
+LD_EMBED = user/prog.uelf.o user/syscall_test.uelf.o
 
 # Kernel runtime files
 KRT = stdc mips sys user
@@ -29,6 +29,7 @@ physmem.elf: physmem.ko $(KRT)
 sched.elf: sched.ko $(KRT)
 sleepq.elf: sleepq.ko $(KRT)
 exec.elf: exec.ko $(KRT)
+exec_syscall.elf: exec_syscall.ko $(KRT)
 
 libkernel.a: $(DEPFILES) $(OBJECTS)
 

--- a/exec_syscall.c
+++ b/exec_syscall.c
@@ -1,0 +1,13 @@
+#include <common.h>
+#include <exec.h>
+
+int main() {
+  exec_args_t exec_args;
+  exec_args.prog_name = "syscall_test";
+  exec_args.argv = (char *[]){"syscall_test"};
+  exec_args.argc = 1;
+
+  do_exec(&exec_args);
+
+  return 0;
+}

--- a/include/sysent.h
+++ b/include/sysent.h
@@ -33,7 +33,7 @@ extern sysent_t sysent[];
 
 int syscall(int n);
 
-/* Empty syscall handler, for uninmplemented and depracated syscall numbers. */
+/* Empty syscall handler, for unimplemented and deprecated syscall numbers. */
 int sys_nosys(thread_t *, syscall_args_t *, int *error);
 
 #endif /* !_SYS_SYSENT_H_ */

--- a/include/sysent.h
+++ b/include/sysent.h
@@ -1,16 +1,39 @@
 #ifndef _SYS_SYSENT_H_
 #define _SYS_SYSENT_H_
+#include <stdint.h>
+#include <mips/mips.h>
 
 typedef struct thread thread_t;
 
-typedef int syscall_t(thread_t *);
+#define SYSCALL_ARGS_MAX 4
+
+typedef struct syscall_args {
+  uint32_t code;
+  reg_t args[SYSCALL_ARGS_MAX];
+} syscall_args_t;
+
+typedef int syscall_t(thread_t *, syscall_args_t *, int *error);
 
 typedef struct { syscall_t *call; } sysent_t;
 
 extern sysent_t sysent[];
 
-#define SYS_LAST 0
+#define SYS_EXIT 1
+#define SYS_OPEN 2
+#define SYS_CLOSE 3
+#define SYS_READ 4
+#define SYS_WRITE 5
+#define SYS_LSEEK 6
+#define SYS_UNLINK 7
+#define SYS_GETPID 8
+#define SYS_KILL 9
+#define SYS_FSTAT 10
 
-int syscall(unsigned num);
+#define SYS_LAST 10
+
+int syscall(int n);
+
+/* Empty syscall handler, for uninmplemented and depracated syscall numbers. */
+int sys_nosys(thread_t *, syscall_args_t *, int *error);
 
 #endif /* !_SYS_SYSENT_H_ */

--- a/include/sysent.h
+++ b/include/sysent.h
@@ -12,7 +12,7 @@ typedef struct syscall_args {
   reg_t args[SYSCALL_ARGS_MAX];
 } syscall_args_t;
 
-typedef int syscall_t(thread_t *, syscall_args_t *, int *error);
+typedef int syscall_t(thread_t *, syscall_args_t *);
 
 typedef struct { syscall_t *call; } sysent_t;
 
@@ -34,6 +34,6 @@ extern sysent_t sysent[];
 int syscall(int n);
 
 /* Empty syscall handler, for unimplemented and deprecated syscall numbers. */
-int sys_nosys(thread_t *, syscall_args_t *, int *error);
+int sys_nosys(thread_t *, syscall_args_t *);
 
 #endif /* !_SYS_SYSENT_H_ */

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -2,6 +2,9 @@
 #include <mips/exc.h>
 #include <mips/mips.h>
 #include <pmap.h>
+#include <sysent.h>
+#include <errno.h>
+#include <thread.h>
 
 extern const char _ebase[];
 
@@ -62,9 +65,38 @@ void kernel_oops(exc_frame_t *frame) {
   panic("Unhandled exception");
 }
 
+void cpu_get_syscall_args(const exc_frame_t *frame, syscall_args_t *args) {
+  args->code = frame->v0;
+  args->args[0] = frame->a0;
+  args->args[1] = frame->a1;
+  args->args[2] = frame->a2;
+  args->args[3] = frame->a3;
+}
+
 void syscall_handler(exc_frame_t *frame) {
-  kprintf("[syscall] entered #%d from %s mode!\n", frame->v0,
+  /* Eventually we will want a platform-independent syscall entry, so
+     argument retrieval is done separately */
+  syscall_args_t args;
+  cpu_get_syscall_args(frame, &args);
+
+  kprintf("[syscall] entered #%d from %s mode!\n", (int)args.code,
           (frame->sr & SR_KSU_MASK) ? "user" : "kernel");
+
+  int error = 0, retval = 0;
+
+  if (args.code > SYS_LAST) {
+    retval = 0;
+    error = ENOSYS;
+    goto finalize;
+  }
+
+  /* Call the handler. */
+  retval = sysent[args.code].call(thread_self(), &args, &error);
+
+finalize:
+  /* Store returned value and errno. */
+  frame->v0 = retval;
+  frame->v1 = error;
   /* we need to fix return address to point to next instruction */
   frame->pc += 4;
 }

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -82,21 +82,19 @@ void syscall_handler(exc_frame_t *frame) {
   kprintf("[syscall] entered #%d from %s mode!\n", (int)args.code,
           (frame->sr & SR_KSU_MASK) ? "user" : "kernel");
 
-  int error = 0, retval = 0;
+  int retval = 0;
 
   if (args.code > SYS_LAST) {
-    retval = 0;
-    error = ENOSYS;
+    retval = -ENOSYS;
     goto finalize;
   }
 
   /* Call the handler. */
-  retval = sysent[args.code].call(thread_self(), &args, &error);
+  retval = sysent[args.code].call(thread_self(), &args);
 
 finalize:
-  /* Store returned value and errno. */
+  /* Store returned value. */
   frame->v0 = retval;
-  frame->v1 = error;
   /* we need to fix return address to point to next instruction */
   frame->pc += 4;
 }

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,8 +1,8 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-SOURCES_C = callout.c clock.c exception.c exec.c interrupt.c malloc.c	\
-	    pci_ids.c physmem.c runq.c sched.c sleepq.c startup.c			\
-	    thread.c turnstile.c vm_map.c vm_object.c vm_pager.c pcpu.c
+SOURCES_C = callout.c clock.c exception.c exec.c interrupt.c malloc.c pci_ids.c	\
+	    physmem.c runq.c sched.c sleepq.c startup.c sysent.c thread.c			\
+	    turnstile.c vm_map.c vm_object.c vm_pager.c pcpu.c
 SOURCES_ASM = 
 
 all: $(DEPFILES) libsys.a 

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -16,6 +16,7 @@
   extern uint8_t _binary_##name##_uelf_end[];
 
 EMBED_ELF_DECLARE(prog);
+EMBED_ELF_DECLARE(syscall_test);
 
 int get_elf_image(const exec_args_t *args, uint8_t **out_image,
                   size_t *out_size) {
@@ -28,6 +29,7 @@ int get_elf_image(const exec_args_t *args, uint8_t **out_image,
   }
 
   EMBED_ELF_BY_NAME(prog);
+  EMBED_ELF_BY_NAME(syscall_test);
   return -ENOENT;
 }
 

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -1,0 +1,37 @@
+#include <sysent.h>
+#include <stdc.h>
+#include <errno.h>
+
+int sys_nosys(thread_t *td, syscall_args_t *args, int *error) {
+  log("No such system call: %ld", args->code);
+  *error = ENOSYS;
+  return -1;
+};
+
+/* This is just a stub. A full implementation of this syscall will probably
+   deserve a separate file. */
+int sys_write(thread_t *td, syscall_args_t *args, int *error) {
+  int fd = args->args[0];
+  const char *buf = (const char *)(uintptr_t)args->args[1];
+  size_t count = args->args[2];
+
+  /* TODO: copyout string from userspace */
+  if (fd == 1 || fd == 2) {
+    /* We need a local copy of the string to null-terminate it after @count
+       bytes, because the only printing facility we have is kprintf. */
+    char buf2[count + 1];
+    memcpy(buf2, buf, count);
+    kprintf("%.*s", (int)count, buf);
+
+    return count;
+  }
+
+  *error = EBADF;
+  return -1;
+}
+
+/* clang-format hates long arrays. */
+sysent_t sysent[] = {
+  {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_write},
+  {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_nosys},
+};

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -17,10 +17,6 @@ int sys_write(thread_t *td, syscall_args_t *args, int *error) {
 
   /* TODO: copyout string from userspace */
   if (fd == 1 || fd == 2) {
-    /* We need a local copy of the string to null-terminate it after @count
-       bytes, because the only printing facility we have is kprintf. */
-    char buf2[count + 1];
-    memcpy(buf2, buf, count);
     kprintf("%.*s", (int)count, buf);
 
     return count;

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -2,15 +2,14 @@
 #include <stdc.h>
 #include <errno.h>
 
-int sys_nosys(thread_t *td, syscall_args_t *args, int *error) {
+int sys_nosys(thread_t *td, syscall_args_t *args) {
   log("No such system call: %ld", args->code);
-  *error = ENOSYS;
-  return -1;
+  return -ENOSYS;
 };
 
 /* This is just a stub. A full implementation of this syscall will probably
    deserve a separate file. */
-int sys_write(thread_t *td, syscall_args_t *args, int *error) {
+int sys_write(thread_t *td, syscall_args_t *args) {
   int fd = args->args[0];
   const char *buf = (const char *)(uintptr_t)args->args[1];
   size_t count = args->args[2];
@@ -22,8 +21,7 @@ int sys_write(thread_t *td, syscall_args_t *args, int *error) {
     return count;
   }
 
-  *error = EBADF;
-  return -1;
+  return -EBADF;
 }
 
 /* clang-format hates long arrays. */

--- a/user/Makefile
+++ b/user/Makefile
@@ -2,7 +2,7 @@ all: prog.uelf.o
 
 include ../Makefile.common
 
-PROGRAMS_C = prog.c
+PROGRAMS_C = prog.c syscall_test.c
 
 CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding
 LDFLAGS  = -nostdlib -T mimiker.ld

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -1,24 +1,11 @@
 #include <stddef.h>
-
-int write(int fd, const char *buf, size_t count) {
-  int retval;
-  asm volatile("move $a0, %1\n"
-               "move $a1, %2\n"
-               "move $a2, %3\n"
-               "li $v0, 5\n" /* SYS_WRITE */
-               "syscall\n"
-               "move %0, $v0\n"
-               : "=r"(retval)
-               : "r"(fd), "r"(buf), "r"(count)
-               : "%a0", "%a1", "%a2", "%v0");
-  /* TODO: */
-  /* if(retval < 0) errno = -retval */
-  return retval;
-}
+#include <errno.h>
+#include <unistd.h>
 
 int main(int argc, char **argv) {
   const char *str = "Hello world from a user program!\n";
   write(1, str, 33);
+  /* assert(errno = 0); */
   while (1)
     ;
 }

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -1,19 +1,18 @@
 #include <stddef.h>
 
 int write(int fd, const char *buf, size_t count) {
-  int retval, errval;
-  asm volatile("move $a0, %2\n"
-               "move $a1, %3\n"
-               "move $a2, %4\n"
+  int retval;
+  asm volatile("move $a0, %1\n"
+               "move $a1, %2\n"
+               "move $a2, %3\n"
                "li $v0, 5\n" /* SYS_WRITE */
                "syscall\n"
                "move %0, $v0\n"
-               "move %1, $v1\n"
-               : "=r"(retval), "=r"(errval)
+               : "=r"(retval)
                : "r"(fd), "r"(buf), "r"(count)
                : "4", "5", "6", "2", "3");
   /* TODO: */
-  /* errno = errval */
+  /* if(retval < 0) errno = -retval */
   return retval;
 }
 

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -1,0 +1,25 @@
+#include <stddef.h>
+
+int write(int fd, const char *buf, size_t count) {
+  int retval, errval;
+  asm volatile("move $a0, %2\n"
+               "move $a1, %3\n"
+               "move $a2, %4\n"
+               "li $v0, 5\n" /* SYS_WRITE */
+               "syscall\n"
+               "move %0, $v0\n"
+               "move %1, $v1\n"
+               : "=r"(retval), "=r"(errval)
+               : "r"(fd), "r"(buf), "r"(count)
+               : "4", "5", "6", "2", "3");
+  /* TODO: */
+  /* errno = errval */
+  return retval;
+}
+
+int main(int argc, char **argv) {
+  const char *str = "Hello world from a user program!\n";
+  write(1, str, 33);
+  while (1)
+    ;
+}

--- a/user/syscall_test.c
+++ b/user/syscall_test.c
@@ -10,7 +10,7 @@ int write(int fd, const char *buf, size_t count) {
                "move %0, $v0\n"
                : "=r"(retval)
                : "r"(fd), "r"(buf), "r"(count)
-               : "4", "5", "6", "2", "3");
+               : "%a0", "%a1", "%a2", "%v0");
   /* TODO: */
   /* if(retval < 0) errno = -retval */
   return retval;

--- a/user/syscalls.c
+++ b/user/syscalls.c
@@ -38,9 +38,22 @@ ssize_t read(int __fd, void *__buf, size_t __nbyte) {
   return -1;
 }
 
-ssize_t write(int __fd, const void *__buf, size_t __nbyte) {
-  errno = ENOSYS;
-  return -1;
+ssize_t write(int fd, const void *buf, size_t count) {
+  int retval;
+  asm volatile("move $a0, %1\n"
+               "move $a1, %2\n"
+               "move $a2, %3\n"
+               "li $v0, 5\n" /* SYS_WRITE */
+               "syscall\n"
+               "move %0, $v0\n"
+               : "=r"(retval)
+               : "r"(fd), "r"(buf), "r"(count)
+               : "%a0", "%a1", "%a2", "%v0");
+  if (retval < 0) {
+    errno = -retval;
+    return -1;
+  }
+  return retval;
 }
 
 _off_t lseek(int __fildes, _off_t __offset, int __whence) {


### PR DESCRIPTION
This is an improved variant of #107. Introduces a minimal syscall vector, and implements `sys_write` stub, which may be used by user programs for writing to temporary stdout/stderr dummies.