### PR TITLE
Changes in mutex implementation

### DIFF
--- a/sys/mutex.c
+++ b/sys/mutex.c
@@ -17,13 +17,14 @@ void mtx_init(mtx_t *m, unsigned type) {
 }
 
 void mtx_lock(mtx_t *m) {
+  critical_enter();
   if (mtx_owned(m)) {
     assert(m->m_type & MTX_RECURSE);
     m->m_count++;
+    critical_leave();
     return;
   }
 
-  critical_enter();
   while (m->m_owner != NULL)
     sleepq_wait(&m->m_owner, NULL);
   m->m_owner = thread_self();
@@ -31,14 +32,14 @@ void mtx_lock(mtx_t *m) {
 }
 
 void mtx_unlock(mtx_t *m) {
+  critical_enter();
   assert(mtx_owned(m));
-
   if (m->m_count > 0) {
     m->m_count--;
+    critical_leave();
     return;
   }
 
-  critical_enter();
   m->m_owner = NULL;
   sleepq_signal(&m->m_owner);
   critical_leave();


### PR DESCRIPTION
I think this is important to have critical_*() around `m->m_count++` and `m->m_count--`