### PR TITLE
Toolchain in deb package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ before_install:
  - sudo apt-get -qq update
  - sudo apt-get install -y qemu-system-mips ctags cscope wget python3-pip
  - sudo pip3 install -I pexpect
- - TOOLCHAIN=`mktemp -d toolchain.XXXXXX`
- - cd ${TOOLCHAIN}
- - wget -c http://codescape-mips-sdk.imgtec.com/components/toolchain/2016.05-03/Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz
- - tar -xf Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz
- - export PATH=$PATH:$(pwd)/mips-mti-elf/2016.05-03/bin
- - cd ..
+ - wget 163.172.141.33/deb/mipsel-unknown-elf_1.0ubuntu1_all.deb 
+ - sudo dpkg -i mipsel-unknown-elf_1.0ubuntu1_all.deb
+ - export PATH="/opt/mipsel-unknown-elf/bin/:$PATH"
+ - rm mipsel-unknown-elf_1.0ubuntu1_all.deb
 script:
  - make
  - ./run_tests.py --thorough

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
  - sudo apt-get -qq update
  - sudo apt-get install -y qemu-system-mips ctags cscope wget python3-pip
  - sudo pip3 install -I pexpect
- - wget 163.172.141.33/deb/mipsel-unknown-elf_1.0ubuntu1_all.deb 
+ - wget http://mimiker.ii.uni.wroc.pl/download/mipsel-unknown-elf_1.0ubuntu1_all.deb 
  - sudo dpkg -i mipsel-unknown-elf_1.0ubuntu1_all.deb
  - export PATH="/opt/mipsel-unknown-elf/bin/:$PATH"
  - rm mipsel-unknown-elf_1.0ubuntu1_all.deb

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -14,4 +14,4 @@ $ make && make install
 $ ct-ng build
 ```
 
-If the build succeeds the toolchain should be installed in `${HOME}/local/{$TARGET}`.
+If the build succeeds the toolchain should be installed in `${HOME}/local/${TARGET}`.

--- a/toolchain/deb/README.md
+++ b/toolchain/deb/README.md
@@ -1,0 +1,11 @@
+Toolchain packaging procedure
+---
+
+ 1. Toolchain should be installed in `${HOME}/local/$TARGET`.
+ 2. Create temporary directory named `<package-name>-<version>` and enter 
+ 3. In this directory launch `dh-make -n`,  choose indep
+ 4. Copy toolchain here `cp ${HOME}/local/$TARGET . -r`
+ 5. Copy installation script
+ `cp ${MIMIKER_TOP}/toolchain/deb/install debian/install`
+6. run `debuild -b`
+7. deb package should appear outside current directory

--- a/toolchain/deb/install
+++ b/toolchain/deb/install
@@ -1,0 +1,1 @@
+mipsel-unknown-elf/* opt/mipsel-unknown-elf/


### PR DESCRIPTION
Toolchain is installed in /opt. `$PATH` isn't touched, so `.travis.yml` exports new value.
`dh_make` is required to package.