### PR TITLE
Minor fixes to callout tests

### DIFF
--- a/tests/callout.c
+++ b/tests/callout.c
@@ -13,9 +13,11 @@ static void callout_simple(void *arg) {
 
 static int test_callout_simple() {
   callout_t callout;
-  callout_setup_relative(&callout, 10, callout_simple, NULL);
 
+  critical_enter();
+  callout_setup_relative(&callout, 5, callout_simple, NULL);
   sleepq_wait(callout_simple, "callout_simple");
+  critical_leave();
 
   return KTEST_SUCCESS;
 }
@@ -25,9 +27,10 @@ static int test_callout_simple() {
 static int current = 0;
 
 static void callout_ordered(void *arg) {
-  int n = (int)arg;
-  assert(current == n);
+  /* Atomic increment */
+  critical_enter();
   current++;
+  critical_leave();
 
   if (current == 10)
     sleepq_signal(callout_ordered);
@@ -42,11 +45,12 @@ static int test_callout_order() {
      base time! */
   critical_enter();
   for (int i = 0; i < 10; i++)
-    callout_setup_relative(&callouts[i], 20 + order[i] * 15, callout_ordered,
+    callout_setup_relative(&callouts[i], 5 + order[i] * 5, callout_ordered,
                            (void *)order[i]);
-  critical_leave();
 
   sleepq_wait(callout_ordered, "callout_ordered");
+  critical_leave();
+
   assert(current == 10);
 
   return KTEST_SUCCESS;
@@ -64,14 +68,19 @@ static void callout_good(void *arg) {
 static int test_callout_stop() {
   current = 0;
   callout_t callout1, callout2;
-  callout_setup_relative(&callout1, 40, callout_bad, NULL);
-  callout_setup_relative(&callout2, 60, callout_good, NULL);
+
+  critical_enter();
+  
+  callout_setup_relative(&callout1, 5, callout_bad, NULL);
+  callout_setup_relative(&callout2, 10, callout_good, NULL);
 
   /* Remove callout1, hope that callout_bad won't be called! */
   callout_stop(&callout1);
 
   /* Give some time for callout_bad, wait for callout_good. */
   sleepq_wait(callout_good, "callout_good");
+  
+  critical_leave();
 
   return KTEST_SUCCESS;
 }


### PR DESCRIPTION
This branch **does not** address issues of #213! It barely fixes the callouts tests so that they won't fail when they should not. This is done in three steps:

- Wrapping callout setup and sleepq wait in a critical section. This prevents sleepq from being signalled before we get to wait on it (`sleepq_wait` takes a long time to print a debug message, so - until #239 is ready - there is some chance of preemption: [see this Travis log](https://travis-ci.org/cahirwpz/mimiker/builds/219684633)).

- Ignoring callout execution order, since we no longer care about it.

- Reducing time values. Using critical sections and ignoring order allows for tighter timing, which in turn makes the tests execute significantly faster, which is particularly observable when testing with `repeat=5`.