### PR TITLE
Fixed .sbss section for user programs

### DIFF
--- a/user/Makefile
+++ b/user/Makefile
@@ -14,7 +14,7 @@ PROGRAMS_OBJS = $(PROGRAMS_C:%.c=%.o)
 PROGRAMS_UELFS = $(PROGRAMS_C:%.c=%.uelf)
 PROGRAMS_UELF_OS = $(PROGRAMS_C:%.c=%.uelf.o)
 
-all: $(PROGRAMS_UELF_OS) $(PROGRAMS_UELFS)
+all: $(PROGRAMS_UELF_OS) $(PROGRAMS_UELFS) start.o
 
 # Compiling the program source
 %.o: %.c

--- a/user/mimiker.ld
+++ b/user/mimiker.ld
@@ -8,6 +8,7 @@ PHDRS
     rodata PT_LOAD FLAGS(4); /* read-only */
     sdata  PT_LOAD FLAGS(6); /* read-write */
     bss    PT_LOAD FLAGS(6); /* read-write */
+    sbss   PT_LOAD FLAGS(6); /* read-write */
 }
 SECTIONS
 {
@@ -39,6 +40,11 @@ SECTIONS
     {
         *(.sdata .sdata.*)
     } : sdata
+    .sbss :
+    {
+        *(.sbss .sbss.*)
+        *(.scommon)
+    } : sbss
 
     . = ALIGN(4096);
     .bss :


### PR DESCRIPTION
When I was repairing the linker script for user programs so that they could use `gp` correctly, I forgot to add the `.sbss` section. It is definitely needed to compile some external programs. I've consulted the gcc's default linker script for our platform, so the section layout should be correct.

I've also asked `user/Makefile` to NOT remove `start.o` when other targets are complete, so that I can use `start.o` when linking external programs.