### PR TITLE
Fixed thread_exit interface

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -96,7 +96,7 @@ noreturn void thread_exit();
 #define panic(FMT, ...)                                                        \
   __extension__({                                                              \
     kprintf("[%s:%d] " FMT "\n", __FILE__, __LINE__, ##__VA_ARGS__);           \
-    thread_exit();                                                             \
+    thread_exit(-1);                                                           \
   })
 
 #ifdef DEBUG

--- a/include/thread.h
+++ b/include/thread.h
@@ -57,7 +57,7 @@ void thread_delete(thread_t *td);
 
 void thread_switch_to(thread_t *td_ready);
 
-noreturn void thread_exit();
+noreturn void thread_exit(int exitcode);
 
 /* Debugging utility that prints out the summary of all_threads contents. */
 void thread_dump_all();

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -383,6 +383,6 @@ fault:
   } else if (ktest_test_running_flag) {
     ktest_failure();
   } else {
-    thread_exit();
+    thread_exit(-1);
   }
 }

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -73,7 +73,7 @@ int sys_exit(thread_t *td, syscall_args_t *args) {
 
   kprintf("[syscall] exit(%d)\n", status);
 
-  thread_exit();
+  thread_exit(status);
   __builtin_unreachable();
 }
 


### PR DESCRIPTION
Uhm, this is what happens when I move features between multiple branches too much. Funny that the compiler did not consider this as an error.