### PR TITLE
Implemented dev_uart_read

### DIFF
--- a/sys/dev_uart.c
+++ b/sys/dev_uart.c
@@ -22,12 +22,28 @@ static int dev_uart_write(vnode_t *t, uio_t *uio) {
 }
 
 static int dev_uart_read(vnode_t *t, uio_t *uio) {
+  char buffer[UART_BUF_MAX];
+  unsigned curr = 0;
+  while(curr < UART_BUF_MAX && curr < uio->uio_resid){
+    buffer[curr] = uart_getchar();
+    if(buffer[curr] == '\n')
+      break;
+    curr++;
+  }
+  int res = uiomove(buffer, UART_BUF_MAX - 1, uio);
+  if(res)
+    return res;
+  return 0;
+}
+
+static int dev_uart_getattr(vnode_t *t, vattr_t *buf){
   return -ENOTSUP;
 }
 
 vnodeops_t dev_uart_vnodeops = {
   .v_lookup = vnode_op_notsup,
   .v_readdir = vnode_op_notsup,
+  .v_getattr = dev_uart_getattr,
   .v_open = vnode_open_generic,
   .v_write = dev_uart_write,
   .v_read = dev_uart_read,

--- a/sys/dev_uart.c
+++ b/sys/dev_uart.c
@@ -24,19 +24,19 @@ static int dev_uart_write(vnode_t *t, uio_t *uio) {
 static int dev_uart_read(vnode_t *t, uio_t *uio) {
   char buffer[UART_BUF_MAX];
   unsigned curr = 0;
-  while(curr < UART_BUF_MAX && curr < uio->uio_resid){
+  while (curr < UART_BUF_MAX && curr < uio->uio_resid) {
     buffer[curr] = uart_getchar();
-    if(buffer[curr] == '\n')
+    if (buffer[curr] == '\n')
       break;
     curr++;
   }
   int res = uiomove(buffer, UART_BUF_MAX - 1, uio);
-  if(res)
+  if (res)
     return res;
   return 0;
 }
 
-static int dev_uart_getattr(vnode_t *t, vattr_t *buf){
+static int dev_uart_getattr(vnode_t *t, vattr_t *buf) {
   return -ENOTSUP;
 }
 

--- a/user/prog/prog.c
+++ b/user/prog/prog.c
@@ -75,6 +75,9 @@ int main(int argc, char **argv) {
   if (argc >= 2 && strcmp(argv[1], "abort_test") == 0)
     assert(0);
 
+  int x;
+  scanf("%d",&x);
+  
   sbrk_test();
   mmap_test();
 
@@ -89,7 +92,7 @@ int main(int argc, char **argv) {
   fclose(f);
 
   printf("Test complete.\n");
-
+  
   uint32_t o = 0;
   while (1) {
     o++;

--- a/user/prog/prog.c
+++ b/user/prog/prog.c
@@ -75,9 +75,6 @@ int main(int argc, char **argv) {
   if (argc >= 2 && strcmp(argv[1], "abort_test") == 0)
     assert(0);
 
-  int x;
-  scanf("%d", &x);
-
   sbrk_test();
   mmap_test();
 

--- a/user/prog/prog.c
+++ b/user/prog/prog.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
     assert(0);
 
   int x;
-  scanf("%d",&x);
-  
+  scanf("%d", &x);
+
   sbrk_test();
   mmap_test();
 
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
   fclose(f);
 
   printf("Test complete.\n");
-  
+
   uint32_t o = 0;
   while (1) {
     o++;


### PR DESCRIPTION
This is just filling in the missing glue between `uart_cbus` and `dev_uart`, so that user programs can get some bytes from uart input. 

A proper solution will require device infrastructure and terminal support - but we're far away from that.