### PR TITLE
cdev, devfs stubs, /dev/null and /dev/zero

### DIFF
--- a/include/cdev.h
+++ b/include/cdev.h
@@ -1,0 +1,46 @@
+#ifndef __CDEV_H__
+#define __CDEV_H__
+
+#include <uio.h>
+
+typedef struct cdev cdev_t;
+
+#define CDEV_NAME_MAX 30
+
+typedef int d_open_t(cdev_t *dev, int flags);
+typedef int d_close_t(cdev_t *dev);
+typedef int d_read_t(cdev_t *dev, uio_t *uio, int flags);
+typedef int d_write_t(cdev_t *dev, uio_t *uio, int flags);
+
+/* Character device switch table */
+typedef struct cdevsw {
+  d_open_t *d_open;
+  d_close_t *d_close;
+  d_read_t *d_read;
+  d_write_t *d_write;
+} cdevsw_t;
+
+typedef struct cdev {
+  /* This implementation of cdev structure is just a stub. Other fields that
+     might be added: flags, user id, group id, reference count, pointer to
+     parent device, list of children devices, driver-specific data, mountpoint,
+     access/create timestamps. */
+  char cdev_name[CDEV_NAME_MAX];
+  struct cdevsw cdev_sw;
+  TAILQ_ENTRY(cdev) cdev_all; /* a link on all devices queue */
+} cdev_t;
+
+/* List of all character devices present in the system */
+typedef TAILQ_HEAD(, cdev) cdev_list_t;
+extern cdev_list_t all_cdevs;
+
+/* Initializes the character devices subsystem */
+void cdev_init();
+
+/* Allocates and initializes a new character device */
+cdev_t *make_dev(cdevsw_t cdevsw, const char *name);
+
+/* Initializes null and zero devices */
+void dev_null_init();
+
+#endif /* __CDEV_H__ */

--- a/include/devfs.h
+++ b/include/devfs.h
@@ -1,0 +1,10 @@
+#ifndef __DEVFS_H__
+#define __DEVFS_H__
+
+#include <cdev.h>
+
+/* A very simple devfs stub. Searches the list of all character devices and
+ * picks one by name. Returns NULL if no device was found. */
+cdev_t *devfs_find_device(char *name);
+
+#endif /* __DEVFS_H__ */

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -3,6 +3,9 @@
 SOURCES_C  = \
 	callout.c \
 	clock.c \
+	cdev.c \
+	dev_null.c \
+	devfs.c \
 	exception.c \
 	exec.c \
 	interrupt.c \

--- a/sys/cdev.c
+++ b/sys/cdev.c
@@ -1,0 +1,37 @@
+#include <cdev.h>
+#include <malloc.h>
+#include <string.h>
+#include <mutex.h>
+
+cdev_list_t all_cdevs;
+static mtx_t all_cdev_mtx;
+
+static MALLOC_DEFINE(cdev_pool, "cdevs pool");
+
+void cdev_init() {
+  TAILQ_INIT(&all_cdevs);
+
+  kmalloc_init(cdev_pool);
+  kmalloc_add_arena(cdev_pool, pm_alloc(1)->vaddr, PAGESIZE);
+
+  mtx_init(&all_cdev_mtx);
+
+  /* Initialize some core devices */
+  dev_null_init();
+}
+
+cdev_t *make_dev(cdevsw_t cdevsw, const char *name) {
+  cdev_t *cdev = kmalloc(cdev_pool, sizeof(cdev_t), M_ZERO);
+  strlcpy(cdev->cdev_name, name, CDEV_NAME_MAX);
+  cdev->cdev_sw = cdevsw;
+
+  /* TODO: This function may get called before the threads system is
+     initialized. Calling mtx_lock before threads started crashes, because
+     thread_self() is not ready yet! See issue #156. Once we fix this, enable
+     mtx_lock and mtx_unlock below. */
+
+  /* mtx_lock(&all_cdev_mtx); */
+  TAILQ_INSERT_TAIL(&all_cdevs, cdev, cdev_all);
+  /* mtx_unlock(&all_cdev_mtx); */
+  return NULL;
+}

--- a/sys/dev_null.c
+++ b/sys/dev_null.c
@@ -1,0 +1,61 @@
+#include <cdev.h>
+#include <malloc.h>
+#include <devfs.h>
+
+static cdev_t *dev_null, *dev_zero;
+vm_page_t *zero_page, *junk_page;
+
+int dev_null_open(cdev_t *dev, int flags) {
+  return 0;
+}
+int dev_null_close(cdev_t *dev) {
+  return 0;
+}
+int dev_null_read(cdev_t *dev, uio_t *uio, int flags) {
+  return 0;
+}
+int dev_null_write(cdev_t *dev, uio_t *uio, int flags) {
+  uio->uio_resid = 0;
+  return 0;
+}
+
+int dev_zero_read(cdev_t *dev, uio_t *uio, int flags) {
+  int error = 0;
+  while (uio->uio_resid && !error) {
+    size_t len = uio->uio_resid;
+    if (len > PAGESIZE)
+      len = PAGESIZE;
+    error = uiomove((void *)zero_page->vaddr, len, uio);
+  }
+  return error;
+}
+
+int dev_zero_write(cdev_t *dev, uio_t *uio, int flags) {
+  /* We might just discard the data, but to demonstrate using uiomove for
+   * writing, store the data into a junkyard page. */
+  int error = 0;
+  while (uio->uio_resid && !error) {
+    size_t len = uio->uio_resid;
+    if (len > PAGESIZE)
+      len = PAGESIZE;
+    error = uiomove((void *)junk_page->vaddr, len, uio);
+  }
+  return error;
+}
+
+static cdevsw_t dev_null_sw = {.d_open = dev_null_open,
+                               .d_close = dev_null_close,
+                               .d_read = dev_null_read,
+                               .d_write = dev_null_write};
+
+static cdevsw_t dev_zero_sw = {.d_open = dev_null_open,
+                               .d_close = dev_null_close,
+                               .d_read = dev_zero_read,
+                               .d_write = dev_zero_write};
+
+void dev_null_init() {
+  zero_page = pm_alloc(1);
+  junk_page = pm_alloc(1);
+  dev_null = make_dev(dev_null_sw, "null");
+  dev_zero = make_dev(dev_zero_sw, "zero");
+}

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -1,0 +1,13 @@
+#include <devfs.h>
+#include <cdev.h>
+#include <string.h>
+
+cdev_t *devfs_find_device(char *name) {
+  cdev_t *cdev;
+  TAILQ_FOREACH (cdev, &all_cdevs, cdev_all) {
+    if (strncmp(name, cdev->cdev_name, CDEV_NAME_MAX) == 0) {
+      return cdev;
+    }
+  }
+  return NULL;
+}

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -17,6 +17,7 @@
 #include <thread.h>
 #include <vm_object.h>
 #include <vm_map.h>
+#include <cdev.h>
 
 extern int main(int argc, char **argv);
 
@@ -41,6 +42,7 @@ int kernel_boot(int argc, char **argv) {
   sched_init();
   sleepq_init();
   mips_clock_init();
+  cdev_init();
   kprintf("[startup] subsystems initialized\n");
   thread_init((void (*)())main, 2, argc, argv);
 }


### PR DESCRIPTION
I decided that there is no point (yet) in having `devfs` use its own list of registered devices, for now it looks for cdevs in the list of all allocated character devices. This made `devfs` stub so simple it's silly.

The next steps will be to add some more devices (`uart`, `kmem`), and link devfs with #152.