### PR TITLE
Basic lseek and fstat interface

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,7 @@ IncludeCategories:
     Priority:        3
   - Regex:           '.*'
     Priority:        1
-IndentCaseLabels: false
+IndentCaseLabels: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/include/common.h
+++ b/include/common.h
@@ -9,11 +9,16 @@
 
 typedef unsigned long vm_addr_t;
 typedef unsigned long pm_addr_t;
-typedef unsigned long off_t;
-typedef unsigned long ssize_t;
-typedef unsigned long uid_t;
-typedef unsigned long gid_t;
-typedef unsigned long ino_t;
+
+typedef long off_t;
+typedef long ssize_t;
+typedef int32_t pid_t;
+typedef uint32_t dev_t;
+typedef uint16_t uid_t;
+typedef uint16_t gid_t;
+typedef uint16_t mode_t;
+typedef uint16_t nlink_t;
+typedef uint32_t ino_t;
 
 /* Generic preprocessor macros */
 #define __STRING(x) #x

--- a/include/file.h
+++ b/include/file.h
@@ -9,15 +9,18 @@
 typedef struct thread thread_t;
 typedef struct file file_t;
 typedef struct vnode vnode_t;
+typedef struct vattr vattr_t;
 
 typedef int fo_read_t(file_t *f, thread_t *td, uio_t *uio);
 typedef int fo_write_t(file_t *f, thread_t *td, uio_t *uio);
 typedef int fo_close_t(file_t *f, thread_t *td);
+typedef int fo_getattr_t(file_t *f, thread_t *td, vattr_t *va);
 
 typedef struct {
   fo_read_t *fo_read;
   fo_write_t *fo_write;
   fo_close_t *fo_close;
+  fo_getattr_t *fo_getattr;
 } fileops_t;
 
 typedef enum {
@@ -40,6 +43,7 @@ typedef struct file {
   fileops_t *f_ops;
   filetype_t f_type; /* File type */
   vnode_t *f_vnode;
+  off_t f_offset;
   int f_count;      /* Reference count, ready for disposal if -1 */
   unsigned f_flags; /* File flags FF_* */
   mtx_t f_mtx;

--- a/include/vfs_syscalls.h
+++ b/include/vfs_syscalls.h
@@ -5,17 +5,22 @@
 
 typedef struct thread thread_t;
 typedef struct syscall_args syscall_args_t;
+typedef struct vattr vattr_t;
 
 /* Kernel interface */
 int do_open(thread_t *td, char *pathname, int flags, int mode, int *fd);
 int do_close(thread_t *td, int fd);
 int do_read(thread_t *td, int fd, uio_t *uio);
 int do_write(thread_t *td, int fd, uio_t *uio);
+int do_lseek(thread_t *td, int fd, off_t offset, int whence);
+int do_fstat(thread_t *td, int fd, vattr_t *buf);
 
 /* Syscall interface */
 int sys_open(thread_t *td, syscall_args_t *args);
 int sys_close(thread_t *td, syscall_args_t *args);
 int sys_read(thread_t *td, syscall_args_t *args);
 int sys_write(thread_t *td, syscall_args_t *args);
+int sys_lseek(thread_t *td, syscall_args_t *args);
+int sys_fstat(thread_t *td, syscall_args_t *args);
 
 #endif /* !_SYS_VFS_SYSCALLS_H_ */

--- a/include/vnode.h
+++ b/include/vnode.h
@@ -51,6 +51,19 @@ typedef struct vnode {
   mtx_t v_mtx;
 } vnode_t;
 
+/* This must match newlib's implementation! */
+typedef struct vattr {
+  dev_t st_dev;
+  ino_t st_ino;
+  mode_t st_mode;
+  nlink_t st_nlink;
+  uid_t st_uid;
+  gid_t st_gid;
+  dev_t st_rdev;
+  off_t st_size;
+} vattr_t;
+
+#ifdef IGNORE_NEWLIB_COMPATIBILITY
 typedef struct vattr {
   uint16_t va_mode; /* files access mode and type */
   size_t va_nlink;  /* number of references to file */
@@ -58,6 +71,7 @@ typedef struct vattr {
   gid_t va_gid;     /* owner group id */
   size_t va_size;   /* file size in bytes */
 } vattr_t;
+#endif
 
 static inline int VOP_LOOKUP(vnode_t *dv, const char *name, vnode_t **vp) {
   return dv->v_ops->v_lookup(dv, name, vp);

--- a/include/vnode.h
+++ b/include/vnode.h
@@ -51,6 +51,7 @@ typedef struct vnode {
   mtx_t v_mtx;
 } vnode_t;
 
+#if !defined(IGNORE_NEWLIB_COMPATIBILITY)
 /* This must match newlib's implementation! */
 typedef struct vattr {
   dev_t st_dev;
@@ -62,8 +63,7 @@ typedef struct vattr {
   dev_t st_rdev;
   off_t st_size;
 } vattr_t;
-
-#ifdef IGNORE_NEWLIB_COMPATIBILITY
+#else
 typedef struct vattr {
   uint16_t va_mode; /* files access mode and type */
   size_t va_nlink;  /* number of references to file */

--- a/sys/file.c
+++ b/sys/file.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <mutex.h>
 #include <thread.h>
+#include <vnode.h>
 
 static MALLOC_DEFINE(file_pool, "file pool");
 
@@ -68,8 +69,11 @@ static int badfo_close(file_t *f, struct thread *td) {
   return -EBADF;
 }
 
-fileops_t badfileops = {
-  .fo_read = badfo_read,
-  .fo_write = badfo_write,
-  .fo_close = badfo_close,
-};
+static int badfo_getattr(file_t *f, struct thread *td, vattr_t *buf) {
+  return -EBADF;
+}
+
+fileops_t badfileops = {.fo_read = badfo_read,
+                        .fo_write = badfo_write,
+                        .fo_close = badfo_close,
+                        .fo_getattr = badfo_getattr};

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -80,5 +80,5 @@ int sys_exit(thread_t *td, syscall_args_t *args) {
 /* clang-format hates long arrays. */
 sysent_t sysent[] = {
   {sys_nosys}, {sys_exit},  {sys_open},  {sys_close}, {sys_read},  {sys_write},
-  {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_sbrk},
+  {sys_lseek}, {sys_nosys}, {sys_nosys}, {sys_nosys}, {sys_fstat}, {sys_sbrk},
 };

--- a/sys/vnode.c
+++ b/sys/vnode.c
@@ -85,17 +85,17 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
   fp->f_type = FT_VNODE;
   fp->f_vnode = v;
   switch (mode) {
-  case O_RDONLY:
-    fp->f_flags = FF_READ;
-    break;
-  case O_WRONLY:
-    fp->f_flags = FF_WRITE;
-    break;
-  case O_RDWR:
-    fp->f_flags = FF_READ | FF_WRITE;
-    break;
-  default:
-    return -EINVAL;
+    case O_RDONLY:
+      fp->f_flags = FF_READ;
+      break;
+    case O_WRONLY:
+      fp->f_flags = FF_WRITE;
+      break;
+    case O_RDWR:
+      fp->f_flags = FF_READ | FF_WRITE;
+      break;
+    default:
+      return -EINVAL;
   }
   return 0;
 }


### PR DESCRIPTION
Cherry-picked from the [`doom_test3`](https://github.com/rafalcieslak/mimiker/tree/doom_test3) branch, slightly updated to reflect recent changes (error return value sign, some renamed functions).

As usual, some files I edited weren't formatted correctly.

Note that as for now no filesystems support `VOP_GETATTR`, but `cpio` eventually will.