### PR TITLE
Split makefile sources into rows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,19 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-TESTS = callout.elf malloc.elf physmem.elf pmap.elf rtc.elf sched.elf		\
-	sleepq.elf syscall.elf thread.elf vm_map.elf exec.elf exec_syscall.elf mutex.elf
+TESTS = \
+	callout.elf \
+	exec.elf \
+	exec_syscall.elf \
+	malloc.elf \
+	mutex.elf \
+	physmem.elf \
+	pmap.elf \
+	rtc.elf \
+	sched.elf \
+	sleepq.elf \
+	syscall.elf \
+	thread.elf \
+	vm_map.elf
 SOURCES_C = 
 SOURCES_ASM = 
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,8 +1,26 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-SOURCES_C = callout.c clock.c exception.c exec.c interrupt.c malloc.c sysent.c \
-	    pci_ids.c physmem.c runq.c sched.c sleepq.c startup.c \
-	    thread.c turnstile.c vm_map.c vm_object.c vm_pager.c pcpu.c mutex.c
+SOURCES_C  = \
+	callout.c \
+	clock.c \
+	exception.c \
+	exec.c \
+	interrupt.c \
+	malloc.c \
+	mutex.c \
+	pci_ids.c \
+	pcpu.c \
+	physmem.c \
+	runq.c \
+	sched.c \
+	sleepq.c \
+	startup.c \
+	sysent.c \
+	thread.c \
+	turnstile.c \
+	vm_map.c \
+	vm_object.c \
+	vm_pager.c
 SOURCES_ASM = 
 
 all: $(DEPFILES) libsys.a 


### PR DESCRIPTION
I don't like the fact that while rebasing or merging a branch which adds new files to repo I often have to resolve conflicts in makefiles, splitting this into rows should avoid these conflicts in most of cases.