### PR TITLE
Unified syscall debug output

### DIFF
--- a/mips/intr.c
+++ b/mips/intr.c
@@ -79,9 +79,6 @@ void syscall_handler(exc_frame_t *frame) {
   syscall_args_t args;
   cpu_get_syscall_args(frame, &args);
 
-  kprintf("[syscall] entered #%d from %s mode!\n", (int)args.code,
-          (frame->sr & SR_KSU_MASK) ? "user" : "kernel");
-
   int retval = 0;
 
   if (args.code > SYS_LAST) {

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -5,7 +5,7 @@
 #include <sched.h>
 
 int sys_nosys(thread_t *td, syscall_args_t *args) {
-  log("No such system call: %ld", args->code);
+  kprintf("[syscall] unimplemented system call %ld\n", args->code);
   return -ENOSYS;
 };
 
@@ -15,6 +15,8 @@ int sys_write(thread_t *td, syscall_args_t *args) {
   int fd = args->args[0];
   const char *buf = (const char *)(uintptr_t)args->args[1];
   size_t count = args->args[2];
+
+  kprintf("[syscall] write(%d, %p, %zu)\n", fd, buf, count);
 
   /* TODO: copyout string from userspace */
   if (fd == 1 || fd == 2) {


### PR DESCRIPTION
Merely a minor cosmetic change to cleanup kernel debug messages for syscalls to make debugging syscalls easier, at least until we can properly filter messages.