### PR TITLE
Fixed .sbss allignment

### DIFF
--- a/user/mimiker.ld
+++ b/user/mimiker.ld
@@ -40,6 +40,7 @@ SECTIONS
     {
         *(.sdata .sdata.*)
     } : sdata
+    . = ALIGN(4096);
     .sbss :
     {
         *(.sbss .sbss.*)


### PR DESCRIPTION
For some reason the tests I originally used happened to have a page-alligned end of `.sdata` section, but that's not always the case, and our `exec` implementation requires the subsequent segment `.sbss` to be page-alligned.