### PR TITLE
Fix deadlock on zombie_threads_mtx

### DIFF
--- a/include/thread.h
+++ b/include/thread.h
@@ -6,6 +6,8 @@
 #include <context.h>
 #include <exception.h>
 #include <sleepq.h>
+#include <mutex.h>
+#include <condvar.h>
 
 typedef uint8_t td_prio_t;
 typedef uint32_t tid_t;
@@ -25,6 +27,9 @@ typedef struct thread {
   TAILQ_ENTRY(thread) td_zombieq; /* a link on zombie queue */
   char *td_name;
   tid_t td_tid;
+  /* Locks*/
+  mtx_t td_lock;
+  condvar_t td_waitcv;
   /* thread state */
   enum { TDS_INACTIVE = 0x0, TDS_WAITING, TDS_READY, TDS_RUNNING } td_state;
   uint32_t td_flags;           /* TDF_* flags */

--- a/include/thread.h
+++ b/include/thread.h
@@ -21,15 +21,16 @@ typedef struct fdtab fdtab_t;
 #define TDF_NEEDSWITCH 0x00000002 /* must switch on next opportunity */
 
 typedef struct thread {
+  /* Locks*/
+  mtx_t td_lock;
+  condvar_t td_waitcv; /* CV for thread exit, used by join */
+  /* List links */
   TAILQ_ENTRY(thread) td_all;     /* a link on all threads list */
   TAILQ_ENTRY(thread) td_runq;    /* a link on run queue */
   TAILQ_ENTRY(thread) td_sleepq;  /* a link on sleep queue */
   TAILQ_ENTRY(thread) td_zombieq; /* a link on zombie queue */
   char *td_name;
   tid_t td_tid;
-  /* Locks*/
-  mtx_t td_lock;
-  condvar_t td_waitcv;
   /* thread state */
   enum { TDS_INACTIVE = 0x0, TDS_WAITING, TDS_READY, TDS_RUNNING } td_state;
   uint32_t td_flags;           /* TDF_* flags */

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -71,7 +71,7 @@ thread_t *thread_create(const char *name, void (*fn)(void *), void *arg) {
   td->td_kstack.stk_size = PAGESIZE;
 
   mtx_init(&td->td_lock, MTX_DEF);
-  cv_init(&td->td_waitcv, "wait");
+  cv_init(&td->td_waitcv, "td_waitcv");
 
   ctx_init(td, fn, arg);
 

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -137,9 +137,9 @@ noreturn void thread_exit(int exitcode) {
   td->td_exitcode = exitcode;
   sleepq_broadcast(&td->td_exitcode);
   td->td_state = TDS_INACTIVE;
-  critical_leave();
 
   mtx_unlock(&zombie_threads_mtx);
+  critical_leave();
 
   sched_yield();
 

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -143,7 +143,7 @@ noreturn void thread_exit(int exitcode) {
   {
     td->td_exitcode = exitcode;
     td->td_state = TDS_INACTIVE;
-    cv_signal(&td->td_waitcv);
+    cv_broadcast(&td->td_waitcv);
     mtx_unlock(&td->td_lock);
   }
   critical_leave();


### PR DESCRIPTION
During `thread_exit`, the mutex on `zombie_threads` must be unlocked before critical section is left. Otherwise we risk preemption before the mutex is unlocked, and as the thread is TDS_INACTIVE, it will never resume execution - permanently blocking any other threads from locking on the mutex.

I've observed this problem several times on my local machine, but I've only managed to trigger it with QEMU, and thus I cannot provide a seed for reproducing the issue.