### PR TITLE
Implemented argument passing when creating a new thread

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -3,28 +3,25 @@
 #include <thread.h>
 #include <sched.h>
 
-void program_thread_1() {
+void program_thread(void *data) {
   exec_args_t exec_args;
-  exec_args.prog_name = "prog";
-  exec_args.argv = (char *[]){"argument1", "ARGUMENT2", "a-r-g-u-m-e-n-t-3"};
-  exec_args.argc = 3;
-  do_exec(&exec_args);
-}
-
-void program_thread_2() {
-  exec_args_t exec_args;
-  exec_args.prog_name = "prog";
-  exec_args.argv = (char *[]){"String passed as argument."};
-  exec_args.argc = 1;
-  do_exec(&exec_args);
-}
-
-void program_thread_3() {
-  exec_args_t exec_args;
-  exec_args.prog_name = "prog";
-  exec_args.argv = (char *[]){"abort_test"};
-  exec_args.argc = 1;
-  do_exec(&exec_args);
+  switch ((int)data) {
+  case 1:
+    exec_args.prog_name = "prog";
+    exec_args.argv = (char *[]){"argument1", "ARGUMENT2", "a-r-g-u-m-e-n-t-3"};
+    exec_args.argc = 3;
+    do_exec(&exec_args);
+  case 2:
+    exec_args.prog_name = "prog";
+    exec_args.argv = (char *[]){"String passed as argument."};
+    exec_args.argc = 1;
+    do_exec(&exec_args);
+  case 3:
+    exec_args.prog_name = "prog";
+    exec_args.argv = (char *[]){"abort_test"};
+    exec_args.argc = 1;
+    do_exec(&exec_args);
+  }
 }
 
 int main() {
@@ -45,9 +42,9 @@ int main() {
    * .bss.
    */
 
-  thread_t *td1 = thread_create("user_thread1", program_thread_1);
-  thread_t *td2 = thread_create("user_thread2", program_thread_2);
-  thread_t *td3 = thread_create("user_thread3", program_thread_3);
+  thread_t *td1 = thread_create("user_thread1", program_thread, (void *)1);
+  thread_t *td2 = thread_create("user_thread2", program_thread, (void *)2);
+  thread_t *td3 = thread_create("user_thread3", program_thread, (void *)3);
 
   sched_add(td1);
   sched_add(td2);

--- a/include/context.h
+++ b/include/context.h
@@ -13,13 +13,13 @@ typedef struct thread thread_t;
 
 /*
  * Initializes thread context so it can be resumed in such a way,
- * as if @target function was called.
+ * as if @target function was called with @arg argument.
  *
  * Such thread can be resumed either by switch or return from exception.
  *
  * TODO: A thread should call `thread_exit(NULL)` on return.
  */
-void ctx_init(thread_t *td, void (*target)());
+void ctx_init(thread_t *td, void (*target)(void *), void *arg);
 
 /*
  * Enters into a context initialized by @ctx_init function.

--- a/include/thread.h
+++ b/include/thread.h
@@ -45,7 +45,7 @@ typedef struct thread {
 
 thread_t *thread_self();
 noreturn void thread_init(void (*fn)(), int n, ...);
-thread_t *thread_create(const char *name, void (*fn)());
+thread_t *thread_create(const char *name, void (*fn)(void *), void *arg);
 void thread_delete(thread_t *td);
 
 void thread_switch_to(thread_t *td_ready);

--- a/mips/context.c
+++ b/mips/context.c
@@ -5,7 +5,7 @@
 extern noreturn void kernel_exit();
 extern noreturn void kern_exc_leave();
 
-void ctx_init(thread_t *td, void (*target)()) {
+void ctx_init(thread_t *td, void (*target)(void *), void *arg) {
   register void *gp asm("$gp");
 
   void *sp = td->td_kstack.stk_base + td->td_kstack.stk_size;
@@ -29,6 +29,7 @@ void ctx_init(thread_t *td, void (*target)()) {
   kframe->gp = (reg_t)gp;
   kframe->sp = (reg_t)sp;
   kframe->sr = (reg_t)sr;
+  kframe->a0 = (reg_t)arg;
 }
 
 void uctx_init(thread_t *td, vm_addr_t pc, vm_addr_t sp) {

--- a/mutex.c
+++ b/mutex.c
@@ -28,11 +28,11 @@ void mtx_test_main() {
 void mtx_test() {
   mtx_init(&mtx);
   mtx_init(&mtx);
-  td1 = thread_create("td1", mtx_test_main);
-  td2 = thread_create("td2", mtx_test_main);
-  td3 = thread_create("td3", mtx_test_main);
-  td4 = thread_create("td4", mtx_test_main);
-  td5 = thread_create("td5", mtx_test_main);
+  td1 = thread_create("td1", mtx_test_main, NULL);
+  td2 = thread_create("td2", mtx_test_main, NULL);
+  td3 = thread_create("td3", mtx_test_main, NULL);
+  td4 = thread_create("td4", mtx_test_main, NULL);
+  td5 = thread_create("td5", mtx_test_main, NULL);
   sched_add(td1);
   sched_add(td2);
   sched_add(td3);
@@ -64,8 +64,8 @@ void deadlock_main2() {
 void deadlock_test() {
   mtx_init(&mtx1);
   mtx_init(&mtx2);
-  td1 = thread_create("td1", deadlock_main1);
-  td2 = thread_create("td2", deadlock_main2);
+  td1 = thread_create("td1", deadlock_main1, NULL);
+  td2 = thread_create("td2", deadlock_main2, NULL);
   sched_add(td1);
   sched_add(td2);
   sched_run();

--- a/sched.c
+++ b/sched.c
@@ -23,11 +23,11 @@ static void demo_thread_2() {
 }
 
 void main() {
-  thread_t *t1 = thread_create("t1", demo_thread_1);
-  thread_t *t2 = thread_create("t2", demo_thread_1);
-  thread_t *t3 = thread_create("t3", demo_thread_1);
-  thread_t *t4 = thread_create("t4", demo_thread_2);
-  thread_t *t5 = thread_create("t5", demo_thread_2);
+  thread_t *t1 = thread_create("t1", demo_thread_1, NULL);
+  thread_t *t2 = thread_create("t2", demo_thread_1, NULL);
+  thread_t *t3 = thread_create("t3", demo_thread_1, NULL);
+  thread_t *t4 = thread_create("t4", demo_thread_2, NULL);
+  thread_t *t5 = thread_create("t5", demo_thread_2, NULL);
 
   sched_add(t1);
   sched_add(t2);
@@ -44,12 +44,10 @@ void main() {
 static struct {
   intptr_t start, end;
 } range[] = {
-  {0xd0000000, 0xd0001000},
-  { 0x1000000,  0x1001000},
-  { 0x2000000,  0x2001000}
-};
+  {0xd0000000, 0xd0001000}, {0x1000000, 0x1001000}, {0x2000000, 0x2001000}};
 
-void test_thread(volatile int *ptr) {
+void test_thread(void *p) {
+  int *ptr = p;
   kprintf("ptr: %p\n", ptr);
   while (1) {
     *ptr = *ptr + 1;
@@ -59,15 +57,12 @@ void test_thread(volatile int *ptr) {
 }
 
 void main() {
-  thread_t *t1 = thread_create("kernel-thread-1", test_thread);
-  thread_t *t3 = thread_create("user-thread-1", test_thread);
-  thread_t *t4 = thread_create("user-thread-2", test_thread);
-
-  /* TODO: How to initialize thread main function arguments in machine
-   * independent way? */
-  t1->td_kframe->a0 = range[0].start;
-  t3->td_kframe->a0 = range[1].start;
-  t4->td_kframe->a0 = range[2].start;
+  thread_t *t1 =
+    thread_create("kernel-thread-1", test_thread, (void *)range[0].start);
+  thread_t *t3 =
+    thread_create("user-thread-1", test_thread, (void *)range[1].start);
+  thread_t *t4 =
+    thread_create("user-thread-2", test_thread, (void *)range[2].start);
 
   vm_map_entry_t *entry1 =
     vm_map_add_entry(get_kernel_vm_map(), range[0].start, range[0].end,

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -20,7 +20,7 @@ noreturn void thread_init(void (*fn)(), int n, ...) {
 
   TAILQ_INIT(&all_threads);
 
-  td = thread_create("main", fn);
+  td = thread_create("main", fn, NULL);
 
   /* Pass arguments to called function. */
   exc_frame_t *kframe = td->td_kframe;
@@ -44,7 +44,7 @@ static tid_t make_tid() {
   return tid++;
 }
 
-thread_t *thread_create(const char *name, void (*fn)()) {
+thread_t *thread_create(const char *name, void (*fn)(void *), void *arg) {
   thread_t *td = kmalloc(td_pool, sizeof(thread_t), M_ZERO);
 
   td->td_name = name;
@@ -53,7 +53,7 @@ thread_t *thread_create(const char *name, void (*fn)()) {
   td->td_kstack.stk_base = (void *)PG_VADDR_START(td->td_kstack_obj);
   td->td_kstack.stk_size = PAGESIZE;
 
-  ctx_init(td, fn);
+  ctx_init(td, fn, arg);
 
   TAILQ_INSERT_TAIL(&all_threads, td, td_all);
 

--- a/thread.c
+++ b/thread.c
@@ -36,8 +36,8 @@ int main(int argc, char **argv, char **envp) {
   kprintf("argp = %p\n", envp);
 
   td0 = thread_self();
-  td1 = thread_create("first", demo_thread_1);
-  td2 = thread_create("second", demo_thread_2);
+  td1 = thread_create("first", demo_thread_1, NULL);
+  td2 = thread_create("second", demo_thread_2, NULL);
 
   thread_switch_to(td1);
 


### PR DESCRIPTION
Basically this modifies
```
thread_t *thread_create(const char *name, void (*fn)());
```
into
```
thread_t *thread_create(const char *name, void (*fn)(void *), void *arg);
```
so that one can optionally pass an argument to the thread function, in a manner similar to `pthread_create`. This mechanism is necessary to create an `init` kernel thread, as it needs to start arbitrarily many threads.  Incidentally this also cleans up thread creation in `sched.c`.