### PR TITLE
Minor improvements to ktests output

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -30,8 +30,9 @@ def test_seed(seed, repeat=1, retry=0):
         child.terminate(True)
         return
     elif index == 1:
-        print("Test failure reported!")
-        message = child.buffer.decode("ascii")
+        print("Test failure reported!\n")
+        message = child.before.decode("ascii")
+        message += child.buffer.decode("ascii")
         try:
             while len(message) < 20000:
                 message += child.read_nonblocking(timeout=1).decode("ascii")
@@ -45,7 +46,7 @@ def test_seed(seed, repeat=1, retry=0):
               "Retrying (%d)..." % (retry + 1))
         test_seed(seed, repeat, retry + 1)
     elif index == 3:
-        print("Timeout reached.")
+        print("Timeout reached.\n")
         message = child.buffer.decode("utf-8")
         child.terminate(True)
         print(message)

--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -56,7 +56,7 @@ void ktest_failure() {
       }
     }
     kprintf("The seed used for this test order was: %ld. Start kernel with "
-            "`test=all seed=%ld, repeat=%ld` to reproduce this test case.\n",
+            "`test=all seed=%ld repeat=%ld` to reproduce this test case.\n",
             ktest_seed, ktest_seed, ktest_repeat);
   } else {
     kprintf("Failure while running single test.\n");


### PR DESCRIPTION
Some cosmetic fixes to test output display. Most importantly, I've learned about `pexpect`'s `before` which allows me to gather and print out the entire kernel output in case of a failed test - this will make it much easier to investigate travis failures.