### PR TITLE
Disabled std library headers use in kernel

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -28,8 +28,14 @@ HOSTCC	 = gcc -g
 SYSROOT  = $(realpath $(dir $(shell which $(P)gcc))/..)
 GENASSYM = $(TOPDIR)/script/genassym.py $(NM)
 
+GCC_INSTALL_PATH = $(shell LANG=C $(CC)  -print-search-dirs | sed -n -e 's/install:\(.*\)/\1/p')
+# The _LIBC_LIMITS_H_ prevents include-fixed/limits.h from forcefully including
+# the system version of limits.h, which is not present in a freestanding
+# environment. I feel like this is a workaround for a bug in GCC.
+GCC_SYSTEM_INC = -I$(GCC_INSTALL_PATH)include/ -I$(GCC_INSTALL_PATH)include-fixed/ -D_LIBC_LIMITS_H_
+
 ASFLAGS  =
-CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -ffreestanding
+CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -nostdinc -nostdlib $(GCC_SYSTEM_INC) -ffreestanding
 CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDFLAGS  = -nostdlib -T $(TOPDIR)/mips/malta.ld
 

--- a/include/common.h
+++ b/include/common.h
@@ -6,14 +6,24 @@
 #include <stdbool.h>     /* bool, true, false */
 #include <stdalign.h>    /* alignof, alignas */
 #include <stdnoreturn.h> /* noreturn */
-#include <sys/types.h>   /* provided by the toolchain */
-#include <sys/cdefs.h>   /* ditto */
 
 typedef unsigned long vm_addr_t;
 typedef unsigned long pm_addr_t;
+typedef unsigned long off_t;
+typedef unsigned long ssize_t;
+typedef unsigned long uid_t;
+typedef unsigned long gid_t;
+typedef unsigned long ino_t;
+
+/* Generic preprocessor macros */
+#define __STRING(x) #x
+#define __CONCAT1(x, y) x##y
+#define __CONCAT(x, y) __CONCAT1(x, y)
 
 /* Wrapper for various GCC attributes */
 #define __nonnull(x) __attribute__((__nonnull__(x)))
+#define __section(s) __attribute__((__section__(#s)))
+#define __used __attribute__((used))
 
 /* Macros for counting and rounding. */
 #ifndef howmany

--- a/include/elf/elf_generic.h
+++ b/include/elf/elf_generic.h
@@ -29,7 +29,7 @@
 #ifndef _SYS_ELF_GENERIC_H_
 #define _SYS_ELF_GENERIC_H_ 1
 
-#include <sys/cdefs.h>
+#include <common.h>
 
 /*
  * Definitions of generic ELF names which relieve applications from

--- a/include/linker_set.h
+++ b/include/linker_set.h
@@ -1,7 +1,7 @@
 #ifndef _SYS_LINKER_SET_H_
 #define _SYS_LINKER_SET_H_
 
-#include <sys/cdefs.h>
+#include <common.h>
 
 /* The implementation mostly follows DragonFly BSD's 'sys/linker_set.h' */
 
@@ -13,8 +13,8 @@
 #define SET_ENTRY(set, sym)                                                    \
   __GLOBL(__CONCAT(__start_set_, set));                                        \
   __GLOBL(__CONCAT(__stop_set_, set));                                         \
-  static void const *const __set_##set##_sym_##sym                             \
-    __section("set_" #set) __used = &sym
+  static void const *const __set_##set##_sym_##sym __section(set_##set)        \
+    __used = &sym
 
 #define SET_DECLARE(set, ptype)                                                \
   extern ptype *__CONCAT(__start_set_, set);                                   \

--- a/include/mips/cpu.h
+++ b/include/mips/cpu.h
@@ -32,7 +32,7 @@
 #define _CPU_H_
 
 #if !defined(__ASSEMBLER__)
-#include <sys/types.h>
+#include <stddef.h>
 #endif
 
 #ifndef SR_IMASK

--- a/mips/malta.c
+++ b/mips/malta.c
@@ -8,7 +8,6 @@
 #include <pcpu.h>
 #include <stdc.h>
 #include <thread.h>
-#include <string.h>
 
 extern unsigned int __bss[];
 extern unsigned int __ebss[];

--- a/mips/stack.c
+++ b/mips/stack.c
@@ -1,6 +1,5 @@
 #include <mips/stack.h>
 #include <common.h>
-#include <string.h>
 #include <stdc.h>
 
 /* Places program args onto the stack.

--- a/stdc/include/low/_stdio.h
+++ b/stdc/include/low/_stdio.h
@@ -50,7 +50,6 @@ extern "C" {
 
 #include <low/_flavour.h>
 #include <stddef.h>
-#include <stdio.h>
 #include <stdarg.h>
 
 #define STD_IO_BUFSIZ  128           /* for stdio and stdout buffer */
@@ -75,7 +74,6 @@ typedef struct
   int _ursize;                        /* unget buffer remaining */
   void *_cookie;                      /* for funopen() function */
   char *_tmpfname;                    /* name of the temporary file */
-  _mbstate_t _mbstate;                /* multi-byte state */
   short _flags2;                      /* for wide/byte orientation */
   unsigned char _nbuf;                /* used when stream is un-buffered */
 } __smFILE;
@@ -89,13 +87,10 @@ typedef struct
     FP->_cookie = 0;                  \
     FP->_flags2 = 0;                  \
     FP->_tmpfname = 0;                \
-    FP->_mbstate.__count = 0;         \
-    FP->_mbstate.__value.__wch = 0;   \
   }
 
 typedef int (*funread) (void *_cookie, char *_buf, int _n);
 typedef int (*funwrite) (void *_cookie, const char *_buf, int _n);
-typedef fpos_t (*funseek) (void *_cookie, fpos_t _off, int _whence);
 typedef int (*funclose) (void *_cookie);
 
 typedef struct funcookie 
@@ -103,7 +98,6 @@ typedef struct funcookie
   void *cookie;
   funread readfn;
   funwrite writefn;
-  funseek seekfn;
   funclose closefn;
 } funcookie;
 
@@ -138,7 +132,6 @@ int __refill (__smFILE *);
 
 int low_read (__smFILE *fp, char* base, int size);
 int low_write (__smFILE *fp, char* base, int size);
-_fpos_t low_seek (__smFILE *fp, int off, int dir);
 int low_close (__smFILE *fp);
 
 int __low_printf(ReadWriteInfo *rw, const void *src, size_t len);
@@ -152,9 +145,6 @@ int __low_asprintf (ReadWriteInfo *rw, const void *src, size_t len);
 int __low_asnprintf (ReadWriteInfo *rw, const void *src, size_t len);
 int __low_wprintf (ReadWriteInfo *rw, const wchar_t *s, size_t len);
 int __low_swprintf (ReadWriteInfo *rw, const void *src, size_t len);
-wint_t  __low_wscanf (ReadWriteInfo *rw);
-wint_t __low_swscanf(ReadWriteInfo *rw);
-wint_t  __low_fwscanf (ReadWriteInfo *rw);
 size_t _format_parser(ReadWriteInfo *rw, const char *fmt, va_list *ap, unsigned int integeronly);
 size_t _wformat_parser(ReadWriteInfo *rw, const wchar_t *fmt, va_list *ap);
 int __scanf_core (ReadWriteInfo *rw, const char *fmt, va_list ap, unsigned int flags);
@@ -165,10 +155,6 @@ size_t _format_parser_float (ReadWriteInfo *rw, const char *fmt, va_list *ap);
 size_t _format_parser_int (ReadWriteInfo *rw, const char *fmt, va_list *ap);
 int __scanf_core_float (ReadWriteInfo *rw, const char *fmt, va_list ap, unsigned int flags);
 int __scanf_core_int (ReadWriteInfo *rw, const char *fmt, va_list ap, unsigned int flags);
-
-extern FILE *__stdin;
-extern FILE *__stdout;
-extern FILE *__stderr;
 
 #ifdef __cplusplus
 }

--- a/stdc/kprintf.c
+++ b/stdc/kprintf.c
@@ -1,5 +1,5 @@
 #include <stdarg.h>
-#include <stdlib.h>
+#include <stddef.h>
 #include <low/_stdio.h>
 #include <mips/uart_cbus.h>
 

--- a/stdc/snprintf.c
+++ b/stdc/snprintf.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <stdarg.h>
 #include <low/_stdio.h>
 

--- a/stdc/stdlib/qsort.c
+++ b/stdc/stdlib/qsort.c
@@ -38,7 +38,7 @@
 ******************************************************************************/
 
 
-#include <stdlib.h>
+#include <stddef.h>
 
 static void swap(char *p, char *q, unsigned int width);
 

--- a/stdc/string/bzero.c
+++ b/stdc/string/bzero.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 /*
  * bzero -- vax movc5 instruction

--- a/stdc/string/memchr.c
+++ b/stdc/string/memchr.c
@@ -31,7 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 void *
 memchr(const void *s, int c, size_t n)

--- a/stdc/string/memcpy.c
+++ b/stdc/string/memcpy.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/types.h>
+#include <stdc.h>
 
 /*
  * This is designed to be small, not fast.

--- a/stdc/string/memset.c
+++ b/stdc/string/memset.c
@@ -31,7 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 void *
 memset(void *dst, int c, size_t n)

--- a/stdc/string/strcmp.c
+++ b/stdc/string/strcmp.c
@@ -32,7 +32,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 /*
  * Compare strings.

--- a/stdc/string/strcspn.c
+++ b/stdc/string/strcspn.c
@@ -31,7 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 /*
  * Span the complement of string s2.

--- a/stdc/string/strlcat.c
+++ b/stdc/string/strlcat.c
@@ -16,8 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/types.h>
-#include <string.h>
+#include <stdc.h>
 
 /*
  * Appends src to string dst of size dsize (unlike strncat, dsize is the

--- a/stdc/string/strlcpy.c
+++ b/stdc/string/strlcpy.c
@@ -16,8 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/types.h>
-#include <string.h>
+#include <stdc.h>
 
 /*
  * Copy string src to buffer dst of size dsize.  At most dsize-1

--- a/stdc/string/strlen.c
+++ b/stdc/string/strlen.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 size_t
 strlen(const char *str)

--- a/stdc/string/strncmp.c
+++ b/stdc/string/strncmp.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 int
 strncmp(const char *s1, const char *s2, size_t n)

--- a/stdc/string/strsep.c
+++ b/stdc/string/strsep.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 /*
  * Get next token from string *stringp, where tokens are possibly-empty

--- a/stdc/string/strspn.c
+++ b/stdc/string/strspn.c
@@ -28,7 +28,7 @@
  * SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdc.h>
 
 /*
  * Span the string s2 (skip characters that are in s2).

--- a/stdc/wctomb.c
+++ b/stdc/wctomb.c
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <stddef.h>
 
 int wctomb(char *s, wchar_t wchar __attribute__((unused))) {
   return (s == NULL) ? 0 : -1;

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -5,7 +5,6 @@
 #include <vm_map.h>
 #include <vm_pager.h>
 #include <thread.h>
-#include <string.h>
 #include <errno.h>
 #include <sync.h>
 #include <filedesc.h>

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -1,6 +1,5 @@
 #include <mount.h>
 #include <stdc.h>
-#include <string.h>
 #include <errno.h>
 #include <malloc.h>
 #include <vnode.h>


### PR DESCRIPTION
As requested, this branch gets the kernel to compile in a fully free-standing environment. This is achieved with a combination of `-ffreestanding` and `-nostdinc` flags. However, as `-nostdinc` disables too much, the build script will query `gcc` about it's install dir, and will manually add include directories where compiler headers (not standard library headers) are located.

I've had to include some extra type definitions to `common.h`. It also turned out that the main user of standard library headers is `_stdio.h`, and it pulls ~20 headers as dependencies; so I've stripped it down from various functions we don't use anyway, so that it no longer requires that many type definitions.