### PR TITLE
Fixed test/server inconsiscency in launch script

### DIFF
--- a/launch
+++ b/launch
@@ -52,7 +52,7 @@ def configure_ovpsim(args):
                '--wallclock',
                '--kernel', args.kernel]
 
-    if args.test:
+    if args.test or args.server:
         OVPSIM_OVERRIDES['uartCBUS/console'] = 0
 
     for item in OVPSIM_OVERRIDES.items():
@@ -74,8 +74,12 @@ def configure_qemu(args):
 
     options += ['-serial', 'none',
                 '-serial', 'null',
-                '-serial', 'null',
-                '-serial', 'stdio']
+                '-serial', 'null']
+
+    if args.server:
+        options += ['-serial', 'tcp:127.0.0.1:%d,server,wait' % PORT]
+    else:
+        options += ['-serial', 'stdio']
 
     if args.debug:
         options += ['-s', '-S']
@@ -136,11 +140,16 @@ if __name__ == '__main__':
                               (', '.join(sim_choices.keys()), sim_default)))
     parser.add_argument('-t', '--test', action='store_true',
                         help='Use current stdin & stdout for simulated UART.')
+    parser.add_argument('-s', '--server', action='store_true',
+                        help='Start a server for simulated UART (port: %d).' % PORT)
 
     args = parser.parse_args()
 
     if not os.path.isfile(args.kernel):
         raise SystemExit('%s: file does not exist!' % args.kernel)
+
+    if args.server and args.test:
+        raise SystemExit('Options --server and --test are exclusive!')
 
     if args.debugger != DEFAULT_DEBUGGER:
         args.debug = True

--- a/launch
+++ b/launch
@@ -75,7 +75,6 @@ def configure_qemu(args):
     if args.test:
         options += ['-serial', 'null',
                     '-serial', 'null',
-                    '-monitor', 'stdio',
                     '-serial', 'tcp:127.0.0.1:%d,server,nowait' % PORT]
     else:
         options += ['-serial', 'none',

--- a/launch
+++ b/launch
@@ -72,15 +72,10 @@ def configure_qemu(args):
                '-kernel', args.kernel,
                '-append', ' '.join(args.args)]
 
-    if args.test:
-        options += ['-serial', 'null',
-                    '-serial', 'null',
-                    '-serial', 'tcp:127.0.0.1:%d,server,nowait' % PORT]
-    else:
-        options += ['-serial', 'none',
-                    '-serial', 'null',
-                    '-serial', 'null',
-                    '-serial', 'stdio']
+    options += ['-serial', 'none',
+                '-serial', 'null',
+                '-serial', 'null',
+                '-serial', 'stdio']
 
     if args.debug:
         options += ['-s', '-S']
@@ -166,12 +161,10 @@ if __name__ == '__main__':
                 break
             except KeyboardInterrupt:
                 gdb.send_signal(signal.SIGINT)
-    elif args.test:
+    elif args.test and args.simulator == 'ovpsim':
+        # Redirect ovpsim output from dedicated console to stdout using nc.
         sim = popen_spawn.PopenSpawn(sim_cmd)
-        if args.simulator == 'ovpsim':
-            sim.expect('Waiting for connection on port %d' % PORT, timeout=5)
-        elif args.simulator == 'qemu':
-            sim.expect('QEMU .* monitor', timeout=5)
+        sim.expect('Waiting for connection on port %d' % PORT, timeout=5)
         nc = subprocess.Popen(['nc', 'localhost', str(PORT)])
         while True:
             try:


### PR DESCRIPTION
This bug was originally discovered by @strzkrzysiek.

When launching the kernel using `./launch` script with `-t` option (which is useful for redirecting kernel output to another terminal or file) and `-d` option simultaneously, both qemu monitor and gdb interface will hook to the same terminal, and will share input/output, making it impossible to enter gdb commands.

This patch disables the qemu monitor in test mode - we do not use the monitor interface anyway.