### PR TITLE
Implemented ktests with a random integer

### DIFF
--- a/include/ktest.h
+++ b/include/ktest.h
@@ -19,17 +19,24 @@
 /* Excludes the test from being run in auto mode. This flag is only useful for
    temporarily marking some tests while debugging the testing framework. */
 #define KTEST_FLAG_BROKEN 0x08
+/* Marks that the test wishes to receive a random integer as an argument. */
+#define KTEST_FLAG_RANDINT 0x10
 
 typedef struct {
   const char test_name[KTEST_NAME_MAX];
   int (*test_func)();
   uint32_t flags;
+  uint32_t randint_max;
 } test_entry_t;
 
 void ktest_main(const char *test);
 
 #define KTEST_ADD(name, func, flags)                                           \
   test_entry_t name##_test = {#name, func, flags};                             \
+  SET_ENTRY(tests, name##_test);
+
+#define KTEST_ADD_RANDINT(name, func, flags, max)                              \
+  test_entry_t name##_test = {#name, func, flags | KTEST_FLAG_RANDINT, max};   \
   SET_ENTRY(tests, name##_test);
 
 /* These are canonical result messages printed to standard output / UART. A

--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -90,9 +90,24 @@ static int run_test(test_entry_t *t) {
             "required to run any other test.\n");
 
   current_test = t;
-  ktest_test_running_flag = 1;
-  int result = t->test_func();
-  ktest_test_running_flag = 0;
+  int result;
+  if (t->flags & KTEST_FLAG_RANDINT){
+    int (*f)(unsigned int) = t->test_func;
+    int randint = rand() % t->randint_max;
+    /* NOTE: Numbers generated here will be the same on each run, since test are
+       started in a deterministic order. This is not a bug! In fact, it allows
+       to reproduce test cases easily, just by reusing the seed.*/
+    /* TODO: Low discrepancy sampling? */
+
+    ktest_test_running_flag = 1;
+    result = f(randint);
+    ktest_test_running_flag = 0;
+  }else{
+
+    ktest_test_running_flag = 1;
+    result = t->test_func();
+    ktest_test_running_flag = 0;
+  }
   if (result == KTEST_FAILURE)
     ktest_failure();
   return result;

--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -91,7 +91,7 @@ static int run_test(test_entry_t *t) {
 
   current_test = t;
   int result;
-  if (t->flags & KTEST_FLAG_RANDINT){
+  if (t->flags & KTEST_FLAG_RANDINT) {
     int (*f)(unsigned int) = t->test_func;
     int randint = rand() % t->randint_max;
     /* NOTE: Numbers generated here will be the same on each run, since test are
@@ -102,7 +102,7 @@ static int run_test(test_entry_t *t) {
     ktest_test_running_flag = 1;
     result = f(randint);
     ktest_test_running_flag = 0;
-  }else{
+  } else {
 
     ktest_test_running_flag = 1;
     result = t->test_func();

--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -41,7 +41,7 @@ static int test_malloc() {
 
 #define MALLOC_RANDINT_PAGES 64
 static int test_malloc_random_size(unsigned int randint) {
-  if(randint == 0)
+  if (randint == 0)
     randint = 64;
 
   vm_page_t *page = pm_alloc(MALLOC_RANDINT_PAGES);
@@ -58,4 +58,5 @@ static int test_malloc_random_size(unsigned int randint) {
 }
 
 KTEST_ADD(malloc, test_malloc, 0);
-KTEST_ADD_RANDINT(malloc_randint, test_malloc_random_size, 0, MALLOC_RANDINT_PAGES * PAGESIZE);
+KTEST_ADD_RANDINT(malloc_randint, test_malloc_random_size, 0,
+                  MALLOC_RANDINT_PAGES *PAGESIZE);

--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -39,4 +39,23 @@ static int test_malloc() {
   return KTEST_SUCCESS;
 }
 
+#define MALLOC_RANDINT_PAGES 64
+static int test_malloc_random_size(unsigned int randint) {
+  if(randint == 0)
+    randint = 64;
+
+  vm_page_t *page = pm_alloc(MALLOC_RANDINT_PAGES);
+  MALLOC_DEFINE(mp, "testing memory pool");
+  kmalloc_init(mp);
+  kmalloc_add_arena(mp, page->vaddr, MALLOC_RANDINT_PAGES * PAGESIZE);
+
+  void *ptr = kmalloc(mp, randint, 0);
+  ktest_assert(ptr != NULL);
+  kfree(mp, ptr);
+
+  pm_free(page);
+  return KTEST_SUCCESS;
+}
+
 KTEST_ADD(malloc, test_malloc, 0);
+KTEST_ADD_RANDINT(malloc_randint, test_malloc_random_size, 0, MALLOC_RANDINT_PAGES * PAGESIZE);


### PR DESCRIPTION
Yet another ktest feature: Tests added with `KTEST_ADD_RANDINT` will be passed a random (deterministic) integer as an argument. The range [0..max] may be specified as an extra argument when registering the test.