### PR TITLE
Basic /dev/uart stub

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -4,6 +4,7 @@ SOURCES_C  = \
 	callout.c \
 	clock.c \
 	dev_null.c \
+	dev_uart.c \
 	devfs.c \
 	exception.c \
 	exec.c \

--- a/sys/dev_uart.c
+++ b/sys/dev_uart.c
@@ -6,14 +6,14 @@
 #include <mips/uart_cbus.h>
 #include <linker_set.h>
 
-vnode_t *dev_uart_device;
+static vnode_t *dev_uart_device;
 
-#define UART_BUFFER_SIZE 100
+#define UART_BUF_MAX 100
 
 static int dev_uart_write(vnode_t *t, uio_t *uio) {
-  char buffer[UART_BUFFER_SIZE];
+  char buffer[UART_BUF_MAX];
   size_t n = uio->uio_resid;
-  int res = uiomove(buffer, UART_BUFFER_SIZE - 1, uio);
+  int res = uiomove(buffer, UART_BUF_MAX - 1, uio);
   if (res < 0)
     return res;
   size_t moved = n - uio->uio_resid;
@@ -34,9 +34,7 @@ vnodeops_t dev_uart_vnodeops = {
 };
 
 void init_dev_uart() {
-
   dev_uart_device = vnode_new(V_DEV, &dev_uart_vnodeops);
-
   devfs_install("uart", dev_uart_device);
 }
 

--- a/sys/dev_uart.c
+++ b/sys/dev_uart.c
@@ -1,0 +1,43 @@
+#include <vnode.h>
+#include <mount.h>
+#include <devfs.h>
+#include <errno.h>
+#include <uio.h>
+#include <mips/uart_cbus.h>
+#include <linker_set.h>
+
+vnode_t *dev_uart_device;
+
+#define UART_BUFFER_SIZE 100
+
+static int dev_uart_write(vnode_t *t, uio_t *uio) {
+  char buffer[UART_BUFFER_SIZE];
+  size_t n = uio->uio_resid;
+  int res = uiomove(buffer, UART_BUFFER_SIZE - 1, uio);
+  if (res < 0)
+    return res;
+  size_t moved = n - uio->uio_resid;
+  uart_write(buffer, moved);
+  return moved;
+}
+
+static int dev_uart_read(vnode_t *t, uio_t *uio) {
+  return ENOTSUP;
+}
+
+vnodeops_t dev_uart_vnodeops = {
+  .v_lookup = vnode_op_notsup,
+  .v_readdir = vnode_op_notsup,
+  .v_open = vnode_op_notsup,
+  .v_write = dev_uart_write,
+  .v_read = dev_uart_read,
+};
+
+void init_dev_uart() {
+
+  dev_uart_device = vnode_new(V_DEV, &dev_uart_vnodeops);
+
+  devfs_install("uart", dev_uart_device);
+}
+
+SET_ENTRY(devfs_init, init_dev_uart);

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -75,5 +75,23 @@ int main() {
   assert(res == 0);
   assert(uio.uio_resid == 0);
 
+  /* Test writing to UART */
+  vnode_t *dev_uart;
+  error = vfs_lookup("/dev/uart", &dev_uart);
+  assert(error == 0);
+  char *str = "Some string for testing UART write\n";
+
+  uio.uio_op = UIO_WRITE;
+  uio.uio_vmspace = get_kernel_vm_map();
+  iov.iov_base = str;
+  iov.iov_len = strlen(str);
+  uio.uio_iovcnt = 1;
+  uio.uio_iov = &iov;
+  uio.uio_offset = 0;
+  uio.uio_resid = iov.iov_len;
+
+  res = dev_uart->v_ops->v_write(dev_uart, &uio);
+  assert(res > 0);
+
   return 0;
 }

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -90,7 +90,7 @@ int main() {
   uio.uio_offset = 0;
   uio.uio_resid = iov.iov_len;
 
-  res = dev_uart->v_ops->v_write(dev_uart, &uio);
+  res = VOP_WRITE(dev_uart, &uio);
   assert(res > 0);
 
   return 0;


### PR DESCRIPTION
Here's a quick implementation of a `/dev/uart` device. We need it because #152 makes user programs unable to output any text - and using a `/dev/uart` for fds 1 and 2 will be a good workaround (until we have terminal support...).

I did not implement reading from UART, because it is not as crucial at the moment, and we need to discuss `poll` behavior beforehand.

Also (*especially for those, who did not follow VFS development*), this PR demonstrates how simple it is to implement new devices using the interface we have. Of particular note is `SET_ENTRY` at the end of `dev_uart.c` which uses linker set to have `init_dev_uart` called when `devfs` starts, without modifying `devfs` sources.