### PR TITLE
Basic kernel arguments support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
 TESTS = \
+	args.elf \
 	callout.elf \
 	exec.elf \
 	exec_syscall.elf \

--- a/args.c
+++ b/args.c
@@ -1,0 +1,14 @@
+#include <args.h>
+#include <stdc.h>
+
+int main() {
+  const char *arg1 = kernel_args_get("arg1");
+  const char *arg2 = kernel_args_get("arg2");
+  int flag1 = kernel_args_get_flag("flag1");
+  int flag2 = kernel_args_get_flag("flag2");
+  kprintf("Argument arg1 is %s\n", arg1 ? arg1 : "NOT PRESENT");
+  kprintf("Argument arg2 is %s\n", arg2 ? arg2 : "NOT PRESENT");
+  kprintf("Flag flag1 is %s\n", flag1 ? "SET" : "NOT SET");
+  kprintf("Flag flag2 is %s\n", flag2 ? "SET" : "NOT SET");
+  return 0;
+}

--- a/include/args.h
+++ b/include/args.h
@@ -1,0 +1,15 @@
+#ifndef __ARGS_H__
+#define __ARGS_H__
+
+void kernel_args_parse(int argc, char **argv, char **envp);
+
+/* Searches for key=val argument in kernel args, and returns a pointer to the
+ * value string, or NULL if not found. On multiple matches, all but first are
+ * ignored. */
+const char *kernel_args_get(const char *key);
+
+/* Searches for flag in kernel arguments, and returns 1 if found, 0 otherwise.
+ */
+int kernel_args_get_flag(const char *flag);
+
+#endif // __ARGS_H__

--- a/launch
+++ b/launch
@@ -36,7 +36,8 @@ def configure_ovpsim(args):
         'mipsle1/srsctlHSS': 1,
         'rtc/timefromhost': 1,
         'uartCBUS/console': 1,
-        'uartCBUS/portnum': PORT
+        'uartCBUS/portnum': PORT,
+        'command': '"' + ' '.join(args.args) + '"'
     }
 
     try:
@@ -123,6 +124,8 @@ if __name__ == '__main__':
         description='Launch kernel in Malta board simulator.')
     parser.add_argument('kernel', metavar='KERNEL', type=str,
                         help='Kernel file in ELF format.')
+    parser.add_argument('args', metavar='ARGS', type=str, nargs='*',
+                        help='Kernel arguments.')
     parser.add_argument('-d', '--debug', action='store_true',
                         help='Start simulation under gdb.')
     parser.add_argument('-D', '--debugger', metavar='DEBUGGER', type=str,

--- a/stdc/Makefile
+++ b/stdc/Makefile
@@ -41,6 +41,8 @@ LIB_SOURCES += stdlib/qsort.c
 EXTRA_SOURCES += wctomb.c
 EXTRA_SOURCES += kprintf.c
 EXTRA_SOURCES += snprintf.c
+# strsep provided by smallclib handles empty fields incorrectly!
+EXTRA_SOURCES += strsep.c
 
 # The default rule.
 all: $(LIBNAME).a

--- a/stdc/Makefile
+++ b/stdc/Makefile
@@ -27,6 +27,7 @@ LIB_SOURCES += string/bzero.c
 LIB_SOURCES += string/memcpy.c
 LIB_SOURCES += string/strlen.c
 LIB_SOURCES += string/strcmp.c
+LIB_SOURCES += string/strncmp.c
 LIB_SOURCES += string/strcpy.c
 LIB_SOURCES += string/strspn.c
 LIB_SOURCES += string/strtok.c

--- a/stdc/Makefile
+++ b/stdc/Makefile
@@ -26,9 +26,10 @@ LIB_SOURCES += string/memset.c
 LIB_SOURCES += string/bzero.c
 LIB_SOURCES += string/memcpy.c
 LIB_SOURCES += string/strlen.c
-LIB_SOURCES += string/strcpy.c
 LIB_SOURCES += string/strcmp.c
+LIB_SOURCES += string/strcpy.c
 LIB_SOURCES += string/strspn.c
+LIB_SOURCES += string/strtok.c
 LIB_SOURCES += stdlib/qsort.c
 
 # LIB_SOURCES += stdlib/wctomb.c

--- a/stdc/Makefile
+++ b/stdc/Makefile
@@ -26,6 +26,7 @@ LIB_SOURCES += string/memset.c
 LIB_SOURCES += string/bzero.c
 LIB_SOURCES += string/memcpy.c
 LIB_SOURCES += string/strlen.c
+LIB_SOURCES += string/strcpy.c
 LIB_SOURCES += string/strcmp.c
 LIB_SOURCES += string/strspn.c
 LIB_SOURCES += stdlib/qsort.c

--- a/stdc/smallclib/string/strcpy.c
+++ b/stdc/smallclib/string/strcpy.c
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ *
+ * Copyright 2014-2015, Imagination Technologies Limited and/or its
+ *                      affiliated group companies.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+* 		  file : $RCSfile: strcpy.c,v $ 
+*     		author : $Author Imagination Technologies Ltd
+*    date last revised : $
+*      current version : $
+******************************************************************************/
+
+/* From newlib-2.0, no change */
+
+/*
+FUNCTION
+	<<strcpy>>---copy string
+
+INDEX
+	strcpy
+
+ANSI_SYNOPSIS
+	#include <string.h>
+	char *strcpy(char *<[dst]>, const char *<[src]>);
+
+TRAD_SYNOPSIS
+	#include <string.h>
+	char *strcpy(<[dst]>, <[src]>)
+	char *<[dst]>;
+	char *<[src]>;
+
+DESCRIPTION
+	<<strcpy>> copies the string pointed to by <[src]>
+	(including the terminating null character) to the array
+	pointed to by <[dst]>.
+
+RETURNS
+	This function returns the initial value of <[dst]>.
+
+PORTABILITY
+<<strcpy>> is ANSI C.
+
+<<strcpy>> requires no supporting OS subroutines.
+
+QUICKREF
+	strcpy ansi pure
+*/
+
+#include "low/_flavour.h"
+#include <string.h>
+#include <limits.h>
+
+/*SUPPRESS 560*/
+/*SUPPRESS 530*/
+
+/* Nonzero if either X or Y is not aligned on a "long" boundary.  */
+#define UNALIGNED(X, Y) \
+  (((long)X & (sizeof (long) - 1)) | ((long)Y & (sizeof (long) - 1)))
+
+#if LONG_MAX == 2147483647L
+#define DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080)
+#else
+#if LONG_MAX == 9223372036854775807L
+/* Nonzero if X (a long int) contains a NULL byte. */
+#define DETECTNULL(X) (((X) - 0x0101010101010101) & ~(X) & 0x8080808080808080)
+#else
+#error long int is not a 32bit or 64bit type.
+#endif
+#endif
+
+#ifndef DETECTNULL
+#error long int is not a 32bit or 64bit byte
+#endif
+
+char*
+_DEFUN (strcpy, (dst0, src0),
+	char *dst0 _AND
+	_CONST char *src0)
+{
+#if defined(__PREFER_SIZE_OVER_SPEED__)
+  char *s = dst0;
+
+  while ((*dst0++ = *src0++))
+    ;
+
+  return s;
+#else
+  char *dst = dst0;
+  _CONST char *src = src0;
+  long *aligned_dst;
+  _CONST long *aligned_src;
+
+  /* If SRC or DEST is unaligned, then copy bytes.  */
+  if (!UNALIGNED (src, dst))
+    {
+      aligned_dst = (long*)dst;
+      aligned_src = (long*)src;
+
+      /* SRC and DEST are both "long int" aligned, try to do "long int"
+         sized copies.  */
+      while (!DETECTNULL(*aligned_src))
+        {
+          *aligned_dst++ = *aligned_src++;
+        }
+
+      dst = (char*)aligned_dst;
+      src = (char*)aligned_src;
+    }
+
+  while ((*dst++ = *src++))
+    ;
+  return dst0;
+#endif /* not PREFER_SIZE_OVER_SPEED */
+}

--- a/stdc/smallclib/string/strncmp.c
+++ b/stdc/smallclib/string/strncmp.c
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *
+ * Copyright 2014-2015, Imagination Technologies Limited and/or its
+ *                      affiliated group companies.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+*                 file : $RCSfile: strncmp.c,v $ 
+*               author : $Author Imagination Technologies Ltd
+*    date last revised : $
+*      current version : $
+******************************************************************************/
+
+#include<string.h>
+
+int
+strncmp (const char *s1, const char *s2, size_t n)
+{ 
+   if (n == 0)
+    return 0;
+
+  while (n-- != 0 && *s1 == *s2)
+    {
+      if (n == 0 || *s1 == '\0')
+	break;
+      s1++;
+      s2++;
+    }
+
+  return (*(unsigned char *) s1) - (*(unsigned char *) s2);
+}

--- a/stdc/smallclib/string/strtok.c
+++ b/stdc/smallclib/string/strtok.c
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ *
+ * Copyright 2014-2015, Imagination Technologies Limited and/or its
+ *                      affiliated group companies.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+*                 file : $RCSfile: strtok.c,v $ 
+*               author : $Author Imagination Technologies Ltd
+*    date last revised : $
+*      current version : $
+******************************************************************************/
+
+#include <stdio.h>
+#include "low/_flavour.h"
+
+char *
+strtok_r (char *s, const char *delim, char **lasts)
+{
+  register char *spanp;
+  register int c, sc;
+  char *tok;
+
+  if (s == NULL)
+    s = *lasts;
+
+  if (s == NULL)
+    return NULL;
+
+  /* Skip leading delimiters */
+cont:
+  c = *s++;
+  for (spanp = (char *)delim; (sc = *spanp++) != 0;)
+    {
+      if (c == sc)
+        goto cont;
+    }
+
+  /* No non-delimiter characters */
+  if (c == 0)
+    {
+      *lasts = NULL;
+      return NULL;
+    }
+
+  tok = s - 1;
+
+  /*
+   * Scan token. Note that delim must have one NUL;
+   * we stop if we see that, too.
+  */
+  for (;;)
+    {
+      c = *s++;
+      spanp = (char *)delim;
+      do
+        {
+          if ((sc = *spanp++) == c)
+            {
+              if (c == 0)
+                s = NULL;
+              else
+                s[-1] = 0;
+              *lasts = s;
+              return (tok);
+            }
+        } while (sc != 0);
+    }
+  /* No Return */
+}
+
+static char *end_ptr = NULL;
+
+char *
+strtok (char *s1, const char *s2)
+{
+  return strtok_r (s1, s2, &end_ptr);
+}

--- a/stdc/strsep.c
+++ b/stdc/strsep.c
@@ -1,0 +1,77 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char sccsid[] = "@(#)strsep.c	8.1 (Berkeley) 6/4/93";
+#endif /* LIBC_SCCS and not lint */
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+
+/*
+ * Get next token from string *stringp, where tokens are possibly-empty
+ * strings separated by characters from delim.
+ *
+ * Writes NULs into the string at *stringp to end tokens.
+ * delim need not remain constant from call to call.
+ * On return, *stringp points past the last NUL written (if there might
+ * be further tokens), or is NULL (if there are definitely no more tokens).
+ *
+ * If *stringp is NULL, strsep returns NULL.
+ */
+char *
+strsep(stringp, delim)
+	char **stringp;
+	const char *delim;
+{
+	char *s;
+	const char *spanp;
+	int c, sc;
+	char *tok;
+
+	if ((s = *stringp) == NULL)
+		return (NULL);
+	for (tok = s;;) {
+		c = *s++;
+		spanp = delim;
+		do {
+			if ((sc = *spanp++) == c) {
+				if (c == 0)
+					s = NULL;
+				else
+					s[-1] = 0;
+				*stringp = s;
+				return (tok);
+			}
+		} while (sc != 0);
+	}
+	/* NOTREACHED */
+}
+

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,6 +1,7 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
 SOURCES_C  = \
+	args.c \
 	callout.c \
 	clock.c \
 	exception.c \

--- a/sys/args.c
+++ b/sys/args.c
@@ -1,0 +1,52 @@
+#include <args.h>
+#include <stdc.h>
+#include <string.h>
+#include <malloc.h>
+
+int kernel_argc;
+char **kernel_argv;
+
+void parse_args(int argc, char **argv, char **envp) {
+
+  /* First, calculate total length so that we can allocate memory where we will
+   * copy kernel arguments.
+   */
+  size_t total_len = 0;
+  for (unsigned int i = 0; i < argc; i++)
+    total_len += 1 + strlen(argv[i]);
+  kprintf("Total len: %zu\n", total_len);
+  /* Now correct argc, by counting spaces in each argument. */
+  kernel_argc = argc;
+  for (unsigned int i = 0; i < argc; i++)
+    for (char *j = argv[i]; *j != '\0'; j++)
+      if (*j == ' ')
+        kernel_argc++;
+  /* Allocate memory for arguments. We never free this memory. */
+  char *args = kernel_sbrk(total_len);
+  kernel_argv = kernel_sbrk(argc * sizeof(char *));
+  /* Copy arguments and prepare values for kernel_argv. */
+  char *curr = args;
+  unsigned int i = 0, j = 0;
+  for (; i < argc; i++) {
+    char *tok = strsep(argv + i, " ");
+    while (tok) {
+      strcpy(curr, tok);
+      kernel_argv[j++] = curr;
+      curr += strlen(tok) + 1;
+      tok = strsep(argv + i, " ");
+    }
+  }
+
+  kprintf("Kernel arguments:\n");
+  for (int i = 0; i < kernel_argc; i++)
+    kprintf("  %s\n", kernel_argv[i]);
+
+  kprintf("Kernel environment: ");
+  char **_envp = envp;
+  while (*_envp) {
+    char *key = *_envp++;
+    char *val = *_envp++;
+    kprintf("%s=%s ", key, val);
+  }
+  kprintf("\n");
+}

--- a/sys/args.c
+++ b/sys/args.c
@@ -6,7 +6,7 @@
 int kernel_argc;
 char **kernel_argv;
 
-void parse_args(int argc, char **argv, char **envp) {
+void kernel_args_parse(int argc, char **argv, char **envp) {
 
   /* First, calculate total length so that we can allocate memory where we will
    * copy kernel arguments.
@@ -49,4 +49,19 @@ void parse_args(int argc, char **argv, char **envp) {
     kprintf("%s=%s ", key, val);
   }
   kprintf("\n");
+}
+
+const char *kernel_args_get(const char *key) {
+  int n = strlen(key);
+  for (int i = 0; i < kernel_argc; i++)
+    if (strncmp(key, kernel_argv[i], n) == 0)
+      return kernel_argv[i];
+  return NULL;
+}
+
+int kernel_args_get_flag(const char *flag) {
+  for (int i = 0; i < kernel_argc; i++)
+    if (strcmp(flag, kernel_argv[i]) == 0)
+      return 1;
+  return 0;
 }

--- a/sys/args.c
+++ b/sys/args.c
@@ -14,7 +14,6 @@ void kernel_args_parse(int argc, char **argv, char **envp) {
   size_t total_len = 0;
   for (unsigned int i = 0; i < argc; i++)
     total_len += 1 + strlen(argv[i]);
-  kprintf("Total len: %zu\n", total_len);
   /* Now correct argc, by counting spaces in each argument. */
   kernel_argc = argc;
   for (unsigned int i = 0; i < argc; i++)
@@ -23,7 +22,7 @@ void kernel_args_parse(int argc, char **argv, char **envp) {
         kernel_argc++;
   /* Allocate memory for arguments. We never free this memory. */
   char *args = kernel_sbrk(total_len);
-  kernel_argv = kernel_sbrk(argc * sizeof(char *));
+  kernel_argv = kernel_sbrk(kernel_argc * sizeof(char *));
   /* Copy arguments and prepare values for kernel_argv. */
   char *curr = args;
   unsigned int i = 0, j = 0;
@@ -55,7 +54,7 @@ const char *kernel_args_get(const char *key) {
   int n = strlen(key);
   for (int i = 0; i < kernel_argc; i++)
     if (strncmp(key, kernel_argv[i], n) == 0)
-      return kernel_argv[i];
+      return kernel_argv[i] + n + 1;
   return NULL;
 }
 

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -23,7 +23,7 @@ extern int main(int argc, char **argv, char **envp);
 
 int kernel_boot(int argc, char **argv, char **envp) {
   uart_init();
-  parse_args(argc, argv, envp);
+  kernel_args_parse(argc, argv, envp);
   cpu_init();
   pcpu_init();
   pci_init();

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -16,26 +16,14 @@
 #include <thread.h>
 #include <vm_object.h>
 #include <vm_map.h>
+#include <string.h>
+#include <args.h>
 
 extern int main(int argc, char **argv, char **envp);
 
 int kernel_boot(int argc, char **argv, char **envp) {
   uart_init();
-
-  kprintf("Kernel arguments: ");
-  for (int i = 0; i < argc; i++)
-    kprintf("%s ", argv[i]);
-  kprintf("\n");
-
-  kprintf("Kernel environment: ");
-  char **_envp = envp;
-  while (*_envp) {
-    char *key = *_envp++;
-    char *val = *_envp++;
-    kprintf("%s=%s ", key, val);
-  }
-  kprintf("\n");
-
+  parse_args(argc, argv, envp);
   cpu_init();
   pcpu_init();
   pci_init();


### PR DESCRIPTION
**Note:** This branch incorporates changes from #140, so please process it before this one.

Here's a simple interface for accessing kernel args. These proposed changes include:
 - parsing kernel arguments (splitting them by spaces)
 - providing utilities for convenient access to arguments, namely:
```
const char *kernel_args_get(const char *key);
int kernel_args_get_flag(const char *flag);
```
The new test `args.c` is pretty self-explanatory. The `launch` script was updated, so that it may be run like this:
```
./launch -d args.elf arg1=value1 flag1 arg2=value2
```
Works with both OVPsim and QEMU.

@mkaim: I suppose you will find this useful.