### PR TITLE
Replaced callout tests

### DIFF
--- a/include/callout.h
+++ b/include/callout.h
@@ -28,6 +28,13 @@ void callout_init();
 void callout_setup(callout_t *handle, realtime_t time, timeout_t fn, void *arg);
 
 /*
+ * Add a callout to the queue, using timing relative to current time.
+ * After ticks @time passed the function @fn is called with argument @arg.
+ */
+void callout_setup_relative(callout_t *handle, realtime_t time, timeout_t fn,
+                            void *arg);
+
+/*
  * Delete a callout from the queue without handling it.
  */
 void callout_stop(callout_t *handle);

--- a/sys/callout.c
+++ b/sys/callout.c
@@ -1,7 +1,9 @@
 #include <stdc.h>
 #include <callout.h>
 
-#define CALLOUT_BUCKETS 5
+/* Note: If the difference in time between ticks is greater than the number of
+   buckets, some callouts may be skipped and/or called out-of-order! */
+#define CALLOUT_BUCKETS 10
 
 #define callout_set_active(c) ((c)->c_flags |= CALLOUT_ACTIVE)
 #define callout_clear_active(c) ((c)->c_flags &= ~CALLOUT_ACTIVE)
@@ -43,6 +45,11 @@ void callout_setup(callout_t *handle, realtime_t time, timeout_t fn,
 
   log("Add callout {%p} with wakeup at %lld.", handle, handle->c_time);
   TAILQ_INSERT_TAIL(&ci.heads[index], handle, c_link);
+}
+
+void callout_setup_relative(callout_t *handle, realtime_t time, timeout_t fn,
+                            void *arg) {
+  callout_setup(handle, time + ci.last, fn, arg);
 }
 
 void callout_stop(callout_t *handle) {

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -38,7 +38,8 @@ int kernel_init(int argc, char **argv) {
 
   kprintf("[startup] kernel initialized\n");
 
-  thread_switch_to(thread_create("main", main, NULL));
+  thread_t *main_thread = thread_create("main", main, NULL);
+  sched_add(main_thread);
 
   sched_run();
 }

--- a/tests/callout.c
+++ b/tests/callout.c
@@ -7,7 +7,7 @@
 static mtx_t foo_mtx;
 static condvar_t foo_cv;
 
-static void callout_foo(void *arg) {
+static void callout_simple(void *arg) {
   kprintf("The callout got executed!\n");
 
   mtx_lock(&foo_mtx);
@@ -20,7 +20,7 @@ static int test_callout_simple() {
   cv_init(&foo_cv, "test_callout_simple CV");
 
   callout_t callout;
-  callout_setup_relative(&callout, 10, callout_foo, NULL);
+  callout_setup_relative(&callout, 10, callout_simple, NULL);
 
   mtx_lock(&foo_mtx);
   cv_wait(&foo_cv, &foo_mtx);
@@ -29,21 +29,17 @@ static int test_callout_simple() {
   return KTEST_SUCCESS;
 }
 
-KTEST_ADD(callout_simple, test_callout_simple, 0);
-
-static mtx_t bar_mtx;
-static condvar_t bar_cv;
 static int current = 0;
 
-static void callout_bar(void *arg) {
+static void callout_ordered(void *arg) {
   int n = (int)arg;
   ktest_assert(current == n);
   current++;
 
   if (current == 10) {
-    mtx_lock(&bar_mtx);
-    cv_signal(&bar_cv);
-    mtx_unlock(&bar_mtx);
+    mtx_lock(&foo_mtx);
+    cv_signal(&foo_cv);
+    mtx_unlock(&foo_mtx);
   }
 }
 
@@ -55,15 +51,16 @@ static int test_callout_order() {
   int order[10] = {2, 5, 4, 6, 9, 0, 8, 1, 3, 7};
   callout_t callouts[10];
   for (int i = 0; i < 10; i++)
-    callout_setup_relative(&callouts[i], 10 + order[i] * 2, callout_bar,
+    callout_setup_relative(&callouts[i], 10 + order[i] * 4, callout_ordered,
                            (void *)order[i]);
 
-  mtx_lock(&bar_mtx);
-  cv_wait(&bar_cv, &bar_mtx);
-  mtx_unlock(&bar_mtx);
+  mtx_lock(&foo_mtx);
+  cv_wait(&foo_cv, &foo_mtx);
+  mtx_unlock(&foo_mtx);
   ktest_assert(current == 10);
 
   return KTEST_SUCCESS;
 }
 
+KTEST_ADD(callout_simple, test_callout_simple, 0);
 KTEST_ADD(callout_order, test_callout_order, 0);

--- a/tests/callout.c
+++ b/tests/callout.c
@@ -54,7 +54,7 @@ static int test_callout_order() {
   int order[10] = {2, 5, 4, 6, 9, 0, 8, 1, 3, 7};
   callout_t callouts[10];
   for (int i = 0; i < 10; i++)
-    callout_setup_relative(&callouts[i], 10 + order[i] * 4, callout_ordered,
+    callout_setup_relative(&callouts[i], 20 + order[i] * 15, callout_ordered,
                            (void *)order[i]);
 
   mtx_lock(&foo_mtx);

--- a/tests/callout.c
+++ b/tests/callout.c
@@ -25,9 +25,45 @@ static int test_callout_simple() {
   mtx_lock(&foo_mtx);
   cv_wait(&foo_cv, &foo_mtx);
   mtx_unlock(&foo_mtx);
-  kprintf("OK\n");
 
   return KTEST_SUCCESS;
 }
 
 KTEST_ADD(callout_simple, test_callout_simple, 0);
+
+static mtx_t bar_mtx;
+static condvar_t bar_cv;
+static int current = 0;
+
+static void callout_bar(void *arg) {
+  int n = (int)arg;
+  ktest_assert(current == n);
+  current++;
+
+  if (current == 10) {
+    mtx_lock(&bar_mtx);
+    cv_signal(&bar_cv);
+    mtx_unlock(&bar_mtx);
+  }
+}
+
+static int test_callout_order() {
+  mtx_init(&foo_mtx, MTX_DEF);
+  cv_init(&foo_cv, "test_callout_order CV");
+
+  current = 0;
+  int order[10] = {2, 5, 4, 6, 9, 0, 8, 1, 3, 7};
+  callout_t callouts[10];
+  for (int i = 0; i < 10; i++)
+    callout_setup_relative(&callouts[i], 10 + order[i] * 2, callout_bar,
+                           (void *)order[i]);
+
+  mtx_lock(&bar_mtx);
+  cv_wait(&bar_cv, &bar_mtx);
+  mtx_unlock(&bar_mtx);
+  ktest_assert(current == 10);
+
+  return KTEST_SUCCESS;
+}
+
+KTEST_ADD(callout_order, test_callout_order, 0);


### PR DESCRIPTION
~~**NOTE: This branch incorporates #197, because it uses conditional variables, and these need a working scheduler!**~~

I've looked at our existing `callout` test, and it's absolute trash. It needlessly messes up internal state, and only works if we're lucky enough to have no clock interrupts appear both in the meantime and before the test.

Here are three safer tests that verify whether callouts are processed correctly, whether the order of execution is right, and whether removing callouts actually stops them from being executed. They use conditional variables to notify the main test thread from a callout-triggered function about state change.