### PR TITLE
Add initrd section to linker script

### DIFF
--- a/include/malloc.h
+++ b/include/malloc.h
@@ -21,7 +21,6 @@
  */
 void kernel_brk(void *addr);
 void *kernel_sbrk(size_t size) __attribute__((warn_unused_result));
-void *kernel_sbrk_shutdown();
 
 /*
  * General purpose kernel memory allocator.

--- a/include/physmem.h
+++ b/include/physmem.h
@@ -3,19 +3,30 @@
 
 #include <vm.h>
 
+typedef struct pm_seg pm_seg_t;
+
 /* Platform independant initialization of physical memory manager. */
 void pm_init();
 
+/* Calculates the size of data structure that should be allocated to describe
+ * segment of @size bytes. */
+size_t pm_seg_space_needed(size_t size);
 /*
- * This adds segment to be managed by the vm_phys subsystem.
- * In this function system uses kernel_sbrk function to allocate some data to
- * manage pages. After kernel_sbrk_shutdown this function shouldn't be used.
+ * Initialize data structure describing physical memory segment.
+ *
  * Note that this system manages PHYSICAL PAGES. Therefore start and end,
- * should be physical addresses. vm_offset determines initial virt_addr
- * for every page allocated from system. All pages in this segment will have
- * their default vm_addresses in range (start + vm_offset, end + vm_offset).
+ * should be physical addresses. @offset determines initial virtual address
+ * offset for pages, i.e. all pages in this segment will be visible under
+ * addresses (start + offset, end + offset) by default.
  */
-void pm_add_segment(pm_addr_t start, pm_addr_t end, vm_addr_t vm_offset);
+void pm_seg_init(pm_seg_t *seg,
+                 pm_addr_t start, pm_addr_t end, vm_addr_t offset);
+/* After using this function pages in range (start, end) are never going to be
+ * allocated. Should be used at start to avoid allocating from text, data,
+ * ebss, or any possibly unwanted places. */
+void pm_seg_reserve(pm_seg_t *seg, pm_addr_t start, pm_addr_t end);
+/* Add physical memory segment to physical memory manager. */
+void pm_add_segment(pm_seg_t *seg);
 
 /* Allocates contiguous big page that consists of n machine pages. */
 vm_page_t *pm_alloc(size_t n);
@@ -23,10 +34,5 @@ vm_page_t *pm_alloc(size_t n);
 void pm_free(vm_page_t *page);
 void pm_dump();
 vm_page_t *pm_split_alloc_page(vm_page_t *pg);
-
-/* After using this function pages in range (start, end) are never going to be
- * allocated. Should be used at start to avoid allocating from text, data,
- * ebss, or any possibly unwanted places. */
-void pm_reserve(pm_addr_t start, pm_addr_t end);
 
 #endif /* !_SYS_PHYSMEM_H_ */

--- a/mips/malta.c
+++ b/mips/malta.c
@@ -101,15 +101,54 @@ static void setup_kenv(int argc, char **argv, char **envp) {
     *tokens++ = make_pair(pair[0], pair[1]);
 }
 
+static char *kenv_get(const char *key) {
+  unsigned n = strlen(key);
+
+  for (int i = 1; i < _kenv.argc; i++) {
+    char *arg = _kenv.argv[i];
+    if ((strncmp(arg, key, n) == 0) && (arg[n] == '='))
+      return arg + n + 1;
+  }
+
+  return NULL;
+}
+
+extern uint8_t __kernel_start[];
+extern uint8_t __kernel_end[];
+
 static void pm_bootstrap(unsigned memsize) {
+  intptr_t rd_start;
+  unsigned rd_size;
+
   pm_init();
 
-  /* Add Malta physical memory segment */
-  pm_add_segment(MALTA_PHYS_SDRAM_BASE, MALTA_PHYS_SDRAM_BASE + memsize,
-                 MIPS_KSEG0_START);
-  /* shutdown sbrk allocator and remove used pages from physmem */
-  pm_reserve(MALTA_PHYS_SDRAM_BASE,
-             (pm_addr_t)kernel_sbrk_shutdown() - MIPS_KSEG0_START);
+  /* ramdisk start address is expected to be page aligned and places directly
+   * after kernel's .bss section */
+  {
+    char *s;
+
+    s = kenv_get("rd_start");
+    rd_start = s ? strtoul(s, NULL, 0) : 0;
+    s = kenv_get("rd_size");
+    rd_size = s ? align(strtoul(s, NULL, 0), PAGESIZE) : 0;
+  }
+
+  pm_seg_t *seg = (pm_seg_t *)(__kernel_end + rd_size);
+  size_t seg_size = align(pm_seg_space_needed(memsize), PAGESIZE);
+
+  /* create Malta physical memory segment */
+  pm_seg_init(seg, MALTA_PHYS_SDRAM_BASE, MALTA_PHYS_SDRAM_BASE + memsize,
+              MIPS_KSEG0_START);
+  /* reserve kernel image space */
+  pm_seg_reserve(seg, MIPS_KSEG0_TO_PHYS((intptr_t)__kernel_start),
+                 MIPS_KSEG0_TO_PHYS((intptr_t)__kernel_end));
+  /* reserve ramdisk space */
+  pm_seg_reserve(seg, MIPS_KSEG0_TO_PHYS(rd_start),
+                 MIPS_KSEG0_TO_PHYS(rd_start + rd_size));
+  /* reserve segment description space */
+  pm_seg_reserve(seg, MIPS_KSEG0_TO_PHYS((intptr_t)seg),
+                 MIPS_KSEG0_TO_PHYS((intptr_t)seg + seg_size));
+  pm_add_segment(seg);
 }
 
 static void thread_bootstrap() {

--- a/mips/malta.ld
+++ b/mips/malta.ld
@@ -12,8 +12,9 @@ SECTIONS
   /* RAM is mapped in kseg0 (cacheable) and kseg1 (non-cacheable) */
   _ram = 0x80000000;
 
-  .text 0x80100000:
+  .text 0x80100000: AT(0x00100000) ALIGN(4096) 
   {
+    __kernel_start = .;
     /* Exception handlers. */
     *(.ebase)
     . = ALIGN(4096);
@@ -23,17 +24,16 @@ SECTIONS
     . = ALIGN (4);
     *(.rodata .rodata.*)
     __etext = ABSOLUTE(.);
-    . = ALIGN(4096);
   } : text
 
-  .data :
+  .data : ALIGN(4096)
   {
     __data = ABSOLUTE(.);
     _gp = .;
     *(.data .data.*)
     *(.sdata .sdata.*)
     *(.eh_frame .eh_frame.*)
-    . = ALIGN(4);
+    . = ALIGN (4);
     __edata = ABSOLUTE(.);
   } : data
 
@@ -45,9 +45,12 @@ SECTIONS
     *(COMMON)
     . = ALIGN (4);
     __ebss = ABSOLUTE(.);
+    /* add one page for early malloc */
+    . = . + 4096;
+    . = ALIGN (4096);
   }
 
-  _end = .;
+  __kernel_end = .;
 
   /* Sections to be discarded */
   /DISCARD/ :


### PR DESCRIPTION
There are few problems with the way the OVPSim maps initial ramdisk to kernel space. Looking at the code of SmartLoader, initial ramdisk is always placed at the end of .data - or in general at the last section with PT_LOAD attribute. We could probably hack around and try to place ramdisk behind .bss section, and this could be easily done with setting .bss to PT_LOAD, but we don't want to do that.

There are few solutions I could come up with to this problem:
- Copy ramdisk to other place before .bss is zeroed. This is a little bit more difficult.
- Maybe PT_LOAD .bss isn't that bad at all.
- Add non-PT_LOAD section containing fixed amount of space for ramdisk. This isn't that bad for now, because we won't need big ramdisks for some time probably, it is extremly easy to add and requires no changes to existing code.