### PR TITLE
High-priority fix for syscalls destroying user stack

### DIFF
--- a/user/syscalls.S
+++ b/user/syscalls.S
@@ -1,6 +1,8 @@
 #include <mips/asm.h>
 #include <errno.h>
 
+        .set noreorder
+
 AENT(sbrk)
 AENT(execve)
 AENT(link)


### PR DESCRIPTION
The last two instructions of `set_errno`, called in userspace when syscalls return error code:
```
        jr      $ra
        addiu   $sp, $sp, 24
```
are compiled into:
```
        jr      $ra
        nop
        addiu   $sp, $sp, 24
```
so the procedure does not restore `$sp` correctly! This branch fixes this issue by adding `.set noreorder` assembler directive, which makes it trust us about branch delay slots.

I hope we can merge this ASAP, because this is blocking all my other syscall-related work. Also: let this be a reminder to us all to always run tests even after cosmetic changes!