### PR TITLE
Convenient ktest_assert alias

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,6 +1,7 @@
 set tcp connect-timeout 30
 target remote localhost:1234
 break main
+break assert_fail
 continue
 
 source debug/ktrace.py

--- a/include/common.h
+++ b/include/common.h
@@ -104,10 +104,12 @@ noreturn void thread_exit();
   __extension__(                                                               \
     { kprintf("[%s:%d] " FMT "\n", __FILE__, __LINE__, ##__VA_ARGS__); })
 
+void assert_fail(const char *expr, const char *file, unsigned int line);
+
 #define assert(EXPR)                                                           \
   __extension__({                                                              \
     if (!(EXPR))                                                               \
-      panic("Assertion '" __STRING(EXPR) "' failed!");                         \
+      assert_fail(__STRING(EXPR), __FILE__, __LINE__);                         \
   })
 #else
 #define log(...)

--- a/include/ktest.h
+++ b/include/ktest.h
@@ -3,6 +3,7 @@
 
 #include <linker_set.h>
 #include <stdc.h>
+#include <common.h>
 
 #define KTEST_NAME_MAX 32
 
@@ -51,6 +52,11 @@ void ktest_failure();
       ktest_failure();                                                         \
     }                                                                          \
   })
+
+#ifdef COMPILING_TESTS
+#undef assert
+#define assert(EXPR) ktest_assert(EXPR)
+#endif
 
 /* This flag is set to 1 when a kernel test is in progress, and 0 otherwise. */
 extern int ktest_test_running_flag;

--- a/include/ktest.h
+++ b/include/ktest.h
@@ -3,7 +3,6 @@
 
 #include <linker_set.h>
 #include <stdc.h>
-#include <common.h>
 
 #define KTEST_NAME_MAX 32
 
@@ -52,11 +51,6 @@ void ktest_failure();
       ktest_failure();                                                         \
     }                                                                          \
   })
-
-#ifdef COMPILING_TESTS
-#undef assert
-#define assert(EXPR) ktest_assert(EXPR)
-#endif
 
 /* This flag is set to 1 when a kernel test is in progress, and 0 otherwise. */
 extern int ktest_test_running_flag;

--- a/include/ktest.h
+++ b/include/ktest.h
@@ -41,17 +41,6 @@ void ktest_main(const char *test);
  * displays some troubleshooting info about the failing test. */
 void ktest_failure();
 
-/* This assert variant will call ktest_failure when assertion fails, which
-   prints out some useful information about the failing test case. */
-#define ktest_assert(EXPR)                                                     \
-  __extension__({                                                              \
-    if (!(EXPR)) {                                                             \
-      kprintf("Assertion '" __STRING(EXPR) "' at %s:%d failed!\n", __FILE__,   \
-              __LINE__);                                                       \
-      ktest_failure();                                                         \
-    }                                                                          \
-  })
-
 /* This flag is set to 1 when a kernel test is in progress, and 0 otherwise. */
 extern int ktest_test_running_flag;
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,6 +1,7 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
 SOURCES_C  = \
+	assert.c \
 	callout.c \
 	clock.c \
 	condvar.c \

--- a/sys/assert.c
+++ b/sys/assert.c
@@ -1,0 +1,11 @@
+#include <common.h>
+#include <stdc.h>
+#include <ktest.h>
+
+void assert_fail(const char *expr, const char *file, unsigned int line) {
+  kprintf("Assertion \"%s\" at [%s:%d] failed!", expr, file, line);
+  if (ktest_test_running_flag)
+    ktest_failure();
+  else
+    panic("Assertion failed.");
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,6 +25,8 @@ all: $(DEPFILES) libtests.a
 
 include ../Makefile.common
 
+CFLAGS += -DCOMPILING_TESTS
+
 libtests.a: $(OBJECTS)
 
 clean:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,8 +25,6 @@ all: $(DEPFILES) libtests.a
 
 include ../Makefile.common
 
-CFLAGS += -DCOMPILING_TESTS
-
 libtests.a: $(OBJECTS)
 
 clean:

--- a/tests/broken.c
+++ b/tests/broken.c
@@ -8,7 +8,7 @@ static int test_broken() {
   (void)v;
 
   /* Failing assertion */
-  ktest_assert(0);
+  assert(0);
 
   /* Failure exit code */
   return KTEST_FAILURE;

--- a/tests/callout.c
+++ b/tests/callout.c
@@ -25,7 +25,7 @@ static int current = 0;
 
 static void callout_ordered(void *arg) {
   int n = (int)arg;
-  ktest_assert(current == n);
+  assert(current == n);
   current++;
 
   if (current == 10)
@@ -41,14 +41,14 @@ static int test_callout_order() {
                            (void *)order[i]);
 
   sleepq_wait(callout_ordered, "callout_ordered");
-  ktest_assert(current == 10);
+  assert(current == 10);
 
   return KTEST_SUCCESS;
 }
 
 /* This test verifies that callouts removed with callout_stop are not run. */
 static void callout_bad(void *arg) {
-  ktest_assert(0);
+  assert(0);
 }
 
 static void callout_good(void *arg) {

--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -50,7 +50,7 @@ static int test_malloc_random_size(unsigned int randint) {
   kmalloc_add_arena(mp, page->vaddr, MALLOC_RANDINT_PAGES * PAGESIZE);
 
   void *ptr = kmalloc(mp, randint, 0);
-  ktest_assert(ptr != NULL);
+  assert(ptr != NULL);
   kfree(mp, ptr);
 
   pm_free(page);

--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -11,19 +11,19 @@ static int test_malloc() {
   kmalloc_add_arena(mp, page->vaddr, PAGESIZE);
 
   void *ptr1 = kmalloc(mp, 15, 0);
-  ktest_assert(ptr1 != NULL);
+  assert(ptr1 != NULL);
 
   void *ptr2 = kmalloc(mp, 23, 0);
-  ktest_assert(ptr2 != NULL && ptr2 > ptr1);
+  assert(ptr2 != NULL && ptr2 > ptr1);
 
   void *ptr3 = kmalloc(mp, 7, 0);
-  ktest_assert(ptr3 != NULL && ptr3 > ptr2);
+  assert(ptr3 != NULL && ptr3 > ptr2);
 
   void *ptr4 = kmalloc(mp, 2000, 0);
-  ktest_assert(ptr4 != NULL && ptr4 > ptr3);
+  assert(ptr4 != NULL && ptr4 > ptr3);
 
   void *ptr5 = kmalloc(mp, 1000, 0);
-  ktest_assert(ptr5 != NULL);
+  assert(ptr5 != NULL);
 
   kfree(mp, ptr1);
   kfree(mp, ptr2);
@@ -32,7 +32,7 @@ static int test_malloc() {
   kfree(mp, ptr5);
 
   void *ptr6 = kmalloc(mp, 2000, M_NOWAIT);
-  ktest_assert(ptr6 == NULL);
+  assert(ptr6 == NULL);
 
   pm_free(page);
 

--- a/tests/physmem.c
+++ b/tests/physmem.c
@@ -14,7 +14,7 @@ static int test_physmem() {
   for (int i = 0; i < size; i++)
     arr[i] = 42; /* Write non-zero value */
   for (int i = 0; i < size; i++)
-    ktest_assert(arr[i] == 42);
+    assert(arr[i] == 42);
 
   /* Allocate deallocate test */
   const int N = 7;
@@ -26,9 +26,9 @@ static int test_physmem() {
   for (int i = 1; i < N; i += 2)
     pm_free(pgs[i]);
 
-  ktest_assert(pre != pm_hash());
+  assert(pre != pm_hash());
   pm_free(pg);
-  ktest_assert(pre == pm_hash());
+  assert(pre == pm_hash());
 
   pre = pm_hash();
   vm_page_t *pg1 = pm_alloc(4);
@@ -37,13 +37,13 @@ static int test_physmem() {
   vm_page_t *pg4 = pm_split_alloc_page(pg3);
 
   pm_free(pg3);
-  ktest_assert(pre != pm_hash());
+  assert(pre != pm_hash());
   pm_free(pg4);
-  ktest_assert(pre != pm_hash());
+  assert(pre != pm_hash());
   pm_free(pg2);
-  ktest_assert(pre != pm_hash());
+  assert(pre != pm_hash());
   pm_free(pg1);
-  ktest_assert(pre == pm_hash());
+  assert(pre == pm_hash());
   kprintf("Tests passed\n");
   return KTEST_SUCCESS;
 }

--- a/tests/pmap.c
+++ b/tests/pmap.c
@@ -24,19 +24,19 @@ static int test_kernel_pmap() {
     for (int i = 0; i < size / sizeof(int); i++)
       *(x + i) = i;
     for (int i = 0; i < size / sizeof(int); i++)
-      ktest_assert(*(x + i) == i);
+      assert(*(x + i) == i);
 
     log("TLB after:");
     tlb_print();
   }
 
-  ktest_assert(pmap_probe(pmap, vaddr1, vaddr3, VM_PROT_READ | VM_PROT_WRITE));
+  assert(pmap_probe(pmap, vaddr1, vaddr3, VM_PROT_READ | VM_PROT_WRITE));
 
   pmap_unmap(pmap, vaddr1, vaddr2);
   pmap_protect(pmap, vaddr2, vaddr3, VM_PROT_READ);
 
-  ktest_assert(pmap_probe(pmap, vaddr1, vaddr2, VM_PROT_NONE));
-  ktest_assert(pmap_probe(pmap, vaddr2, vaddr3, VM_PROT_READ));
+  assert(pmap_probe(pmap, vaddr1, vaddr2, VM_PROT_NONE));
+  assert(pmap_probe(pmap, vaddr2, vaddr3, VM_PROT_READ));
 
   pmap_unmap(pmap, vaddr2, vaddr3);
   pm_free(pg);
@@ -67,10 +67,10 @@ static int test_user_pmap() {
   pmap_activate(pmap1);
   *ptr = 200;
   pmap_activate(pmap2);
-  ktest_assert(*ptr == 100);
+  assert(*ptr == 100);
   log("*ptr == %d", *ptr);
   pmap_activate(pmap1);
-  ktest_assert(*ptr == 200);
+  assert(*ptr == 200);
   log("*ptr == %d", *ptr);
 
   pmap_delete(pmap1);

--- a/tests/thread.c
+++ b/tests/thread.c
@@ -41,10 +41,10 @@ static int test_thread() {
 
   kprintf("Thread '%s' running.\n", thread_self()->td_name);
 
-  ktest_assert(td0 == thread_get_by_tid(td0->td_tid));
-  ktest_assert(td1 == thread_get_by_tid(td1->td_tid));
-  ktest_assert(td2 == thread_get_by_tid(td2->td_tid));
-  ktest_assert(NULL == thread_get_by_tid(1234));
+  assert(td0 == thread_get_by_tid(td0->td_tid));
+  assert(td1 == thread_get_by_tid(td1->td_tid));
+  assert(td2 == thread_get_by_tid(td2->td_tid));
+  assert(NULL == thread_get_by_tid(1234));
 
   thread_dump_all();
 

--- a/tests/uiomove.c
+++ b/tests/uiomove.c
@@ -33,9 +33,9 @@ static int test_uiomove() {
   uio.uio_resid = 8 + 5 + 12;
 
   res = uiomove(buffer1, sizeof(buffer1), &uio);
-  ktest_assert(res == 0);
+  assert(res == 0);
   res = strcmp(buffer1, "=====Example data operations.");
-  ktest_assert(res == 0);
+  assert(res == 0);
 
   /* Now, perform a READ from text, using buffer2 as data. */
   uio.uio_op = UIO_READ;
@@ -52,10 +52,10 @@ static int test_uiomove() {
   uio.uio_resid = 8 + 7 + 10;
 
   res = uiomove((char *)text, strlen(text), &uio);
-  ktest_assert(res == 0);
+  assert(res == 0);
   buffer2[37] = 0; /* Manually null-terminate */
   res = strcmp(buffer2, "Example ====string ========with data ");
-  ktest_assert(res == 0);
+  assert(res == 0);
 
   return KTEST_SUCCESS;
 }

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -10,37 +10,37 @@ static int test_vfs() {
   int error;
 
   error = vfs_lookup("/dev/SPAM", &v);
-  ktest_assert(error == -ENOENT);
+  assert(error == -ENOENT);
   error = vfs_lookup("/usr", &v);
-  ktest_assert(error == -ENOENT); /* Root filesystem not implemented yet. */
+  assert(error == -ENOENT); /* Root filesystem not implemented yet. */
   error = vfs_lookup("/", &v);
-  ktest_assert(error == 0 && v == vfs_root_vnode);
+  assert(error == 0 && v == vfs_root_vnode);
   vnode_unref(v);
   error = vfs_lookup("/dev////", &v);
-  ktest_assert(error == 0 && v == vfs_root_dev_vnode);
+  assert(error == 0 && v == vfs_root_dev_vnode);
   vnode_unref(v);
 
   vnode_t *dev_null, *dev_zero;
   error = vfs_lookup("/dev/null", &dev_null);
-  ktest_assert(error == 0);
+  assert(error == 0);
   vnode_unref(dev_null);
   error = vfs_lookup("/dev/zero", &dev_zero);
-  ktest_assert(error == 0);
+  assert(error == 0);
   vnode_unref(dev_zero);
 
-  ktest_assert(dev_zero->v_usecnt == 1);
+  assert(dev_zero->v_usecnt == 1);
   /* Ask for the same vnode multiple times and check for correct v_usecnt. */
   error = vfs_lookup("/dev/zero", &dev_zero);
-  ktest_assert(error == 0);
+  assert(error == 0);
   error = vfs_lookup("/dev/zero", &dev_zero);
-  ktest_assert(error == 0);
+  assert(error == 0);
   error = vfs_lookup("/dev/zero", &dev_zero);
-  ktest_assert(error == 0);
-  ktest_assert(dev_zero->v_usecnt == 4);
+  assert(error == 0);
+  assert(dev_zero->v_usecnt == 4);
   vnode_unref(dev_zero);
   vnode_unref(dev_zero);
   vnode_unref(dev_zero);
-  ktest_assert(dev_zero->v_usecnt == 1);
+  assert(dev_zero->v_usecnt == 1);
 
   uio_t uio;
   iovec_t iov;
@@ -59,9 +59,9 @@ static int test_vfs() {
   uio.uio_resid = sizeof(buffer);
 
   res = VOP_READ(dev_zero, &uio);
-  ktest_assert(res == 0);
-  ktest_assert(buffer[1] == 0 && buffer[10] == 0);
-  ktest_assert(uio.uio_resid == 0);
+  assert(res == 0);
+  assert(buffer[1] == 0 && buffer[10] == 0);
+  assert(uio.uio_resid == 0);
 
   /* Now write some data to /dev/null */
   uio.uio_op = UIO_WRITE;
@@ -73,15 +73,15 @@ static int test_vfs() {
   uio.uio_offset = 0;
   uio.uio_resid = sizeof(buffer);
 
-  ktest_assert(dev_null != 0);
+  assert(dev_null != 0);
   res = VOP_WRITE(dev_null, &uio);
-  ktest_assert(res == 0);
-  ktest_assert(uio.uio_resid == 0);
+  assert(res == 0);
+  assert(uio.uio_resid == 0);
 
   /* Test writing to UART */
   vnode_t *dev_uart;
   error = vfs_lookup("/dev/uart", &dev_uart);
-  ktest_assert(error == 0);
+  assert(error == 0);
   char *str = "Some string for testing UART write\n";
 
   uio.uio_op = UIO_WRITE;
@@ -94,7 +94,7 @@ static int test_vfs() {
   uio.uio_resid = iov.iov_len;
 
   res = VOP_WRITE(dev_uart, &uio);
-  ktest_assert(res == 0);
+  assert(res == 0);
 
   return KTEST_SUCCESS;
 }

--- a/tests/vm_map.c
+++ b/tests/vm_map.c
@@ -64,31 +64,31 @@ static int findspace_demo() {
   vm_addr_t t;
   int n;
   n = vm_map_findspace(umap, 0x00010000, PAGESIZE, &t);
-  ktest_assert(n == 0 && t == 0x00010000);
+  assert(n == 0 && t == 0x00010000);
 
   n = vm_map_findspace(umap, addr1, PAGESIZE, &t);
-  ktest_assert(n == 0 && t == addr2);
+  assert(n == 0 && t == addr2);
 
   n = vm_map_findspace(umap, addr1 + 20 * PAGESIZE, PAGESIZE, &t);
-  ktest_assert(n == 0 && t == addr2);
+  assert(n == 0 && t == addr2);
 
   n = vm_map_findspace(umap, addr1, 0x6000, &t);
-  ktest_assert(n == 0 && t == addr4);
+  assert(n == 0 && t == addr4);
 
   n = vm_map_findspace(umap, addr1, 0x5000, &t);
-  ktest_assert(n == 0 && t == addr2);
+  assert(n == 0 && t == addr2);
 
   /* Fill the gap exactly */
   vm_map_add_entry(umap, t, t + 0x5000, VM_PROT_NONE);
 
   n = vm_map_findspace(umap, addr1, 0x5000, &t);
-  ktest_assert(n == 0 && t == addr4);
+  assert(n == 0 && t == addr4);
 
   n = vm_map_findspace(umap, addr4, 0x6000, &t);
-  ktest_assert(n == 0 && t == addr4);
+  assert(n == 0 && t == addr4);
 
   n = vm_map_findspace(umap, 0, 0x40000000, &t);
-  ktest_assert(n == -ENOMEM);
+  assert(n == -ENOMEM);
 
   /* Restore original vm_map */
   vm_map_activate(orig);


### PR DESCRIPTION
I've recently noticed @czapiga using `assert` when writing new tests, while he should choose `ktest_assert` instead, as this variant correctly notifies the testing framework about a failure.

We can avoid this inconvenience by defining `assert` to be an alias of `ktest_assert` when compiling sources in `./tests` directory.