### PR TITLE
Automatically inspect kernel state on test deadlock

### DIFF
--- a/launch
+++ b/launch
@@ -70,7 +70,8 @@ def configure_qemu(args):
                '-machine', 'malta',
                '-cpu', '24Kf',
                '-kernel', args.kernel,
-               '-append', ' '.join(args.args)]
+               '-append', ' '.join(args.args),
+               '-gdb', 'tcp::1234']
 
     options += ['-serial', 'none',
                 '-serial', 'null',
@@ -82,7 +83,7 @@ def configure_qemu(args):
         options += ['-serial', 'stdio']
 
     if args.debug:
-        options += ['-s', '-S']
+        options += ['-S']
 
     return options
 


### PR DESCRIPTION
This is a particularly nifty feature: When test results are inconclusive because neither success nor failure were reported within timeout, the `run_tests.py` script will launch `gdb` to get some information (`info registers`, `backtrace`, `kdump threads`, etc.) about kernel state, which may give some hints on why did it hang.