### PR TITLE
Fixed vnode ref counting on vfs_open and vnode_generic_close

### DIFF
--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -251,5 +251,9 @@ int vfs_open(file_t *f, char *pathname, int flags, int mode) {
   error = vfs_lookup(pathname, &v);
   if (error)
     return error;
-  return VOP_OPEN(v, flags, f);
+  int res = VOP_OPEN(v, flags, f);
+  /* Drop our reference to v. We received it from vfs_lookup, but we no longer
+     need it - file f keeps its own reference to v after open. */
+  vnode_unref(v);
+  return res;
 }

--- a/sys/vnode.c
+++ b/sys/vnode.c
@@ -65,6 +65,7 @@ static int vnode_generic_write(file_t *f, thread_t *td, uio_t *uio) {
 
 static int vnode_generic_close(file_t *f, thread_t *td) {
   /* TODO: vnode closing is not meaningful yet. */
+  vnode_unref(f->f_vnode);
   return 0;
 }
 static int vnode_generic_getattr(file_t *f, thread_t *td, vattr_t *vattr) {

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -28,6 +28,7 @@ static int test_vfs() {
   ktest_assert(error == 0);
   vnode_unref(dev_zero);
 
+  ktest_assert(dev_zero->v_usecnt == 1);
   /* Ask for the same vnode multiple times and check for correct v_usecnt. */
   error = vfs_lookup("/dev/zero", &dev_zero);
   ktest_assert(error == 0);


### PR DESCRIPTION
This is a fairly simple fix for vnode ref counts that I've discovered while working on #200.