### PR TITLE
Reduced randint range for test_malloc_random

### DIFF
--- a/tests/malloc.c
+++ b/tests/malloc.c
@@ -58,5 +58,8 @@ static int test_malloc_random_size(unsigned int randint) {
 }
 
 KTEST_ADD(malloc, test_malloc, 0);
+
+/* Reserve some memory for mem_block_t. */
+#define RESERVED 1024
 KTEST_ADD_RANDINT(malloc_randint, test_malloc_random_size, 0,
-                  MALLOC_RANDINT_PAGES *PAGESIZE);
+                  MALLOC_RANDINT_PAGES *PAGESIZE - RESERVED);


### PR DESCRIPTION
`malloc_randint` fails occasionally, when the generated random integer - used as the size of allocation - is close to the size of entire pool, because malloc is unable to fit the `mem_block_t` structure.

At b3925e8bcde231643ccb4320c8f6001884bf2025, an example offending seed is (for OVPsim):

`test=all seed=516288384 repeat=5`:

```
Running test malloc_randint.
[pmem] pm_alloc {paddr:3c0000 size:64}
[malloc.c:196] memory exhausted in 'testing memory pool'
```

This branch fixes the problem by slightly reducing the range of random integers for this test.