### PR TITLE
File descriptors test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TESTS = \
 	crash.elf \
 	exec.elf \
 	exec_misbehave.elf \
+	exec_fd_test.elf \
 	malloc.elf \
 	mutex.elf \
 	physmem.elf \
@@ -29,7 +30,7 @@ SUBDIRS = mips stdc sys user
 LDLIBS += -Lsys -Lmips -Lstdc \
 	  -Wl,--start-group -lsys -lmips -lstdc -lgcc -Wl,--end-group
 # Files that need to be embedded alongside kernel image
-LD_EMBED = user/prog.uelf.o user/misbehave.uelf.o
+LD_EMBED = user/prog.uelf.o user/misbehave.uelf.o user/fd_test.uelf.o
 
 # Files required to link kernel image
 KRT = stdc/libstdc.a mips/libmips.a sys/libsys.a $(LD_EMBED)

--- a/exec_fd_test.c
+++ b/exec_fd_test.c
@@ -1,0 +1,13 @@
+#include <common.h>
+#include <exec.h>
+
+int main() {
+  exec_args_t exec_args;
+  exec_args.prog_name = "fd_test";
+  exec_args.argv = (char *[]){"fd_test"};
+  exec_args.argc = 1;
+
+  do_exec(&exec_args);
+
+  return 0;
+}

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -17,6 +17,7 @@
 
 EMBED_ELF_DECLARE(prog);
 EMBED_ELF_DECLARE(misbehave);
+EMBED_ELF_DECLARE(fd_test);
 
 int get_elf_image(const exec_args_t *args, uint8_t **out_image,
                   size_t *out_size) {
@@ -30,6 +31,7 @@ int get_elf_image(const exec_args_t *args, uint8_t **out_image,
 
   EMBED_ELF_BY_NAME(prog);
   EMBED_ELF_BY_NAME(misbehave);
+  EMBED_ELF_BY_NAME(fd_test);
   return -ENOENT;
 }
 

--- a/user/Makefile
+++ b/user/Makefile
@@ -2,7 +2,7 @@ all: prog.uelf.o
 
 include ../Makefile.common
 
-PROGRAMS_C = prog.c misbehave.c
+PROGRAMS_C = prog.c misbehave.c fd_test.c
 SOURCES_ASM = syscalls.S start.S
 
 CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -ffreestanding -mhard-float

--- a/user/fd_test.c
+++ b/user/fd_test.c
@@ -1,0 +1,137 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <string.h>
+#include <errno.h>
+
+int main(int argc, char **argv) {
+  const char *str = "Hello world from a user program!\n";
+  int error = 0;
+  int fd0, fd1, fd2;
+  char buf[100];
+
+  /* Open a /dev/null */
+  fd0 = open("/dev/null", 0, O_WRONLY);
+  assert(fd0 == 0);
+  /* Open an invalid file */
+  fd1 = open("/proc/cpuinfo", 0, NULL);
+  assert(fd1 < 0);
+  assert(errno == ENOENT);
+  /* Write to /dev/null */
+  error = write(fd0, str, strlen(str));
+  assert(error >= 0);
+  /* Open another /dev/null */
+  fd1 = open("/dev/null", 0, O_RDONLY);
+  assert(fd1 == 1);
+  /* And one more. */
+  fd2 = open("/dev/null", 0, O_RDONLY);
+  assert(fd2 == 2);
+  /* Read from the second /dev/null */
+  memset(buf, -1, 100);
+  error = read(fd1, buf, 100);
+  assert(error >= 0);
+  assert(buf[10] == 0 && buf[90] == 0);
+  /* Close the second /dev/null */
+  error = close(fd1);
+  assert(error >= 0);
+  /* Open one more /dev/null, observe how fd 1 is reused. */
+  fd1 = open("/dev/null", 0, O_WRONLY);
+  assert(fd1 == 1);
+  /* Write to the newest /dev/null */
+  error = write(fd0, str, strlen(str));
+  assert(error >= 0);
+  /* Close fd0 */
+  error = close(fd0);
+  assert(error >= 0);
+  /* Try closing fd0 again. */
+  error = close(fd0);
+  assert(error < 0);
+  assert(errno == EBADF);
+  /* Try writing to fd0 */
+  error = write(fd0, str, strlen(str));
+  assert(error < 0);
+  assert(errno == EBADF);
+  /* Try reading from fd0 */
+  memset(buf, -1, 100);
+  error = read(fd0, buf, 100);
+  assert(error < 0);
+  assert(errno == EBADF);
+  assert(buf[10] == -1 && buf[90] == -1);
+  /* Try writing to file we never referenced. */
+  error = write(42, str, strlen(str));
+  assert(error < 0);
+  assert(errno == EBADF);
+  /* Try closing a file we never referenced. */
+  error = close(42);
+  assert(error < 0);
+  assert(errno == EBADF);
+  /* Try closing invalid file */
+  error = close(-15);
+  assert(error < 0);
+  assert(errno == EBADF);
+  /* At this point, fd1 and fd2 are still open. */
+  /* fd1 is open in write-only mode, reading from it should fail */
+  memset(buf, -1, 100);
+  error = read(fd1, buf, 100);
+  assert(error < 0);
+  assert(errno == EBADF);
+  assert(buf[10] == -1 && buf[90] == -1);
+  /* fd2 is open in read-only mode, writing to it should fail */
+  error = write(fd2, str, strlen(str));
+  assert(error < 0);
+  assert(errno == EBADF);
+  /* Try opening a valid file with an invalid mode */
+  error = open("/dev/null", 0, 42);
+  assert(error < 0);
+  assert(errno == EINVAL);
+  /* Close fd1 and reopen it in read-write mode */
+  close(fd1);
+  fd0 = open("/dev/null", 0, O_RDWR);
+  assert(fd0 == 0);
+  /* See that both reading from and writing to fd0 now works. */
+  memset(buf, -1, 100);
+  error = read(fd0, buf, 100);
+  assert(error >= 0);
+  assert(buf[10] == 0 && buf[90] == 0);
+  error = write(fd0, str, strlen(str));
+  assert(error >= 0);
+
+  /* Try opening a file with a name too long. */
+  char too_long[500];
+  memset(too_long, 'c', sizeof(too_long));
+  too_long[sizeof(too_long) - 1] = 0;
+  error = open(too_long, 0, O_RDWR);
+  assert(error < 0);
+  /* This is very unfortunate! In our errno.h: ENAMETOOLONG is 63, but errno.h
+     provided by newlib (since we DID NOT port newlib to our system, which would
+     include providing our custom sys/errno.h) uses ENAMETOOLONG 91. */
+  assert(errno == 63);
+  /* Now, try passing some invalid pointers as data to read/write. */
+  /* Kernel space */
+  char *naughty_ptr1 = (char *)0x80001000;
+  /* User space, hopefully not mapped */
+  char *naughty_ptr2 = (char *)0x00001000;
+  error = write(fd0, naughty_ptr1, 200);
+  assert(error < 0);
+  assert(errno == EFAULT);
+  error = write(fd0, naughty_ptr2, 200);
+  assert(error < 0);
+  assert(errno == EFAULT);
+  error = read(fd0, naughty_ptr1, 200);
+  assert(error < 0);
+  assert(errno == EFAULT);
+  error = read(fd0, naughty_ptr2, 200);
+  assert(error < 0);
+  assert(errno == EFAULT);
+  /* Also, try opening a file using a bad pointer */
+  error = open(naughty_ptr1, 0, O_RDWR);
+  assert(error < 0);
+  assert(errno == EFAULT);
+  error = open(naughty_ptr2, 0, O_RDWR);
+  assert(error < 0);
+  assert(errno == EFAULT);
+
+  /* At this point fd0 and fd2 are left open. */
+  /* After this thread returns, all files should get closed. */
+  return 0;
+}

--- a/user/fd_test.c
+++ b/user/fd_test.c
@@ -4,134 +4,150 @@
 #include <string.h>
 #include <errno.h>
 
-int main(int argc, char **argv) {
-  const char *str = "Hello world from a user program!\n";
-  int error = 0;
-  int fd0, fd1, fd2;
-  char buf[100];
+const char *str = "Hello world from a user program!\n";
+int error = 0;
+int n;
+int fd0, fd1, fd2;
+char buf[100];
 
-  /* Open a /dev/null */
-  fd0 = open("/dev/null", 0, O_WRONLY);
-  assert(fd0 == 0);
-  /* Open an invalid file */
-  fd1 = open("/proc/cpuinfo", 0, NULL);
-  assert(fd1 < 0);
-  assert(errno == ENOENT);
-  /* Write to /dev/null */
-  error = write(fd0, str, strlen(str));
-  assert(error >= 0);
-  /* Open another /dev/null */
-  fd1 = open("/dev/null", 0, O_RDONLY);
-  assert(fd1 == 1);
-  /* And one more. */
-  fd2 = open("/dev/null", 0, O_RDONLY);
-  assert(fd2 == 2);
-  /* Read from the second /dev/null */
-  memset(buf, -1, 100);
-  error = read(fd1, buf, 100);
-  assert(error >= 0);
-  assert(buf[10] == 0 && buf[90] == 0);
-  /* Close the second /dev/null */
-  error = close(fd1);
-  assert(error >= 0);
-  /* Open one more /dev/null, observe how fd 1 is reused. */
-  fd1 = open("/dev/null", 0, O_WRONLY);
-  assert(fd1 == 1);
-  /* Write to the newest /dev/null */
-  error = write(fd0, str, strlen(str));
-  assert(error >= 0);
-  /* Close fd0 */
-  error = close(fd0);
-  assert(error >= 0);
-  /* Try closing fd0 again. */
-  error = close(fd0);
-  assert(error < 0);
-  assert(errno == EBADF);
-  /* Try writing to fd0 */
-  error = write(fd0, str, strlen(str));
-  assert(error < 0);
-  assert(errno == EBADF);
-  /* Try reading from fd0 */
-  memset(buf, -1, 100);
-  error = read(fd0, buf, 100);
-  assert(error < 0);
-  assert(errno == EBADF);
-  assert(buf[10] == -1 && buf[90] == -1);
-  /* Try writing to file we never referenced. */
-  error = write(42, str, strlen(str));
-  assert(error < 0);
-  assert(errno == EBADF);
-  /* Try closing a file we never referenced. */
-  error = close(42);
-  assert(error < 0);
-  assert(errno == EBADF);
-  /* Try closing invalid file */
-  error = close(-15);
-  assert(error < 0);
-  assert(errno == EBADF);
-  /* At this point, fd1 and fd2 are still open. */
-  /* fd1 is open in write-only mode, reading from it should fail */
-  memset(buf, -1, 100);
-  error = read(fd1, buf, 100);
-  assert(error < 0);
-  assert(errno == EBADF);
-  assert(buf[10] == -1 && buf[90] == -1);
-  /* fd2 is open in read-only mode, writing to it should fail */
-  error = write(fd2, str, strlen(str));
-  assert(error < 0);
-  assert(errno == EBADF);
-  /* Try opening a valid file with an invalid mode */
-  error = open("/dev/null", 0, 42);
-  assert(error < 0);
-  assert(errno == EINVAL);
-  /* Close fd1 and reopen it in read-write mode */
-  close(fd1);
-  fd0 = open("/dev/null", 0, O_RDWR);
-  assert(fd0 == 0);
-  /* See that both reading from and writing to fd0 now works. */
-  memset(buf, -1, 100);
-  error = read(fd0, buf, 100);
-  assert(error >= 0);
-  assert(buf[10] == 0 && buf[90] == 0);
-  error = write(fd0, str, strlen(str));
-  assert(error >= 0);
+#define assert_open_ok(fd, file, mode, flag)                                   \
+  n = open(file, 0, flag);                                                     \
+  assert(n == fd);
 
-  /* Try opening a file with a name too long. */
-  char too_long[500];
-  memset(too_long, 'c', sizeof(too_long));
-  too_long[sizeof(too_long) - 1] = 0;
-  error = open(too_long, 0, O_RDWR);
-  assert(error < 0);
-  /* This is very unfortunate! In our errno.h: ENAMETOOLONG is 63, but errno.h
-     provided by newlib (since we DID NOT port newlib to our system, which would
-     include providing our custom sys/errno.h) uses ENAMETOOLONG 91. */
-  assert(errno == 63);
-  /* Now, try passing some invalid pointers as data to read/write. */
+#define assert_open_fail(file, mode, flag, err)                                \
+  n = open(file, 0, flag);                                                     \
+  assert(n < 0);                                                               \
+  assert(errno == err);
+
+#define assert_read_ok(fd, buf, len)                                           \
+  n = read(fd, buf, len);                                                      \
+  assert(n >= 0);
+
+#define assert_read_fail(fd, buf, len, err)                                    \
+  n = read(fd, buf, len);                                                      \
+  assert(n < 0);                                                               \
+  assert(errno == err);
+
+#define assert_write_ok(fd, buf, len)                                          \
+  n = write(fd, buf, len);                                                     \
+  assert(n >= 0);
+
+#define assert_write_fail(fd, buf, len, err)                                   \
+  n = write(fd, buf, len);                                                     \
+  assert(n < 0);                                                               \
+  assert(errno == err);
+
+#define assert_close_ok(fd)                                                    \
+  n = close(fd);                                                               \
+  assert(n == 0);
+
+#define assert_close_fail(fd, err)                                             \
+  n = close(fd);                                                               \
+  assert(n < 0);                                                               \
+  assert(errno == err);
+
+/* Just the basic, correct operations on a single /dev/null */
+void test_devnull() {
+  assert_open_ok(0, "/dev/null", 0, O_RDWR);
+  assert_read_ok(0, buf, 100);
+  assert_write_ok(0, str, strlen(str));
+  assert_close_ok(0);
+}
+
+/* Opens and closes multiple descriptors, checks if descriptor numbers are
+   correctly reused */
+void test_multiple_descriptors() {
+  assert_open_ok(0, "/dev/null", 0, O_RDWR);
+  assert_open_ok(1, "/dev/null", 0, O_RDWR);
+  assert_open_ok(2, "/dev/null", 0, O_RDWR);
+  assert_close_ok(1);
+  assert_open_ok(1, "/dev/null", 0, O_RDWR);
+  assert_close_ok(0);
+  assert_close_ok(2);
+  assert_open_ok(0, "/dev/null", 0, O_RDWR);
+  assert_open_ok(2, "/dev/null", 0, O_RDWR);
+  assert_close_ok(1);
+  assert_close_ok(0);
+  assert_open_ok(0, "/dev/null", 0, O_RDWR);
+  assert_open_ok(1, "/dev/null", 0, O_RDWR);
+  assert_close_ok(1);
+  assert_close_ok(2);
+  assert_close_ok(0);
+}
+
+/* Tests whether READ/WRITE flags are checked correctly */
+void test_readwrite() {
+  assert_open_ok(0, "/dev/null", 0, O_RDONLY);
+  assert_open_ok(1, "/dev/null", 0, O_WRONLY);
+  assert_open_ok(2, "/dev/null", 0, O_RDWR);
+  /* Test reading, on fd1 it should fail */
+  assert_read_ok(0, buf, 100);
+  assert_read_fail(1, buf, 100, EBADF);
+  assert_read_ok(2, buf, 100);
+  /* Test writing, should fail only on fd0 */
+  assert_write_fail(0, str, strlen(str), EBADF);
+  assert_write_ok(1, str, strlen(str));
+  assert_write_ok(2, str, strlen(str));
+  /* Close all files */
+  assert_close_ok(0);
+  assert_close_ok(1);
+  assert_close_ok(2);
+}
+
+/* Try passing invalid pointers as arguments to open,read,write. */
+void test_copy() {
+  assert_open_ok(0, "/dev/null", 0, O_RDWR);
   /* Kernel space */
   char *naughty_ptr1 = (char *)0x80001000;
   /* User space, hopefully not mapped */
   char *naughty_ptr2 = (char *)0x00001000;
-  error = write(fd0, naughty_ptr1, 200);
-  assert(error < 0);
-  assert(errno == EFAULT);
-  error = write(fd0, naughty_ptr2, 200);
-  assert(error < 0);
-  assert(errno == EFAULT);
-  error = read(fd0, naughty_ptr1, 200);
-  assert(error < 0);
-  assert(errno == EFAULT);
-  error = read(fd0, naughty_ptr2, 200);
-  assert(error < 0);
-  assert(errno == EFAULT);
+  assert_write_fail(0, naughty_ptr1, 200, EFAULT);
+  assert_write_fail(0, naughty_ptr2, 200, EFAULT);
+  assert_read_fail(0, naughty_ptr1, 200, EFAULT);
+  assert_read_fail(0, naughty_ptr2, 200, EFAULT);
   /* Also, try opening a file using a bad pointer */
-  error = open(naughty_ptr1, 0, O_RDWR);
-  assert(error < 0);
-  assert(errno == EFAULT);
-  error = open(naughty_ptr2, 0, O_RDWR);
-  assert(error < 0);
-  assert(errno == EFAULT);
+  assert_open_fail(naughty_ptr1, 0, O_RDWR, EFAULT);
+  assert_open_fail(naughty_ptr2, 0, O_RDWR, EFAULT);
+  /* Clean up */
+  assert_close_ok(0);
+}
 
-  /* At this point fd0 and fd2 are left open. */
-  /* After this thread returns, all files should get closed. */
+/* Tries accessing some invalid descriptor numbers */
+void test_bad_descrip() {
+  assert_write_fail(0, buf, 100, EBADF);
+  assert_write_fail(42, buf, 100, EBADF);
+  assert_write_fail(-10, buf, 100, EBADF);
+  assert_read_fail(0, buf, 100, EBADF);
+  assert_read_fail(42, buf, 100, EBADF);
+  assert_read_fail(-10, buf, 100, EBADF);
+  assert_close_fail(0, EBADF);
+  assert_close_fail(-10, EBADF);
+  assert_close_fail(42, EBADF);
+}
+
+void test_open_path() {
+  assert_open_fail("/etc/shadow", 0, O_RDONLY, ENOENT);
+  assert_open_fail("123456", 0, O_RDONLY, ENOENT);
+  assert_open_fail("", 0, O_RDONLY, ENOENT);
+
+  assert_open_fail("123456", 0, O_RDONLY, ENOENT);
+
+  /* Also try opening a file with a name too long. */
+  char too_long[500];
+  memset(too_long, 'c', sizeof(too_long));
+  too_long[sizeof(too_long) - 1] = 0;
+  /* This is very unfortunate! In our errno.h: ENAMETOOLONG is 63, but errno.h
+     provided by newlib (since we DID NOT port newlib to our system, which would
+     include providing our custom sys/errno.h) uses ENAMETOOLONG 91. */
+  assert_open_fail(too_long, 0, O_RDONLY, 63);
+}
+
+int main(int argc, char **argv) {
+  test_devnull();
+  test_multiple_descriptors();
+  test_readwrite();
+  test_copy();
+  test_bad_descrip();
+  test_open_path();
   return 0;
 }


### PR DESCRIPTION
Simple user program testing various descriptor features, extracted from #152. Naturally, as for now these tests do not work at all, but - at the point of writing this - #152 passes these tests successfully, so they are *probably* correct. Luckily the tests are now much easier to read, as I've introduced some convenient macros.