### PR TITLE
Fixed missing rependency *.elf: KRT

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -71,7 +71,7 @@ endef
 	@echo "[AS] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
-%.elf:	%.o
+%.elf:	%.o $(KRT)
 	@echo "[LD] $(addprefix $(DIR),$<) -> $(DIR)$@"
 	$(CC) $(LDFLAGS) $< -Wl,-Map=$@.map $(LDLIBS) $(LD_EMBED) -o $@
 


### PR DESCRIPTION
We lost this dependency at some point. Without it everything builds just fine, but touching a file in, say, `./sys` did not cause the tests to rebuild.