### PR TITLE
Fixed idle thread always marked as running

### DIFF
--- a/sys/sched.c
+++ b/sys/sched.c
@@ -22,10 +22,13 @@ void sched_init() {
 void sched_add(thread_t *td) {
   // log("Add '%s' {%p} thread to scheduler", td->td_name, td);
 
+  td->td_state = TDS_READY;
+
+  /* Idle thread does not get inserted to the runqueue, and it does not require
+     increasing its time slice. */
   if (td == PCPU_GET(idle_thread))
     return;
 
-  td->td_state = TDS_READY;
   td->td_slice = SLICE;
   critical_enter();
 


### PR DESCRIPTION
The idle thread would always stay marked as `TDS_RUNNING`, this patch fixes this problem.