### PR TITLE
Removed a non-ascii character from kmalloc_dump

### DIFF
--- a/sys/malloc.c
+++ b/sys/malloc.c
@@ -222,7 +222,7 @@ void kmalloc_dump(malloc_pool_t *mp) {
     mem_block_t *block = (void *)arena->ma_data;
     mem_block_t *end = (void *)arena->ma_data + arena->ma_size;
 
-    kprintf("[kmalloc]  malloc_arena %p – %p:\n", block, end);
+    kprintf("[kmalloc]  malloc_arena %p - %p:\n", block, end);
 
     while (block < end) {
       assert(block->mb_magic == MB_MAGIC);


### PR DESCRIPTION
The dash in:
```
"[kmalloc]  malloc_arena %p – %p:\n"
```
was a non-ascii character. This disables travis from correctly displaying failed test output!

It looks as if someone's editor used automatic fancy unicode character substitution.