### PR TITLE
Fixed exception level for new threads

### DIFF
--- a/mips/context.c
+++ b/mips/context.c
@@ -29,7 +29,7 @@ void ctx_init(thread_t *td, void (*target)(void *), void *arg) {
   kframe->ra = (reg_t)thread_exit;
   kframe->gp = (reg_t)gp;
   kframe->sp = (reg_t)sp;
-  kframe->sr = (reg_t)sr;
+  kframe->sr = (reg_t)sr | SR_EXL;
   kframe->a0 = (reg_t)arg;
 }
 

--- a/mips/context.c
+++ b/mips/context.c
@@ -29,8 +29,13 @@ void ctx_init(thread_t *td, void (*target)(void *), void *arg) {
   kframe->ra = (reg_t)thread_exit;
   kframe->gp = (reg_t)gp;
   kframe->sp = (reg_t)sp;
-  kframe->sr = (reg_t)sr | SR_EXL;
   kframe->a0 = (reg_t)arg;
+
+  /* Status register: Take interrupt mask and exception vector location from
+     caller's context. */
+  kframe->sr = sr & (SR_IMASK | SR_BEV);
+  /* Set Interrupt Enable and Exception Level. */
+  kframe->sr |= SR_EXL | SR_IE;
 }
 
 void uctx_init(thread_t *td, vm_addr_t pc, vm_addr_t sp) {


### PR DESCRIPTION
This is a tiny change, but it fixes a huge bug.

To understand it, please have a look at the ending of `kern_exc_leave`:

```
# [...] Restoring state

# ... and finally status register (assume EXL bit is set)
LOAD_REG($k1, SR, $sp)
mtc0    $k1, C0_STATUS

# Restore stack frame.
move    $sp, $k0

sync
eret
```

If the assumption mentioned in comment is not met, that is: EXL bit of the status register stored in saved context is **not set**, then between the `mtc0` instruction and `eret` an interrupt may arrive. This is unacceptable, because it would overwrite the just-restored context (in particular, it overwrites EPC address with the address of the `move` instruction, resulting in a endless loop over the last three instructions). That seems unlikely to happen, so here's a proof:

b3925e8bcde231643ccb4320c8f6001884bf2025, OVPsimp: `test=all seed=823261445 repeat=5`

EDIT: You can also see the problem in [this build](https://travis-ci.org/cahirwpz/mimiker/builds/215642759) for #234.

Now typically the stored SR has EXL set, because usually we store the SR value in `kern_exc_enter`. But when a new context is prepared in `ctx_init`, the contents of SR are based on current SR state - so naturally it is likely the EXL bit is 0.

The reason we've not observed this issue until now is because this problem may only occur on the very first `ctx_switch -> kern_exc_leave` for a new thread, and it requires the interrupt to come at a very precise moment - which happens very rarely. So it only goes to show how much have our testing procedures improved that we are able to catch such an obscure problem.

This fix ensures SR EXL bit is set for all fresh contexts.