### PR TITLE
Simplify mutex implementation, add recursive capability.

### DIFF
--- a/include/mount.h
+++ b/include/mount.h
@@ -1,6 +1,7 @@
 #ifndef _SYS_MOUNT_H_
 #define _SYS_MOUNT_H_
 
+#include <common.h>
 #include <queue.h>
 #include <mutex.h>
 

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -6,8 +6,8 @@
 
 typedef struct thread thread_t;
 
-#define MT_DEF 0
-#define MT_RECURSE 1
+#define MTX_DEF 0
+#define MTX_RECURSE 1
 
 typedef struct mtx {
   volatile thread_t *m_owner; /* stores address of the owner */

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,6 +1,7 @@
 #ifndef _SYS_MUTEX_H_
 #define _SYS_MUTEX_H_
 
+#include <stdbool.h>
 #include <turnstile.h>
 
 typedef struct thread thread_t;

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -2,27 +2,32 @@
 #define _SYS_MUTEX_H_
 
 #include <turnstile.h>
-#include <thread.h>
+
+typedef struct thread thread_t;
+
+#define MT_DEF 0
+#define MT_RECURSE 1
 
 typedef struct mtx {
-  volatile uint32_t mtx_state; /* 0 if unowned or has address of the owner */
-  turnstile_t turnstile;       /* FIFO Queue for blocked threads */
+  volatile thread_t *m_owner; /* stores address of the owner */
+  volatile unsigned m_count; /* Counter for recursive mutexes */
+  unsigned m_type;           /* Normal or recursive mutex */
+  turnstile_t m_turnstile;   /* FIFO Queue for blocked threads */
 } mtx_t;
 
 /* Initializes mutex. Note that EVERY mutex has to be initialized
  * before it is used. */
-void mtx_init(mtx_t *);
-
-/* Locks the mutex, if the mutex is already owned by someone,
- * then this blocks on turnstile, otherwise it takes the mutex.
- * At this moment mutexes cannot be recursive. */
-void mtx_lock(mtx_t *);
-
-/* Unlocks the mutex. If some thread blocked for the mutex, then it
- * wakes up the thread in FIFO manner. */
-void mtx_unlock(mtx_t *);
+void mtx_init(mtx_t *m, unsigned type);
 
 /* Returns true iff the mutex is locked and we are the owner. */
 bool mtx_owned(mtx_t *mtx);
+
+/* Locks the mutex, if the mutex is already owned by someone,
+ * then this blocks on turnstile, otherwise it takes the mutex. */
+void mtx_lock(mtx_t *m);
+
+/* Unlocks the mutex. If some thread blocked for the mutex,
+ * then it wakes up the thread in FIFO manner. */
+void mtx_unlock(mtx_t *m);
 
 #endif /* !_SYS_MUTEX_H_ */

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -3,6 +3,7 @@
 #include <vnode.h>
 #include <errno.h>
 #include <stdc.h>
+#include <mutex.h>
 #include <malloc.h>
 #include <linker_set.h>
 
@@ -113,7 +114,7 @@ static int devfs_init(vfsconf_t *vfc) {
   kmalloc_init(devfs_pool);
   kmalloc_add_arena(devfs_pool, pm_alloc(1)->vaddr, PAGESIZE);
 
-  mtx_init(&devfs_device_list_mtx);
+  mtx_init(&devfs_device_list_mtx, MTX_DEF);
 
   /* Prepare some initial devices */
   typedef void devfs_init_func_t();

--- a/sys/file.c
+++ b/sys/file.c
@@ -3,6 +3,7 @@
 #include <stdc.h>
 #include <errno.h>
 #include <mutex.h>
+#include <thread.h>
 
 static MALLOC_DEFINE(file_pool, "file pool");
 
@@ -29,7 +30,7 @@ void file_unref(file_t *f) {
 file_t *file_alloc() {
   file_t *f = kmalloc(file_pool, sizeof(file_t), M_ZERO);
   f->f_ops = &badfileops;
-  mtx_init(&f->f_mtx);
+  mtx_init(&f->f_mtx, MTX_DEF);
   return f;
 }
 

--- a/sys/filedesc.c
+++ b/sys/filedesc.c
@@ -76,7 +76,7 @@ fdtab_t *fdtab_alloc() {
   /* For now, fdt_files and fdt_map have a static size, so there is no need to
    * separately allocate memory for them. */
   fdt->fdt_nfiles = NDFILE;
-  mtx_init(&fdt->fdt_mtx);
+  mtx_init(&fdt->fdt_mtx, MTX_DEF);
   return fdt;
 }
 

--- a/sys/mutex.c
+++ b/sys/mutex.c
@@ -1,5 +1,5 @@
+#include <stdc.h>
 #include <sync.h>
-#include <atomic.h>
 #include <mutex.h>
 #include <thread.h>
 
@@ -9,40 +9,37 @@ bool mtx_owned(mtx_t *mtx) {
   return (mtx->mtx_state == (uint32_t)thread_self());
 }
 
-static bool mtx_locked(mtx_t *mtx) {
-  return (mtx->mtx_state != MTX_UNOWNED);
+void mtx_init(mtx_t *m, unsigned type) {
+  m->m_owner = NULL;
+  m->m_count = 0;
+  m->m_type = type;
+  turnstile_init(&m->m_turnstile);
 }
 
-static int mtx_try_lock(mtx_t *mtx) {
-  return atomic_cmp_exchange(&mtx->mtx_state, MTX_UNOWNED,
-                             (uint32_t)thread_self());
-}
-
-void mtx_init(mtx_t *mtx) {
-  mtx->mtx_state = MTX_UNOWNED;
-  turnstile_init(&mtx->turnstile);
-}
-
-void mtx_lock(mtx_t *mtx) {
-  /* TODO: Implement recursive mutexes */
-  assert(!mtx_owned(mtx));
-
-  while (!mtx_try_lock(mtx)) {
-    critical_enter();
-    /* Check if the mutex got unlocked since a call to mtx_try_lock */
-    if (mtx->mtx_state == MTX_UNOWNED) {
-      critical_leave();
-      continue;
-    }
-    assert(mtx_locked(mtx));
-    turnstile_wait(&mtx->turnstile);
-    critical_leave();
+void mtx_lock(mtx_t *m) {
+  if (mtx_owned(m)) {
+    assert(m->m_type & MT_RECURSE);
+    m->m_count++;
+    return;
   }
+
+  cs_enter();
+  while (m->m_owner != NULL)
+    turnstile_wait(&m->m_turnstile);
+  m->m_owner = thread_self();
+  cs_leave();
 }
 
-void mtx_unlock(mtx_t *mtx) {
-  critical_enter();
-  mtx->mtx_state = MTX_UNOWNED;
-  turnstile_signal(&mtx->turnstile);
-  critical_leave();
+void mtx_unlock(mtx_t *m) {
+  assert(mtx_owned(m));
+
+  if (m->m_count > 0) {
+    m->m_count--;
+    return;
+  }
+
+  cs_enter();
+  m->m_owner = NULL;
+  turnstile_signal(&m->m_turnstile);
+  cs_leave();
 }

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -225,6 +225,7 @@ int vfs_lookup(const char *path, vnode_t **vp) {
     int error = VOP_LOOKUP(v, component, &v_child);
     vnode_unlock(v);
     vnode_unref(v);
+
     /* Handle the special case of root vnode returning ENOTSUP on lookup. We
        don't have a filesystem at / (root) yet, but we want to get the correct
        error when trying to open a non-existent file. */
@@ -233,6 +234,8 @@ int vfs_lookup(const char *path, vnode_t **vp) {
     if (error)
       return error;
     v = v_child;
+    vnode_ref(v);
+    vnode_lock(v);
   }
 
   vnode_unlock(v);

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -39,8 +39,8 @@ static vnodeops_t vfs_root_ops = {
 static int vfs_register(vfsconf_t *vfc);
 
 void vfs_init() {
-  mtx_init(&vfsconf_list_mtx);
-  mtx_init(&mount_list_mtx);
+  mtx_init(&vfsconf_list_mtx, MTX_DEF);
+  mtx_init(&mount_list_mtx, MTX_DEF);
 
   /* TODO: We probably need some fancier allocation, since eventually we should
    * start recycling vnodes */
@@ -130,7 +130,7 @@ mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc) {
   m->mnt_vnodecovered = v;
 
   m->mnt_refcnt = 0;
-  mtx_init(&m->mnt_mtx);
+  mtx_init(&m->mnt_mtx, MTX_DEF);
 
   return m;
 }

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -1,10 +1,11 @@
-#include <vfs_syscalls.h>
-#include <file.h>
 #include <filedesc.h>
+#include <file.h>
 #include <mount.h>
+#include <stdc.h>
 #include <sysent.h>
 #include <systm.h>
-#include <stdc.h>
+#include <thread.h>
+#include <vfs_syscalls.h>
 #include <vm_map.h>
 
 int do_open(thread_t *td, char *pathname, int flags, int mode, int *fd) {

--- a/sys/vnode.c
+++ b/sys/vnode.c
@@ -1,9 +1,9 @@
-#include <vnode.h>
+#include <errno.h>
+#include <file.h>
 #include <malloc.h>
 #include <mutex.h>
 #include <stdc.h>
-#include <errno.h>
-#include <file.h>
+#include <vnode.h>
 
 static MALLOC_DEFINE(vnode_pool, "vnode pool");
 
@@ -23,7 +23,7 @@ vnode_t *vnode_new(vnodetype_t type, vnodeops_t *ops) {
   v->v_data = NULL;
   v->v_ops = ops;
   v->v_usecnt = 1;
-  mtx_init(&v->v_mtx);
+  mtx_init(&v->v_mtx, MTX_DEF);
 
   return v;
 }

--- a/tests/mutex.c
+++ b/tests/mutex.c
@@ -15,19 +15,16 @@ thread_t *td4;
 thread_t *td5;
 
 void mtx_test_main() {
-  mtx_lock(&mtx);
-  for (size_t i = 0; i < 20000; i++) {
+  for (size_t i = 0; i < 200000; i++) {
+    mtx_lock(&mtx);
     value++;
-    kprintf("%s: %ld\n", thread_self()->td_name, (long)value);
+    mtx_unlock(&mtx);
   }
-  mtx_unlock(&mtx);
-  while (1)
-    ;
+  kprintf("%s: %ld\n", thread_self()->td_name, (long)value);
 }
 
 void mtx_test() {
-  mtx_init(&mtx);
-  mtx_init(&mtx);
+  mtx_init(&mtx, MT_DEF);
   td1 = thread_create("td1", mtx_test_main, NULL);
   td2 = thread_create("td2", mtx_test_main, NULL);
   td3 = thread_create("td3", mtx_test_main, NULL);
@@ -62,8 +59,8 @@ void deadlock_main2() {
 }
 
 void deadlock_test() {
-  mtx_init(&mtx1);
-  mtx_init(&mtx2);
+  mtx_init(&mtx1, MT_DEF);
+  mtx_init(&mtx2, MT_DEF);
   td1 = thread_create("td1", deadlock_main1, NULL);
   td2 = thread_create("td2", deadlock_main2, NULL);
   sched_add(td1);

--- a/tests/mutex.c
+++ b/tests/mutex.c
@@ -24,7 +24,7 @@ void mtx_test_main() {
 }
 
 void mtx_test() {
-  mtx_init(&mtx, MT_DEF);
+  mtx_init(&mtx, MTX_DEF);
   td1 = thread_create("td1", mtx_test_main, NULL);
   td2 = thread_create("td2", mtx_test_main, NULL);
   td3 = thread_create("td3", mtx_test_main, NULL);
@@ -59,8 +59,8 @@ void deadlock_main2() {
 }
 
 void deadlock_test() {
-  mtx_init(&mtx1, MT_DEF);
-  mtx_init(&mtx2, MT_DEF);
+  mtx_init(&mtx1, MTX_DEF);
+  mtx_init(&mtx2, MTX_DEF);
   td1 = thread_create("td1", deadlock_main1, NULL);
   td2 = thread_create("td2", deadlock_main2, NULL);
   sched_add(td1);

--- a/tests/producer_consumer.c
+++ b/tests/producer_consumer.c
@@ -72,7 +72,7 @@ int main() {
   buf.items = 0;
   buf.all_produced = 0;
   buf.all_consumed = 0;
-  mtx_init(&buf.lock);
+  mtx_init(&buf.lock, MTX_DEF);
   cv_init(&buf.not_empty, "not_empty");
   cv_init(&buf.not_full, "not_full");
 


### PR DESCRIPTION
@rafalcieslak, @coodie Please review.

I've noticed some locking patterns while reviewing #167 that made me wondering if it's right time to add recursive mutexes. This is my first attempt. I've completely got rid of `atomic_cmp_exchange ` as we run whole OS on single core - critical section will do for now.