### PR TITLE
Fixed scheduler never getting started

### DIFF
--- a/sys/startup.c
+++ b/sys/startup.c
@@ -38,7 +38,8 @@ int kernel_init(int argc, char **argv) {
 
   kprintf("[startup] kernel initialized\n");
 
-  thread_switch_to(thread_create("main", main, NULL));
+  thread_t *main_thread = thread_create("main", main, NULL);
+  sched_add(main_thread);
 
   sched_run();
 }


### PR DESCRIPTION
I've noticed that when kernel tests are running, the scheduler was not started (`sched_active` is `false`). This makes it impossible to use conditional variables in tests, and these would be very useful for verifying multi-threaded tests.

Apparently the `sched_run()` that appears in `kernel_init` was never called, because it was preceded by a `thread_switch_to`. I've fixed this so that the `"main"` thread is properly registered in the scheduler, and then `sched_run()` is called.