### PR TITLE
Improved debug log on deadlocks

### DIFF
--- a/sys/mutex.c
+++ b/sys/mutex.c
@@ -25,7 +25,7 @@ void mtx_lock(mtx_t *m) {
 
   critical_enter();
   while (m->m_owner != NULL)
-    sleepq_wait(&m->m_owner, NULL);
+    sleepq_wait(&m->m_owner, "mutex");
   m->m_owner = thread_self();
   critical_leave();
 }

--- a/sys/rwlock.c
+++ b/sys/rwlock.c
@@ -32,7 +32,7 @@ void rw_enter(rwlock_t *rw, rwo_t who) {
   critical_enter();
   if (who == RW_READER) {
     while (is_wlocked(rw) || rw->writers_waiting > 0)
-      sleepq_wait(&rw->readers, NULL);
+      sleepq_wait(&rw->readers, rw->name);
     rw->readers++;
     rw->state = RW_RLOCKED;
   } else if (who == RW_WRITER) {
@@ -42,7 +42,7 @@ void rw_enter(rwlock_t *rw, rwo_t who) {
     } else {
       rw->writers_waiting++;
       while (is_locked(rw))
-        sleepq_wait(&rw->writer, NULL);
+        sleepq_wait(&rw->writer, rw->name);
       rw->state = RW_WLOCKED;
       rw->writer = thread_self();
       rw->writers_waiting--;

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -92,6 +92,7 @@ noreturn void sched_run() {
 
   PCPU_SET(idle_thread, td);
 
+  td->td_name = "idle-thread";
   td->td_slice = 0;
   sched_active = true;
 


### PR DESCRIPTION
I find it annoying to see:

```
[sleepq.c:68] Sleep 'main' thread on '(null)' (0x801b8704)
```

while we have an interface for specifying names for wait channels. This branch improves some calls to `sleepq_wait` so that they provide meaningful name, instead of lazily passing a `NULL`.

I've also decided to rename the thread which enters `sched_run` to `idle thread`, otherwise we end up with both `kernel-main` and `main` in output logs, and one has to KNOW that `kernel-main` had become the idle thread and now functions as one.