### PR TITLE
Fixed kernel_pmap test destroying kernel pmap

### DIFF
--- a/tests/pmap.c
+++ b/tests/pmap.c
@@ -38,7 +38,7 @@ static int test_kernel_pmap() {
   ktest_assert(pmap_probe(pmap, vaddr1, vaddr2, VM_PROT_NONE));
   ktest_assert(pmap_probe(pmap, vaddr2, vaddr3, VM_PROT_READ));
 
-  pmap_reset(pmap);
+  pmap_unmap(pmap, vaddr2, vaddr3);
   pm_free(pg);
 
   log("Test passed.");


### PR DESCRIPTION
This is a straight-forward fix for an obvious bug in `pmap_kernel` test, which I've found while working on #202.