### PR TITLE
Filesystem type registration with a linker set

### DIFF
--- a/include/devfs.h
+++ b/include/devfs.h
@@ -5,9 +5,6 @@
 
 typedef struct vnode vnode_t;
 
-/* Registers the devfs file system in the vfs. */
-void devfs_init();
-
 /* Installs a new device into the devfs */
 int devfs_install(const char *name, vnode_t *device);
 

--- a/include/mount.h
+++ b/include/mount.h
@@ -79,8 +79,6 @@ extern vnode_t *vfs_root_dev_vnode;
 
 /* Look up a file system type by name. */
 vfsconf_t *vfs_get_by_name(const char *name);
-/* Register a file system type */
-int vfs_register(vfsconf_t *vfc);
 
 /* Allocates and initializes a new mount struct, using filesystem vfc, covering
  * vnode v. Does not modify v. Does not insert new mount onto the all mounts

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -60,10 +60,6 @@ int devfs_install(const char *name, vnode_t *device) {
   return 0;
 }
 
-static vfs_mount_t devfs_mount;
-static vfs_root_t devfs_root;
-static vfs_init_t devfs_init;
-
 static vnode_lookup_t devfs_root_lookup;
 static vnode_readdir_t devfs_root_readdir;
 
@@ -137,9 +133,14 @@ static int devfs_init(vfsconf_t *vfc) {
 }
 
 static vfsops_t devfs_vfsops = {
-  .vfs_mount = devfs_mount, .vfs_root = devfs_root, .vfs_init = devfs_init};
+  .vfs_mount = devfs_mount,
+  .vfs_root = devfs_root,
+  .vfs_init = devfs_init
+};
 
-static vfsconf_t devfs_conf = {.vfc_name = "devfs",
-                               .vfc_vfsops = &devfs_vfsops};
+static vfsconf_t devfs_conf = {
+  .vfc_name = "devfs",
+  .vfc_vfsops = &devfs_vfsops
+};
 
 SET_ENTRY(vfsconf, devfs_conf);

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -62,6 +62,7 @@ int devfs_install(const char *name, vnode_t *device) {
 
 static vfs_mount_t devfs_mount;
 static vfs_root_t devfs_root;
+static vfs_init_t devfs_init;
 
 static vnode_lookup_t devfs_root_lookup;
 static vnode_readdir_t devfs_root_readdir;
@@ -73,12 +74,6 @@ static vnodeops_t devfs_root_ops = {
   .v_read = vnode_op_notsup,
   .v_write = vnode_op_notsup,
 };
-
-static vfsops_t devfs_vfsops = {.vfs_mount = devfs_mount,
-                                .vfs_root = devfs_root};
-
-static vfsconf_t devfs_conf = {.vfc_name = "devfs",
-                               .vfc_vfsops = &devfs_vfsops};
 
 static int devfs_mount(mount_t *m) {
   /* Prepare the root vnode. We'll use a single instead of allocating a new
@@ -118,13 +113,11 @@ static int devfs_root(mount_t *m, vnode_t **v) {
   return 0;
 }
 
-void devfs_init() {
+static int devfs_init(vfsconf_t *vfc) {
   kmalloc_init(devfs_pool);
   kmalloc_add_arena(devfs_pool, pm_alloc(1)->vaddr, PAGESIZE);
 
   mtx_init(&devfs_device_list_mtx);
-
-  vfs_register(&devfs_conf);
 
   /* Prepare some initial devices */
   typedef void devfs_init_func_t();
@@ -138,5 +131,15 @@ void devfs_init() {
   /* Mount devfs at /dev. */
   /* TODO: This should actually happen somewhere else in the init process, much
    * later, and is configuration-dependent. */
-  vfs_domount(&devfs_conf, vfs_root_dev_vnode);
+  vfs_domount(vfc, vfs_root_dev_vnode);
+
+  return 0;
 }
+
+static vfsops_t devfs_vfsops = {
+  .vfs_mount = devfs_mount, .vfs_root = devfs_root, .vfs_init = devfs_init};
+
+static vfsconf_t devfs_conf = {.vfc_name = "devfs",
+                               .vfc_vfsops = &devfs_vfsops};
+
+SET_ENTRY(vfsconf, devfs_conf);

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -33,7 +33,6 @@ int kernel_init(int argc, char **argv) {
 
   vnode_init();
   vfs_init();
-  devfs_init();
 
   kprintf("[startup] kernel initialized\n");
 

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <malloc.h>
 #include <vnode.h>
+#include <linker_set.h>
 
 static MALLOC_DEFINE(vfs_pool, "VFS pool");
 
@@ -35,6 +36,8 @@ static vnodeops_t vfs_root_ops = {
   .v_write = vnode_op_notsup,
 };
 
+static int vfs_register(vfsconf_t *vfc);
+
 void vfs_init() {
   mtx_init(&vfsconf_list_mtx);
   mtx_init(&mount_list_mtx);
@@ -46,6 +49,13 @@ void vfs_init() {
 
   vfs_root_vnode = vnode_new(V_DIR, &vfs_root_ops);
   vfs_root_dev_vnode = vnode_new(V_DIR, &vfs_root_ops);
+
+  /* Initialize available filesystem types. */
+  SET_DECLARE(vfsconf, vfsconf_t);
+  vfsconf_t **ptr;
+  SET_FOREACH(ptr, vfsconf) {
+    vfs_register(*ptr);
+  }
 }
 
 vfsconf_t *vfs_get_by_name(const char *name) {
@@ -61,7 +71,8 @@ vfsconf_t *vfs_get_by_name(const char *name) {
   return NULL;
 }
 
-int vfs_register(vfsconf_t *vfc) {
+/* Register a file system type */
+static int vfs_register(vfsconf_t *vfc) {
 
   /* Check if this file system type was already registered */
   if (vfs_get_by_name(vfc->vfc_name))

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -73,7 +73,6 @@ vfsconf_t *vfs_get_by_name(const char *name) {
 
 /* Register a file system type */
 static int vfs_register(vfsconf_t *vfc) {
-
   /* Check if this file system type was already registered */
   if (vfs_get_by_name(vfc->vfc_name))
     return EEXIST;
@@ -171,7 +170,6 @@ int vfs_domount(vfsconf_t *vfc, vnode_t *v) {
 }
 
 int vfs_lookup(const char *path, vnode_t **vp) {
-
   /* TODO: This is a simplified implementation, and it does not support many
      required features! These include: relative paths, symlinks, parent dirs */
 


### PR DESCRIPTION
This branch introduces a linker set which gathers all filesystem types implemented in the kernel. It also uses `vfs_init` the way it was intended to be used.

Naturally, this is useful for implementing new file systems, if anybody, hypothetically, would like to do that.