### PR TITLE
Implemented init= and test= kernel arguments support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-all: tags cscope tests
+all: mimiker.elf tags cscope
 
 include Makefile.common
 $(info Using CC: $(CC))
@@ -8,9 +8,14 @@ $(info Using CC: $(CC))
 # Directories which require calling make recursively
 SUBDIRS = mips stdc sys user tests
 
-# This ensures that the test subdirectory may only be built once these specified
-# dirs are brought up-to-date.
-tests: | mips stdc sys user
+# This rule ensures that all subdirectories are processed before any file
+# generated within them is used for linking the main kernel image.
+$(KRT): | $(SUBDIRS)
+	true # Disable default recipe from Makefile.common
+
+mimiker.elf: $(KRT)
+	@echo "[LD] Linking kernel image: $@"
+	$(CC) $(LDFLAGS) -Wl,-Map=$@.map $(LDLIBS) $(LD_EMBED) -o $@
 
 cscope:
 	cscope -b include/*.h ./*/*.[cS]
@@ -34,7 +39,7 @@ $(SUBDIRS):
 
 clean:
 	$(foreach DIR, $(SUBDIRS), $(MAKE) -C $(DIR) $@;)
-	$(RM) -f *.a *.lst *~ *.log
+	$(RM) -f *.a *.elf *.map *.lst *~ *.log
 	$(RM) -f tags etags cscope.out *.taghl
 
 .PHONY: format tags cscope $(SUBDIRS)

--- a/Makefile.common
+++ b/Makefile.common
@@ -33,10 +33,11 @@ CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -ffreestanding
 CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDFLAGS  = -nostdlib -T $(TOPDIR)/mips/malta.ld
 
-LDLIBS += -L$(TOPDIR)/sys -L$(TOPDIR)/mips -L$(TOPDIR)/stdc \
+LDLIBS += -L$(TOPDIR)/sys -L$(TOPDIR)/mips -L$(TOPDIR)/stdc -L$(TOPDIR)/tests \
 	  -Wl,--start-group \
         -Wl,--whole-archive \
           -lsys \
+          -ltests \
         -Wl,--no-whole-archive \
         -lmips \
         -lstdc \
@@ -54,6 +55,7 @@ KRT = \
     $(TOPDIR)/stdc/libstdc.a \
     $(TOPDIR)/mips/libmips.a \
     $(TOPDIR)/sys/libsys.a \
+    $(TOPDIR)/tests/libtests.a \
     $(LD_EMBED)
 
 DIR = $(patsubst $(TOPDIR)/%,%,$(CURDIR)/)
@@ -77,10 +79,6 @@ endef
 %.o: %.S
 	@echo "[AS] $(DIR)$< -> $(DIR)$@"
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
-
-%.elf:	%.o $(KRT)
-	@echo "[LD] $(addprefix $(DIR),$<) -> $(DIR)$@"
-	$(CC) $(LDFLAGS) $< -Wl,-Map=$@.map $(LDLIBS) $(LD_EMBED) -o $@
 
 %.test: %.c
 	@echo "[HOSTCC] $(DIR)$< -> $(DIR)$@"

--- a/include/exec.h
+++ b/include/exec.h
@@ -9,11 +9,11 @@ typedef struct exec_args {
    * identifier of an embedded ELF image to use, eventually this
    * would become a path to the executable (or an open file
    * descriptor). */
-  char *prog_name;
+  const char *prog_name;
   /* Program arguments. These will get copied to the stack of the
    * starting process. */
   uint8_t argc;
-  char **argv;
+  const char **argv;
   /* TODO: Environment */
 } exec_args_t;
 

--- a/include/ktest.h
+++ b/include/ktest.h
@@ -1,3 +1,6 @@
+#ifndef _SYS_KTEST_H_
+#define _SYS_KTEST_H_
+
 #include <linker_set.h>
 
 #define TEST_NAME_MAX 32
@@ -7,6 +10,8 @@ typedef struct {
   int (*test_func)();
 } test_entry_t;
 
-#define TEST_ADD(name, func)                                                   \
+#define KTEST_ADD(name, func)                                                   \
   test_entry_t name##_test = {#name, func};                                    \
   SET_ENTRY(tests, name##_test);
+
+#endif /* !_SYS_KTEST_H_ */

--- a/include/test.h
+++ b/include/test.h
@@ -1,0 +1,12 @@
+#include <linker_set.h>
+
+#define TEST_NAME_MAX 32
+
+typedef struct {
+  const char test_name[TEST_NAME_MAX];
+  int (*test_func)();
+} test_entry_t;
+
+#define TEST_ADD(name, func)                                                   \
+  test_entry_t name##_test = {#name, func};                                    \
+  SET_ENTRY(tests, name##_test);

--- a/launch
+++ b/launch
@@ -123,8 +123,9 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(
         description='Launch kernel in Malta board simulator.')
-    parser.add_argument('kernel', metavar='KERNEL', type=str,
-                        help='Kernel file in ELF format.')
+    parser.add_argument('-k', '--kernel', metavar='KERNEL', type=str,
+                        help='Kernel image file in ELF format.',
+                        default='mimiker.elf')
     parser.add_argument('args', metavar='ARGS', type=str, nargs='*',
                         help='Kernel arguments.')
     parser.add_argument('-d', '--debug', action='store_true',

--- a/mips/malta.c
+++ b/mips/malta.c
@@ -101,7 +101,7 @@ static void setup_kenv(int argc, char **argv, char **envp) {
     *tokens++ = make_pair(pair[0], pair[1]);
 }
 
-static char *kenv_get(const char *key) {
+char *kenv_get(const char *key) {
   unsigned n = strlen(key);
 
   for (int i = 1; i < _kenv.argc; i++) {

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -12,6 +12,7 @@ SOURCES_C  = \
 	file.c \
 	filedesc.c \
 	interrupt.c \
+	main.c \
 	malloc.c \
 	mutex.c \
 	pci_ids.c \

--- a/sys/main.c
+++ b/sys/main.c
@@ -1,0 +1,55 @@
+#include <stdc.h>
+#include <exec.h>
+#include <test.h>
+
+/* Borrowed from mips/malta.c */
+char *kenv_get(const char *key);
+
+static void run_init(const char *program) {
+  log("Starting program \"%s\"", program);
+
+  exec_args_t exec_args;
+  exec_args.prog_name = program;
+  exec_args.argv = (const char *[]){program};
+  exec_args.argc = 1;
+
+  int res = do_exec(&exec_args);
+  if (res) {
+    log("Failed to start init program.");
+  }
+}
+
+static void run_test(const char *test) {
+  log("Running test \"%s\"", test);
+  SET_DECLARE(tests, test_entry_t);
+  test_entry_t **ptr;
+  SET_FOREACH(ptr, tests) {
+    if (strcmp((*ptr)->test_name, test) == 0) {
+      (*ptr)->test_func();
+      return;
+    }
+  }
+  log("Test \"%s\" not found!", test);
+}
+
+int main() {
+  const char *init = kenv_get("init");
+  const char *test = kenv_get("test");
+
+  if (init)
+    run_init(init);
+  else if (test)
+    run_test(test);
+  else {
+    /* This is a message to the user, so I intentionally use kprintf instead of
+     * log. */
+    kprintf("============\n");
+    kprintf("No init specified!\n");
+    kprintf("Use init=PROGRAM to start a user-space init program or test=TEST "
+            "to run a kernel test.\n");
+    kprintf("============\n");
+    return 1;
+  }
+
+  return 0;
+}

--- a/sys/main.c
+++ b/sys/main.c
@@ -1,6 +1,6 @@
 #include <stdc.h>
 #include <exec.h>
-#include <test.h>
+#include <ktest.h>
 
 /* Borrowed from mips/malta.c */
 char *kenv_get(const char *key);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,29 +1,30 @@
-TESTS = \
-	callout.elf \
-	crash.elf \
-	exec.elf \
-	exec_misbehave.elf \
-	exec_fd_test.elf \
-	linker_set.elf \
-	malloc.elf \
-	mutex.elf \
-	physmem.elf \
-	pmap.elf \
-	producer_consumer.elf \
-	rtc.elf \
-	sched.elf \
-	strtol.elf \
-	syscall.elf \
-	thread.elf \
-	uiomove.elf \
-	vm_map.elf \
-	vfs.elf
-SOURCES_C = $(patsubst %.elf,%.c,$(TESTS))
+SOURCES_C = \
+	callout.c \
+	crash.c \
+	exec.c \
+	exec_misbehave.c \
+	exec_fd_test.c \
+	linker_set.c \
+	malloc.c \
+	mutex.c \
+	physmem.c \
+	pmap.c \
+	producer_consumer.c \
+	rtc.c \
+	sched.c \
+	strtol.c \
+	syscall.c \
+	thread.c \
+	uiomove.c \
+	vm_map.c \
+	vfs.c
 SOURCES_ASM =
 
-all: $(TESTS)
+all: $(DEPFILES) libtests.a
 
 include ../Makefile.common
 
+libtests.a: $(OBJECTS)
+
 clean:
-	$(RM) -f .*.D *.o *.elf *.map *~
+	$(RM) -f .*.D *.o *.elf *.a *.map *~

--- a/tests/callout.c
+++ b/tests/callout.c
@@ -1,11 +1,12 @@
 #include <stdc.h>
 #include <callout.h>
+#include <test.h>
 
 static void callout_foo(void *arg) {
   kprintf("Someone executed me! After %d ticks.\n", *((int *)arg));
 }
 
-int main() {
+int test_callout() {
   callout_t callout[10];
   int timeouts[10] = {2, 5, 3, 1, 6, 3, 7, 10, 5, 3};
   for (int i = 0; i < 10; i++)
@@ -18,3 +19,5 @@ int main() {
 
   return 0;
 }
+
+TEST_ADD(callout, test_callout);

--- a/tests/callout.c
+++ b/tests/callout.c
@@ -1,6 +1,6 @@
 #include <stdc.h>
 #include <callout.h>
-#include <test.h>
+#include <ktest.h>
 
 static void callout_foo(void *arg) {
   kprintf("Someone executed me! After %d ticks.\n", *((int *)arg));
@@ -20,4 +20,4 @@ int test_callout() {
   return 0;
 }
 
-TEST_ADD(callout, test_callout);
+KTEST_ADD(callout, test_callout);

--- a/tests/crash.c
+++ b/tests/crash.c
@@ -2,14 +2,13 @@
 #include <thread.h>
 #include <sched.h>
 #include <mips/mips.h>
+#include <test.h>
 
-__attribute__((noinline))
-static int load(intptr_t ptr) {
+__attribute__((noinline)) static int load(intptr_t ptr) {
   return *(volatile int *)ptr;
 }
 
-__attribute__((noinline))
-static void store(intptr_t ptr, int value) {
+__attribute__((noinline)) static void store(intptr_t ptr, int value) {
   *(volatile int *)ptr = value;
 }
 
@@ -29,10 +28,9 @@ static void unmapped_store(void *data) {
   store(0x10000000, 666);
 }
 
-
 #define NEW_THREAD(fn, arg) thread_create(#fn, fn, arg)
 
-int main() {
+int test_crash() {
   sched_add(NEW_THREAD(unaligned_load, NULL));
   sched_add(NEW_THREAD(unaligned_store, NULL));
   sched_add(NEW_THREAD(unmapped_load, NULL));
@@ -41,3 +39,5 @@ int main() {
   thread_dump_all();
   sched_run();
 }
+
+TEST_ADD(crash, test_crash);

--- a/tests/crash.c
+++ b/tests/crash.c
@@ -2,7 +2,7 @@
 #include <thread.h>
 #include <sched.h>
 #include <mips/mips.h>
-#include <test.h>
+#include <ktest.h>
 
 __attribute__((noinline)) static int load(intptr_t ptr) {
   return *(volatile int *)ptr;
@@ -30,7 +30,7 @@ static void unmapped_store(void *data) {
 
 #define NEW_THREAD(fn, arg) thread_create(#fn, fn, arg)
 
-int test_crash() {
+static int test_crash() {
   sched_add(NEW_THREAD(unaligned_load, NULL));
   sched_add(NEW_THREAD(unaligned_store, NULL));
   sched_add(NEW_THREAD(unmapped_load, NULL));
@@ -40,4 +40,4 @@ int test_crash() {
   sched_run();
 }
 
-TEST_ADD(crash, test_crash);
+KTEST_ADD(crash, test_crash);

--- a/tests/exec.c
+++ b/tests/exec.c
@@ -2,9 +2,9 @@
 #include <exec.h>
 #include <thread.h>
 #include <sched.h>
-#include <test.h>
+#include <ktest.h>
 
-void program_thread(void *data) {
+static void program_thread(void *data) {
   exec_args_t exec_args;
   switch ((int)data) {
   case 1:
@@ -26,7 +26,7 @@ void program_thread(void *data) {
   }
 }
 
-int test_exec() {
+static int test_exec() {
   /* This is a simple demonstration of the exec functionality. It
    * requests to substitute current thread's image with program
    * called "prog", which is implemented in ./user/prog.c, and after
@@ -57,4 +57,4 @@ int test_exec() {
   return 0;
 }
 
-TEST_ADD(exec, test_exec);
+KTEST_ADD(exec, test_exec);

--- a/tests/exec.c
+++ b/tests/exec.c
@@ -2,6 +2,7 @@
 #include <exec.h>
 #include <thread.h>
 #include <sched.h>
+#include <test.h>
 
 void program_thread(void *data) {
   exec_args_t exec_args;
@@ -9,23 +10,23 @@ void program_thread(void *data) {
   case 1:
     exec_args.prog_name = "prog";
     exec_args.argv =
-      (char *[]){"prog", "argument1", "ARGUMENT2", "a-r-g-u-m-e-n-t-3"};
+      (const char *[]){"prog", "argument1", "ARGUMENT2", "a-r-g-u-m-e-n-t-3"};
     exec_args.argc = 4;
     do_exec(&exec_args);
   case 2:
     exec_args.prog_name = "prog";
-    exec_args.argv = (char *[]){"prog", "String passed as argument."};
+    exec_args.argv = (const char *[]){"prog", "String passed as argument."};
     exec_args.argc = 2;
     do_exec(&exec_args);
   case 3:
     exec_args.prog_name = "prog";
-    exec_args.argv = (char *[]){"prog", "abort_test"};
+    exec_args.argv = (const char *[]){"prog", "abort_test"};
     exec_args.argc = 2;
     do_exec(&exec_args);
   }
 }
 
-int main() {
+int test_exec() {
   /* This is a simple demonstration of the exec functionality. It
    * requests to substitute current thread's image with program
    * called "prog", which is implemented in ./user/prog.c, and after
@@ -55,3 +56,5 @@ int main() {
 
   return 0;
 }
+
+TEST_ADD(exec, test_exec);

--- a/tests/exec_fd_test.c
+++ b/tests/exec_fd_test.c
@@ -1,13 +1,16 @@
 #include <common.h>
 #include <exec.h>
+#include <test.h>
 
-int main() {
+int test_exec_fd_test() {
   exec_args_t exec_args;
   exec_args.prog_name = "fd_test";
-  exec_args.argv = (char *[]){"fd_test"};
+  exec_args.argv = (const char *[]){"fd_test"};
   exec_args.argc = 1;
 
   do_exec(&exec_args);
 
   return 0;
 }
+
+TEST_ADD(exec_fd_test, test_exec_fd_test);

--- a/tests/exec_fd_test.c
+++ b/tests/exec_fd_test.c
@@ -1,8 +1,8 @@
 #include <common.h>
 #include <exec.h>
-#include <test.h>
+#include <ktest.h>
 
-int test_exec_fd_test() {
+static int test_exec_fd_test() {
   exec_args_t exec_args;
   exec_args.prog_name = "fd_test";
   exec_args.argv = (const char *[]){"fd_test"};
@@ -13,4 +13,4 @@ int test_exec_fd_test() {
   return 0;
 }
 
-TEST_ADD(exec_fd_test, test_exec_fd_test);
+KTEST_ADD(exec_fd_test, test_exec_fd_test);

--- a/tests/exec_misbehave.c
+++ b/tests/exec_misbehave.c
@@ -1,13 +1,16 @@
 #include <common.h>
 #include <exec.h>
+#include <test.h>
 
-int main() {
+int test_exec_misbehave() {
   exec_args_t exec_args;
   exec_args.prog_name = "misbehave";
-  exec_args.argv = (char *[]){"misbehave"};
+  exec_args.argv = (const char *[]){"misbehave"};
   exec_args.argc = 1;
 
   do_exec(&exec_args);
 
   return 0;
 }
+
+TEST_ADD(exec_misbehave, test_exec_misbehave);

--- a/tests/exec_misbehave.c
+++ b/tests/exec_misbehave.c
@@ -1,8 +1,8 @@
 #include <common.h>
 #include <exec.h>
-#include <test.h>
+#include <ktest.h>
 
-int test_exec_misbehave() {
+static int test_exec_misbehave() {
   exec_args_t exec_args;
   exec_args.prog_name = "misbehave";
   exec_args.argv = (const char *[]){"misbehave"};
@@ -13,4 +13,4 @@ int test_exec_misbehave() {
   return 0;
 }
 
-TEST_ADD(exec_misbehave, test_exec_misbehave);
+KTEST_ADD(exec_misbehave, test_exec_misbehave);

--- a/tests/linker_set.c
+++ b/tests/linker_set.c
@@ -1,6 +1,6 @@
 #include <stdc.h>
 #include <linker_set.h>
-#include <test.h>
+#include <ktest.h>
 
 static int some_int_1 = 1;
 static int some_int_2 = 2;
@@ -13,7 +13,7 @@ SET_ENTRY(testset, some_int_3);
 SET_ENTRY(testset, some_int_4);
 SET_ENTRY(testset, some_int_5);
 
-int test_linker_set() {
+static int test_linker_set() {
   SET_DECLARE(testset, int);
 
   kprintf("# of elements in testset: %zu\n", SET_COUNT(testset));
@@ -25,4 +25,4 @@ int test_linker_set() {
   return 0;
 }
 
-TEST_ADD(linker_set, test_linker_set);
+KTEST_ADD(linker_set, test_linker_set);

--- a/tests/linker_set.c
+++ b/tests/linker_set.c
@@ -1,5 +1,6 @@
 #include <stdc.h>
 #include <linker_set.h>
+#include <test.h>
 
 static int some_int_1 = 1;
 static int some_int_2 = 2;
@@ -12,7 +13,7 @@ SET_ENTRY(testset, some_int_3);
 SET_ENTRY(testset, some_int_4);
 SET_ENTRY(testset, some_int_5);
 
-int main() {
+int test_linker_set() {
   SET_DECLARE(testset, int);
 
   kprintf("# of elements in testset: %zu\n", SET_COUNT(testset));
@@ -23,3 +24,5 @@ int main() {
   }
   return 0;
 }
+
+TEST_ADD(linker_set, test_linker_set);

--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -1,7 +1,8 @@
 #include <stdc.h>
 #include <malloc.h>
+#include <test.h>
 
-int main() {
+int test_malloc() {
   vm_page_t *page = pm_alloc(1);
 
   MALLOC_DEFINE(mp, "testing memory pool");
@@ -37,3 +38,5 @@ int main() {
 
   return 0;
 }
+
+TEST_ADD(malloc, test_malloc);

--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -1,8 +1,8 @@
 #include <stdc.h>
 #include <malloc.h>
-#include <test.h>
+#include <ktest.h>
 
-int test_malloc() {
+static int test_malloc() {
   vm_page_t *page = pm_alloc(1);
 
   MALLOC_DEFINE(mp, "testing memory pool");
@@ -39,4 +39,4 @@ int test_malloc() {
   return 0;
 }
 
-TEST_ADD(malloc, test_malloc);
+KTEST_ADD(malloc, test_malloc);

--- a/tests/mutex.c
+++ b/tests/mutex.c
@@ -2,20 +2,18 @@
 #include <sched.h>
 #include <mutex.h>
 #include <thread.h>
-#include <test.h>
+#include <ktest.h>
 
-mtx_t mtx;
-mtx_t mtx1;
-mtx_t mtx2;
-volatile int32_t value;
+static mtx_t mtx;
+static volatile int32_t value;
 
-thread_t *td1;
-thread_t *td2;
-thread_t *td3;
-thread_t *td4;
-thread_t *td5;
+static thread_t *td1;
+static thread_t *td2;
+static thread_t *td3;
+static thread_t *td4;
+static thread_t *td5;
 
-void mtx_test_main() {
+static void mtx_test_main() {
   mtx_lock(&mtx);
   for (size_t i = 0; i < 20000; i++) {
     value++;
@@ -26,8 +24,7 @@ void mtx_test_main() {
     ;
 }
 
-void mtx_test() {
-  mtx_init(&mtx);
+static int mtx_test() {
   mtx_init(&mtx);
   td1 = thread_create("td1", mtx_test_main, NULL);
   td2 = thread_create("td2", mtx_test_main, NULL);
@@ -40,9 +37,14 @@ void mtx_test() {
   sched_add(td4);
   sched_add(td5);
   sched_run();
+  return 0;
 }
 
-void deadlock_main1() {
+#if 0
+static mtx_t mtx1;
+static mtx_t mtx2;
+
+static void deadlock_main1() {
   mtx_lock(&mtx1);
   for (size_t i = 0; i < 400000; i++)
     ;
@@ -52,7 +54,7 @@ void deadlock_main1() {
   mtx_unlock(&mtx1);
 }
 
-void deadlock_main2() {
+static void deadlock_main2() {
   mtx_lock(&mtx2);
   for (size_t i = 0; i < 400000; i++)
     ;
@@ -62,7 +64,7 @@ void deadlock_main2() {
   mtx_unlock(&mtx2);
 }
 
-void deadlock_test() {
+static void deadlock_test() {
   mtx_init(&mtx1);
   mtx_init(&mtx2);
   td1 = thread_create("td1", deadlock_main1, NULL);
@@ -73,10 +75,6 @@ void deadlock_test() {
   while (1)
     kprintf("elo!\n");
 }
+#endif
 
-int test_mutex() {
-  mtx_test();
-  return 0;
-}
-
-TEST_ADD(mutex, test_mutex);
+KTEST_ADD(mutex, mtx_test);

--- a/tests/mutex.c
+++ b/tests/mutex.c
@@ -2,6 +2,7 @@
 #include <sched.h>
 #include <mutex.h>
 #include <thread.h>
+#include <test.h>
 
 mtx_t mtx;
 mtx_t mtx1;
@@ -73,7 +74,9 @@ void deadlock_test() {
     kprintf("elo!\n");
 }
 
-int main() {
+int test_mutex() {
   mtx_test();
   return 0;
 }
+
+TEST_ADD(mutex, test_mutex);

--- a/tests/physmem.c
+++ b/tests/physmem.c
@@ -1,9 +1,10 @@
 #include <stdc.h>
 #include <physmem.h>
+#include <test.h>
 
 unsigned long pm_hash();
 
-int main() {
+int test_physmem() {
   unsigned long pre = pm_hash();
 
   /* Write - read test */
@@ -46,3 +47,5 @@ int main() {
   kprintf("Tests passed\n");
   return 0;
 }
+
+TEST_ADD(physmem, test_physmem);

--- a/tests/physmem.c
+++ b/tests/physmem.c
@@ -1,10 +1,10 @@
 #include <stdc.h>
 #include <physmem.h>
-#include <test.h>
+#include <ktest.h>
 
 unsigned long pm_hash();
 
-int test_physmem() {
+static int test_physmem() {
   unsigned long pre = pm_hash();
 
   /* Write - read test */
@@ -48,4 +48,4 @@ int test_physmem() {
   return 0;
 }
 
-TEST_ADD(physmem, test_physmem);
+KTEST_ADD(physmem, test_physmem);

--- a/tests/pmap.c
+++ b/tests/pmap.c
@@ -3,6 +3,7 @@
 #include <pmap.h>
 #include <physmem.h>
 #include <vm.h>
+#include <test.h>
 
 void kernel_pmap_test() {
   pmap_t *pmap = get_kernel_pmap();
@@ -74,10 +75,11 @@ void user_pmap_test() {
   log("Test passed.");
 }
 
-int main() {
+int test_pmap() {
   kernel_pmap_test();
   user_pmap_test();
 
   return 0;
 }
 
+TEST_ADD(pmap, test_pmap);

--- a/tests/pmap.c
+++ b/tests/pmap.c
@@ -3,9 +3,9 @@
 #include <pmap.h>
 #include <physmem.h>
 #include <vm.h>
-#include <test.h>
+#include <ktest.h>
 
-void kernel_pmap_test() {
+static int test_kernel_pmap() {
   pmap_t *pmap = get_kernel_pmap();
 
   vm_page_t *pg = pm_alloc(16);
@@ -42,9 +42,10 @@ void kernel_pmap_test() {
   pm_free(pg);
 
   log("Test passed.");
+  return 0;
 }
 
-void user_pmap_test() {
+static int test_user_pmap() {
   pmap_t *pmap1 = pmap_new();
   pmap_t *pmap2 = pmap_new();
 
@@ -73,13 +74,8 @@ void user_pmap_test() {
   pmap_delete(pmap1);
   pmap_delete(pmap2);
   log("Test passed.");
-}
-
-int test_pmap() {
-  kernel_pmap_test();
-  user_pmap_test();
-
   return 0;
 }
 
-TEST_ADD(pmap, test_pmap);
+KTEST_ADD(pmap_kernel, test_kernel_pmap);
+KTEST_ADD(pmap_user, test_user_pmap);

--- a/tests/producer_consumer.c
+++ b/tests/producer_consumer.c
@@ -3,6 +3,7 @@
 #include <sched.h>
 #include <stdc.h>
 #include <thread.h>
+#include <test.h>
 
 #define BUF_MAX 16384
 #define THREADS 3
@@ -29,7 +30,7 @@ static void producer(void *ptr) {
       if (buf.items < BUF_MAX)
         break;
       cv_wait(&buf.not_full, &buf.lock);
-    } while(true);
+    } while (true);
     if (working) {
       produced++;
       buf.all_produced++;
@@ -38,8 +39,8 @@ static void producer(void *ptr) {
     }
     mtx_unlock(&buf.lock);
   }
-  log("%s finished, produced %d of %d.",
-      thread_self()->td_name, produced, buf.all_produced);
+  log("%s finished, produced %d of %d.", thread_self()->td_name, produced,
+      buf.all_produced);
 }
 
 static void consumer(void *ptr) {
@@ -64,11 +65,11 @@ static void consumer(void *ptr) {
     }
     mtx_unlock(&buf.lock);
   }
-  log("%s finished, consumed %d of %d.",
-      thread_self()->td_name, consumed, buf.all_consumed);
+  log("%s finished, consumed %d of %d.", thread_self()->td_name, consumed,
+      buf.all_consumed);
 }
 
-int main() {
+int test_producer_consumer() {
   buf.items = 0;
   buf.all_produced = 0;
   buf.all_consumed = 0;
@@ -77,7 +78,7 @@ int main() {
   cv_init(&buf.not_full, "not_full");
 
   for (int i = 0; i < THREADS; i++) {
-    char name[20]; 
+    char name[20];
     snprintf(name, sizeof(name), "producer-%d", i);
     sched_add(thread_create(name, producer, (void *)i));
     snprintf(name, sizeof(name), "consumer-%d", i);
@@ -87,3 +88,5 @@ int main() {
   sched_run();
   return 0;
 }
+
+TEST_ADD(producer_consumer, test_producer_consumer);

--- a/tests/producer_consumer.c
+++ b/tests/producer_consumer.c
@@ -3,7 +3,7 @@
 #include <sched.h>
 #include <stdc.h>
 #include <thread.h>
-#include <test.h>
+#include <ktest.h>
 
 #define BUF_MAX 16384
 #define THREADS 3
@@ -69,7 +69,7 @@ static void consumer(void *ptr) {
       buf.all_consumed);
 }
 
-int test_producer_consumer() {
+static int test_producer_consumer() {
   buf.items = 0;
   buf.all_produced = 0;
   buf.all_consumed = 0;
@@ -89,4 +89,4 @@ int test_producer_consumer() {
   return 0;
 }
 
-TEST_ADD(producer_consumer, test_producer_consumer);
+KTEST_ADD(producer_consumer, test_producer_consumer);

--- a/tests/rtc.c
+++ b/tests/rtc.c
@@ -1,7 +1,7 @@
 #include <common.h>
 #include <mips/malta.h>
 #include <rtc.h>
-#include <test.h>
+#include <ktest.h>
 
 /* http://geezer.osdevbrasil.net/temp/rtc.txt */
 
@@ -48,7 +48,7 @@ void mdelay(unsigned msec) {
     ;
 }
 
-int test_rtc() {
+static int test_rtc() {
   rtc_init();
 
   while (1) {
@@ -62,6 +62,7 @@ int test_rtc() {
 
   return 0;
 }
-#endif
 
-TEST_ADD(rtc, test_rtc);
+KTEST_ADD(rtc, test_rtc);
+
+#endif

--- a/tests/rtc.c
+++ b/tests/rtc.c
@@ -1,6 +1,7 @@
 #include <common.h>
 #include <mips/malta.h>
 #include <rtc.h>
+#include <test.h>
 
 /* http://geezer.osdevbrasil.net/temp/rtc.txt */
 
@@ -47,7 +48,7 @@ void mdelay(unsigned msec) {
     ;
 }
 
-int main() {
+int test_rtc() {
   rtc_init();
 
   while (1) {
@@ -62,3 +63,5 @@ int main() {
   return 0;
 }
 #endif
+
+TEST_ADD(rtc, test_rtc);

--- a/tests/sched.c
+++ b/tests/sched.c
@@ -4,6 +4,7 @@
 #include <sched.h>
 #include <vm_map.h>
 #include <vm_pager.h>
+#include <test.h>
 
 #if 0
 static void demo_thread_1() {
@@ -46,7 +47,7 @@ static struct {
 } range[] = {
   {0xd0000000, 0xd0001000}, {0x1000000, 0x1001000}, {0x2000000, 0x2001000}};
 
-void test_thread(void *p) {
+static void test_thread(void *p) {
   int *ptr = p;
   kprintf("ptr: %p\n", ptr);
   while (1) {
@@ -56,7 +57,7 @@ void test_thread(void *p) {
   }
 }
 
-void main() {
+int test_sched() {
   thread_t *t1 =
     thread_create("kernel-thread-1", test_thread, (void *)range[0].start);
   thread_t *t3 =
@@ -90,4 +91,7 @@ void main() {
   thread_dump_all();
 
   sched_run();
+  return 0;
 }
+
+TEST_ADD(sched, test_sched);

--- a/tests/sched.c
+++ b/tests/sched.c
@@ -4,7 +4,7 @@
 #include <sched.h>
 #include <vm_map.h>
 #include <vm_pager.h>
-#include <test.h>
+#include <ktest.h>
 
 #if 0
 static void demo_thread_1() {
@@ -57,7 +57,7 @@ static void test_thread(void *p) {
   }
 }
 
-int test_sched() {
+static int test_sched() {
   thread_t *t1 =
     thread_create("kernel-thread-1", test_thread, (void *)range[0].start);
   thread_t *t3 =
@@ -94,4 +94,4 @@ int test_sched() {
   return 0;
 }
 
-TEST_ADD(sched, test_sched);
+KTEST_ADD(sched, test_sched);

--- a/tests/strtol.c
+++ b/tests/strtol.c
@@ -1,24 +1,27 @@
 #include <stdc.h>
+#include <test.h>
 
-typedef struct strtol_test
-{
-    const char* str;
-    long value;
-    long base;
+typedef struct strtol_test {
+  const char *str;
+  long value;
+  long base;
 } strtol_test_t;
 
-strtol_test_t values[] = {{"123", 123, 10},
-                          {"0xA23B", 41531, 16},
-                          {"03417", 1807, 8}};
+strtol_test_t values[] = {
+  {"123", 123, 10}, {"0xA23B", 41531, 16}, {"03417", 1807, 8}};
 
-int main(void)
-{
-    int max = sizeof(values)/sizeof(strtol_test_t);
-    for(int i=0;i<max;i++)
-        if(values[i].value != strtol(values[i].str,(char **) NULL, values[i].base))
-            log("Mismatch for test %d: Expected: %ld, Actual: %ld", i, values[i].value, strtol(values[i].str,(char **) NULL, values[i].base));
-        else
-            log("Match for test %d: Expected: %ld, Actual: %ld", i, values[i].value, strtol(values[i].str,(char **) NULL, values[i].base));
-    
-    return 0;
+int test_strtol(void) {
+  int max = sizeof(values) / sizeof(strtol_test_t);
+  for (int i = 0; i < max; i++)
+    if (values[i].value != strtol(values[i].str, (char **)NULL, values[i].base))
+      log("Mismatch for test %d: Expected: %ld, Actual: %ld", i,
+          values[i].value,
+          strtol(values[i].str, (char **)NULL, values[i].base));
+    else
+      log("Match for test %d: Expected: %ld, Actual: %ld", i, values[i].value,
+          strtol(values[i].str, (char **)NULL, values[i].base));
+
+  return 0;
 }
+
+TEST_ADD(strtol, test_strtol);

--- a/tests/strtol.c
+++ b/tests/strtol.c
@@ -1,5 +1,5 @@
 #include <stdc.h>
-#include <test.h>
+#include "../include/ktest.h"
 
 typedef struct strtol_test {
   const char *str;
@@ -24,4 +24,4 @@ int test_strtol(void) {
   return 0;
 }
 
-TEST_ADD(strtol, test_strtol);
+KTEST_ADD(strtol, test_strtol);

--- a/tests/syscall.c
+++ b/tests/syscall.c
@@ -3,8 +3,9 @@
 #include <thread.h>
 #include <vm_map.h>
 #include <vm_pager.h>
+#include <test.h>
 
-int main() {
+int test_syscall() {
   /* System call from kernel space! */
   kprintf("syscall(1) = %d\n", syscall(1));
 
@@ -14,16 +15,14 @@ int main() {
 
   vm_addr_t stext = 0x400000;
   vm_addr_t etext = stext + PAGESIZE;
-  vm_map_entry_t *text =
-    vm_map_add_entry(umap, stext, etext,
-                     VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC);
+  vm_map_entry_t *text = vm_map_add_entry(
+    umap, stext, etext, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC);
   text->object = default_pager->pgr_alloc();
 
   vm_addr_t sdata = 0x800000;
   vm_addr_t edata = sdata + PAGESIZE;
   vm_map_entry_t *data =
-    vm_map_add_entry(umap, sdata, edata,
-                     VM_PROT_READ | VM_PROT_WRITE);
+    vm_map_add_entry(umap, sdata, edata, VM_PROT_READ | VM_PROT_WRITE);
   data->object = default_pager->pgr_alloc();
 
   vm_map_dump(umap);
@@ -41,3 +40,5 @@ int main() {
   td->td_uctx.pc = stext;
   user_exc_leave();
 }
+
+TEST_ADD(syscall, test_syscall);

--- a/tests/syscall.c
+++ b/tests/syscall.c
@@ -3,9 +3,9 @@
 #include <thread.h>
 #include <vm_map.h>
 #include <vm_pager.h>
-#include <test.h>
+#include <ktest.h>
 
-int test_syscall() {
+static int test_syscall() {
   /* System call from kernel space! */
   kprintf("syscall(1) = %d\n", syscall(1));
 
@@ -41,4 +41,4 @@ int test_syscall() {
   user_exc_leave();
 }
 
-TEST_ADD(syscall, test_syscall);
+KTEST_ADD(syscall, test_syscall);

--- a/tests/thread.c
+++ b/tests/thread.c
@@ -1,6 +1,6 @@
 #include <stdc.h>
 #include <thread.h>
-#include <test.h>
+#include <ktest.h>
 
 static thread_t *td0, *td1, *td2;
 
@@ -30,7 +30,7 @@ static void demo_thread_2() {
   panic("This line need not be reached!");
 }
 
-int test_thread() {
+static int test_thread() {
   kprintf("Thread '%s' started.\n", thread_self()->td_name);
 
   td0 = thread_self();
@@ -54,4 +54,4 @@ int test_thread() {
   return 0;
 }
 
-TEST_ADD(thread, test_thread);
+KTEST_ADD(thread, test_thread);

--- a/tests/thread.c
+++ b/tests/thread.c
@@ -1,5 +1,6 @@
 #include <stdc.h>
 #include <thread.h>
+#include <test.h>
 
 static thread_t *td0, *td1, *td2;
 
@@ -29,7 +30,7 @@ static void demo_thread_2() {
   panic("This line need not be reached!");
 }
 
-int main() {
+int test_thread() {
   kprintf("Thread '%s' started.\n", thread_self()->td_name);
 
   td0 = thread_self();
@@ -52,3 +53,5 @@ int main() {
 
   return 0;
 }
+
+TEST_ADD(thread, test_thread);

--- a/tests/uiomove.c
+++ b/tests/uiomove.c
@@ -2,9 +2,9 @@
 #include <systm.h>
 #include <stdc.h>
 #include <vm_map.h>
-#include <test.h>
+#include <ktest.h>
 
-int test_uiomove() {
+static int test_uiomove() {
   int res = 0;
 
   char buffer1[100];
@@ -60,4 +60,4 @@ int test_uiomove() {
   return 0;
 }
 
-TEST_ADD(uiomove, test_uiomove);
+KTEST_ADD(uiomove, test_uiomove);

--- a/tests/uiomove.c
+++ b/tests/uiomove.c
@@ -2,8 +2,9 @@
 #include <systm.h>
 #include <stdc.h>
 #include <vm_map.h>
+#include <test.h>
 
-int main() {
+int test_uiomove() {
   int res = 0;
 
   char buffer1[100];
@@ -58,3 +59,5 @@ int main() {
 
   return 0;
 }
+
+TEST_ADD(uiomove, test_uiomove);

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -3,8 +3,9 @@
 #include <vnode.h>
 #include <errno.h>
 #include <vm_map.h>
+#include <test.h>
 
-int main() {
+int test_vfs() {
   vnode_t *v;
   int error;
 
@@ -95,3 +96,5 @@ int main() {
 
   return 0;
 }
+
+TEST_ADD(vfs, test_vfs);

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -3,9 +3,9 @@
 #include <vnode.h>
 #include <errno.h>
 #include <vm_map.h>
-#include <test.h>
+#include <ktest.h>
 
-int test_vfs() {
+static int test_vfs() {
   vnode_t *v;
   int error;
 
@@ -97,4 +97,4 @@ int test_vfs() {
   return 0;
 }
 
-TEST_ADD(vfs, test_vfs);
+KTEST_ADD(vfs, test_vfs);

--- a/tests/vm_map.c
+++ b/tests/vm_map.c
@@ -3,7 +3,7 @@
 #include <vm_object.h>
 #include <vm_map.h>
 #include <errno.h>
-#include <test.h>
+#include <ktest.h>
 
 static void paging_on_demand_and_memory_protection_demo() {
   vm_map_activate(vm_map_new());
@@ -43,7 +43,7 @@ static void paging_on_demand_and_memory_protection_demo() {
   log("Test passed.");
 }
 
-void findspace_demo() {
+static void findspace_demo() {
   vm_map_t *umap = vm_map_new();
   vm_map_activate(umap);
 
@@ -86,10 +86,10 @@ void findspace_demo() {
   log("Test passed.");
 }
 
-int test_vm_map() {
+static int test_vm_map() {
   paging_on_demand_and_memory_protection_demo();
   findspace_demo();
   return 0;
 }
 
-TEST_ADD(vm_map, test_vm_map);
+KTEST_ADD(vm_map, test_vm_map);

--- a/tests/vm_map.c
+++ b/tests/vm_map.c
@@ -3,6 +3,7 @@
 #include <vm_object.h>
 #include <vm_map.h>
 #include <errno.h>
+#include <test.h>
 
 static void paging_on_demand_and_memory_protection_demo() {
   vm_map_activate(vm_map_new());
@@ -85,8 +86,10 @@ void findspace_demo() {
   log("Test passed.");
 }
 
-int main() {
+int test_vm_map() {
   paging_on_demand_and_memory_protection_demo();
   findspace_demo();
   return 0;
 }
+
+TEST_ADD(vm_map, test_vm_map);


### PR DESCRIPTION
This branch cleans up the build process by reducing the final output to just a single `.elf` kernel image. The kernel now accepts `init=PROGRAM` and `test=TEST` arguments, which may be used to run a user-space program as the init process, or run the specified kernel test. This slightly generalizes our test architecture, and improves build time.

Tests are now declared with `TEST_ADD(name, function_implementing_test)`, which appends appropriate data to a linker set. Tests no longer provide their own version of `main`, the only `main` is now implemented in `sys/main.c`. Kernel image is linked once, to `mimiker.elf` in the root directory. The launch script uses `mimiker.elf` by default, so it may be used like this:
```
./launch init=fd_test
```
or
```
./launch -td test=vm_map
```

As always, many files weren't formatted with `make format`, so this diff also has to incorporate formatting fixes.