### PR TITLE
Major makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,40 +14,27 @@ TESTS = \
 	syscall.elf \
 	thread.elf \
 	vm_map.elf
-SOURCES_C = 
-SOURCES_ASM = 
+SOURCES_C =
+SOURCES_ASM =
 
-all: tags cscope mips stdc sys $(TESTS)
+all: tags cscope $(TESTS)
 
 include Makefile.common
 $(info Using CC: $(CC))
 
+# Directories which require calling make recursively
+SUBDIRS = mips stdc sys user
+
 LDLIBS += -Lsys -Lmips -Lstdc \
 	  -Wl,--start-group -lsys -lmips -lstdc -lgcc -Wl,--end-group
-
+# Files that need to be embedded alongside kernel image
 LD_EMBED = user/prog.uelf.o user/syscall_test.uelf.o
 
-# Kernel runtime files
-KRT = stdc mips sys user
-
-callout.elf: callout.ko $(KRT)
-thread.elf: thread.ko $(KRT)
-malloc.elf: malloc.ko $(KRT)
-pmap.elf: pmap.ko $(KRT)
-rtc.elf: rtc.ko $(KRT)
-context.elf: context.ko $(KRT)
-vm_map.elf: vm_map.ko $(KRT)
-physmem.elf: physmem.ko $(KRT)
-sched.elf: sched.ko $(KRT)
-sleepq.elf: sleepq.ko $(KRT)
-exec.elf: exec.ko $(KRT)
-exec_syscall.elf: exec_syscall.ko $(KRT)
-mutex.elf: mutex.ko $(KRT)
-
-libkernel.a: $(DEPFILES) $(OBJECTS)
+# Files required to link kernel image
+KRT = stdc/libstdc.a mips/libmips.a sys/libsys.a $(LD_EMBED)
 
 cscope:
-	cscope -b include/*.h ./*.[cS] 
+	cscope -b include/*.h ./*.[cS]
 
 tags:
 	find -iname '*.[ch]' -not -path "*/toolchain/*" | ctags --language-force=c -L-
@@ -55,11 +42,38 @@ tags:
 	find -iname '*.S' -not -path "*/toolchain/*" | ctags -a --language-force=asm -L-
 	find -iname '*.S' -not -path "*/toolchain/*" | ctags -a --language-force=asm -L- -e -f etags
 
+# These files get destroyed by clang-format, so we exclude them from formatting
 FORMATTABLE_EXCLUDE = include/elf stdc/smallclib include/mips/asm.h include/mips/m32c0.h
+# Search for all .c and .h files, excluding toolchain build directory and files from FORMATTABLE_EXCLUDE
 FORMATTABLE = $(shell find -type f -not -path "*/toolchain/*" -and \( -name '*.c' -or -name '*.h' \) | grep -v $(FORMATTABLE_EXCLUDE:%=-e %))
 format:
 	@echo "Formatting files: $(FORMATTABLE:./%=%)"
 	clang-format -style=file -i $(FORMATTABLE)
+
+
+define emit_subdir_rules
+# To make a directory, call make recursively
+$(1):
+	$$(MAKE) -C $$@
+endef
+define emit_krt_rule
+# To make an embeddable file, you need to make its directory
+$(1): $(patsubst %/,%,$(dir $(1)))
+	# This target has to override the generic %.a rule from Makefile.common, so
+	# that it won't get invoked in this case. Otherwise we would try to build,
+	# say, "sys/libsys.a" from "sys" with ar.
+	true
+endef
+define emit_test_rule
+# To build a test .elf, you require the corresponding .ko and all of $(KRT)
+$(1): $(1:%.elf=%.ko) $(KRT)
+endef
+
+# Generate targets according to rules above
+$(foreach subdir, $(SUBDIRS), $(eval $(call emit_subdir_rules,$(subdir))))
+$(foreach file, $(KRT), $(eval $(call emit_krt_rule,$(file))))
+$(foreach test, $(TESTS), $(eval $(call emit_test_rule,$(test))))
+
 
 test:
 	for file in $(wildcard *.test); do		\
@@ -71,23 +85,8 @@ test:
 	  fi						\
 	done
 
-mips:
-	$(MAKE) -C mips
-
-stdc:
-	$(MAKE) -C stdc 
-
-sys:
-	$(MAKE) -C sys
-
-user:
-	$(MAKE) -C user
-
 clean:
-	$(MAKE) -C mips clean
-	$(MAKE) -C stdc clean
-	$(MAKE) -C sys clean
-	$(MAKE) -C user clean
+	$(foreach DIR, $(SUBDIRS), $(MAKE) -C $(DIR) $@;)
 	$(RM) -f .*.D *.ko *.o *.a *.lst *~ *.elf *.map *.log
 	$(RM) -f tags cscope.out *.taghl
 	$(RM) -f $(TESTS)


### PR DESCRIPTION
I finally got down to cleaning up the main Makefile. My changes include:
- Correcting dependencies so that they point to files and not their parent directories
- Simplifying frequently edited variables
- Automatically generating as much as possible to reduce human-error risk (for example, creating a new test `*.c` required adding the file in two places in `Makefile`, and as some tests were present in only one of these places, the success of build varied with the order of dependency evaluation...)
- Providing slightly more documentation, as makefiles tend to get difficult to read. Minor formatting fixes.

As a pleasant effects of these changes:
- `make` no longer pointlessly rebuilds kernel `.elf`s and some other files when nothing was changed
- Fixed dependencies finally allow for parallelized building.

I've tested this new `Makefile` by manually touching each `*.{c,h,S}` file and verifying whether all targets rebuild correctly and in order, both with `make` and `make -j32`, so I am fairly confident everything works well.