### PR TITLE
Experiments with driver interface

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -2,6 +2,7 @@ set tcp connect-timeout 30
 target remote localhost:1234
 break main
 break assert_fail
+break kernel_init
 continue
 
 source debug/ktrace.py

--- a/include/common.h
+++ b/include/common.h
@@ -45,6 +45,9 @@ typedef uint32_t ino_t;
 #define clz(x) (__builtin_clz(x))
 #define ctz(x) (__builtin_ctz(x))
 
+#define container_of(p, type, field)                                           \
+  ((type *)((char *)(p)-offsetof(type, field)))
+
 #define abs(x)                                                                 \
   ({                                                                           \
     typeof(x) _x = (x);                                                        \

--- a/include/drivers.h
+++ b/include/drivers.h
@@ -6,24 +6,38 @@
 typedef struct device device_t;
 typedef struct driver driver_t;
 
-typedef int bus_match(device_t *dev, driver_t *drv);
+/* The match function should return 1 iff this driver may support the device. */
+typedef int bus_match_function(device_t *dev, driver_t *drv);
 
 typedef struct bus_type {
   char *name;
-  bus_match *match;
+  bus_match_function *match;
   TAILQ_HEAD(, device) devices;
-  TAILQ_HEAD(, device) drivers;
+  TAILQ_HEAD(, driver) drivers;
 } bus_type_t;
 
 typedef struct device {
-  char bus_id[100];  /* The identifier of this device in its parent bus */
-  bus_type_t *bus;   /* The bus this device sits on. */
-  driver_t *driver;  /* The driver managing this device */
-  void *driver_data; /* Driver-specific. */
+  /* Link on list of devices under a bus. */
+  TAILQ_ENTRY(device) bus_dev_entry;
+  /* Link on list of devices bound to a driver. */
+  TAILQ_ENTRY(device) drv_dev_entry;
+  /* Link on list of devices beneath our parent. */
+  TAILQ_ENTRY(device) children_entry;
+
+  char bus_id[100]; /* The identifier of this device in its parent bus */
+  bus_type_t *bus;  /* The bus this device sits on. */
+  device_t *parent; /* The parent device. */
+  TAILQ_HEAD(, device) children; /* Devices under this one. */
+  driver_t *driver;              /* The driver managing this device */
+  void *driver_data;             /* Driver-specific. */
 } device_t;
 
+/* The probe function must return 1 if the driver can support and wishes to
+   claim the device. */
 typedef int probe_function(device_t *device);
 typedef struct driver {
+  TAILQ_ENTRY(driver)
+  bus_drv_entry; /* The link on the list of all drivers working with on bus. */
   char *name;
   bus_type_t *bus; /* The type of bus this driver works with */
   TAILQ_HEAD(, device)
@@ -41,5 +55,7 @@ int bus_for_each_drv(bus_type_t *bus, void *data,
 int bus_register(bus_type_t *bus);
 int device_register(device_t *device);
 int driver_register(driver_t *driver);
+
+void register_builtin_drivers();
 
 #endif /* _SYS_DRIVERS_H_ */

--- a/include/drivers.h
+++ b/include/drivers.h
@@ -1,0 +1,45 @@
+#ifndef _SYS_DRIVERS_H_
+#define _SYS_DRIVERS_H_
+
+#include <queue.h>
+
+typedef struct device device_t;
+typedef struct driver driver_t;
+
+typedef int bus_match(device_t *dev, driver_t *drv);
+
+typedef struct bus_type {
+  char *name;
+  bus_match *match;
+  TAILQ_HEAD(, device) devices;
+  TAILQ_HEAD(, device) drivers;
+} bus_type_t;
+
+typedef struct device {
+  char bus_id[100];  /* The identifier of this device in its parent bus */
+  bus_type_t *bus;   /* The bus this device sits on. */
+  driver_t *driver;  /* The driver managing this device */
+  void *driver_data; /* Driver-specific. */
+} device_t;
+
+typedef int probe_function(device_t *device);
+typedef struct driver {
+  char *name;
+  bus_type_t *bus; /* The type of bus this driver works with */
+  TAILQ_HEAD(, device)
+  devices; /* list of devices currently bound by this driver */
+  probe_function *probe;
+} driver_t;
+
+/* Implementation for these two is provided by the driver core. Useful for
+ * writing buses. */
+int bus_for_each_dev(bus_type_t *bus, void *data,
+                     int (*fn)(device_t *, void *));
+int bus_for_each_drv(bus_type_t *bus, void *data,
+                     int (*fn)(device_t *, void *));
+
+int bus_register(bus_type_t *bus);
+int device_register(device_t *device);
+int driver_register(driver_t *driver);
+
+#endif /* _SYS_DRIVERS_H_ */

--- a/include/pci.h
+++ b/include/pci.h
@@ -2,6 +2,8 @@
 #define _PCI_H_
 
 #include <common.h>
+#include <drivers.h>
+#include <pci_drivers.h>
 
 typedef struct {
   uint16_t id;
@@ -48,13 +50,22 @@ typedef struct {
 
   unsigned nbars;
   pci_bar_t bar[6];
+
+  pci_driver_t *driver; /* The driver managing this device. */
+  device_t dev;
 } pci_device_t;
 
 typedef struct {
   unsigned ndevs;
   pci_device_t *dev;
+
 } pci_bus_t;
 
 void pci_init();
+
+void pci_bus_assign_space(pci_bus_t *pcibus, intptr_t mem_base,
+                          intptr_t io_base);
+unsigned platform_pci_bus_count();
+void platform_pci_bus_enumerate(pci_bus_t *pcibus);
 
 #endif /* _PCI_H_ */

--- a/include/pci.h
+++ b/include/pci.h
@@ -3,7 +3,8 @@
 
 #include <common.h>
 #include <drivers.h>
-#include <pci_drivers.h>
+
+typedef struct pci_driver pci_driver_t;
 
 typedef struct {
   uint16_t id;
@@ -51,17 +52,22 @@ typedef struct {
   unsigned nbars;
   pci_bar_t bar[6];
 
-  pci_driver_t *driver; /* The driver managing this device. */
-  device_t dev;
+  device_t device;
 } pci_device_t;
+
+#define device_to_pci_device(dev)                                              \
+  (pci_device_t *)container_of(dev, pci_device_t, device)
+#define driver_to_pci_driver(drv)                                              \
+  (pci_driver_t *)container_of(drv, pci_driver_t, driver)
 
 typedef struct {
   unsigned ndevs;
   pci_device_t *dev;
-
 } pci_bus_t;
 
 void pci_init();
+
+extern bus_type_t pci_bus_type;
 
 void pci_bus_assign_space(pci_bus_t *pcibus, intptr_t mem_base,
                           intptr_t io_base);

--- a/include/pci_drivers.h
+++ b/include/pci_drivers.h
@@ -1,0 +1,11 @@
+#ifndef _SYS_PCI_DRIVERS_H_
+#define _SYS_PCI_DRIVERS_H_
+
+#include <drivers.h>
+
+typedef struct pci_driver {
+  char *name;
+  driver_t driver;
+} pci_driver_t;
+
+#endif /* _SYS_PCI_DRIVERS_H_ */

--- a/include/pci_drivers.h
+++ b/include/pci_drivers.h
@@ -1,11 +1,24 @@
 #ifndef _SYS_PCI_DRIVERS_H_
 #define _SYS_PCI_DRIVERS_H_
 
+#include <pci.h>
 #include <drivers.h>
+#include <common.h>
+
+typedef struct pci_devid {
+  uint16_t vendor;
+  uint16_t device;
+} pci_devid_t;
+
+typedef int pci_probe_func(pci_device_t *dev, pci_devid_t *id);
 
 typedef struct pci_driver {
   char *name;
+  pci_devid_t *devids;
+  pci_probe_func *probe;
   driver_t driver;
 } pci_driver_t;
+
+int pci_driver_register(pci_driver_t *drv);
 
 #endif /* _SYS_PCI_DRIVERS_H_ */

--- a/mips/pci.c
+++ b/mips/pci.c
@@ -1,8 +1,6 @@
-#include <stdc.h>
 #include <mips/mips.h>
 #include <mips/malta.h>
 #include <mips/gt64120.h>
-#include <malloc.h>
 #include <pci.h>
 
 #define PCI0_CFG_ADDR_R GT_R(GT_PCI0_CFG_ADDR)
@@ -18,36 +16,10 @@
   (((dev) << PCI0_CFG_DEV_SHIFT) | ((funct) << PCI0_CFG_FUNCT_SHIFT) |         \
    ((reg) << PCI0_CFG_REG_SHIFT))
 
-static MALLOC_DEFINE(mp, "PCI bus discovery memory pool");
-
 /* For reference look at: http://wiki.osdev.org/PCI */
 
-static const pci_device_id *pci_find_device(const pci_vendor_id *vendor,
-                                            uint16_t device_id) {
-  if (vendor) {
-    const pci_device_id *device = vendor->devices;
-    while (device->name) {
-      if (device->id == device_id)
-        return device;
-      device++;
-    }
-  }
-  return NULL;
-}
-
-static const pci_vendor_id *pci_find_vendor(uint16_t vendor_id) {
-  const pci_vendor_id *vendor = pci_vendor_list;
-  while (vendor->name) {
-    if (vendor->id == vendor_id)
-      return vendor;
-    vendor++;
-  }
-  return NULL;
-}
-
-static void pci_bus_enumerate(pci_bus_t *pcibus) {
-  /* count devices & allocate memory */
-  pcibus->ndevs = 0;
+unsigned platform_pci_bus_count() {
+  unsigned ndevs = 0;
 
   for (int j = 0; j < 32; j++) {
     for (int k = 0; k < 8; k++) {
@@ -56,11 +28,13 @@ static void pci_bus_enumerate(pci_bus_t *pcibus) {
       if (PCI0_CFG_DATA_R == -1)
         continue;
 
-      pcibus->ndevs++;
+      ndevs++;
     }
   }
+  return ndevs;
+}
 
-  pcibus->dev = kmalloc(mp, sizeof(pci_device_t) * pcibus->ndevs, M_ZERO);
+void platform_pci_bus_enumerate(pci_bus_t *pcibus) {
 
   /* read device descriptions into main memory */
   for (int j = 0, n = 0; j < 32; j++) {
@@ -104,111 +78,6 @@ static void pci_bus_enumerate(pci_bus_t *pcibus) {
       }
     }
   }
-}
 
-static int pci_bar_compare(const void *a, const void *b) {
-  const pci_bar_t *bar0 = *(const pci_bar_t **)a;
-  const pci_bar_t *bar1 = *(const pci_bar_t **)b;
-
-  if (bar0->size < bar1->size)
-    return 1;
-  if (bar0->size > bar1->size)
-    return -1;
-  return 0;
-}
-
-static void pci_bus_assign_space(pci_bus_t *pcibus, intptr_t mem_base,
-                                 intptr_t io_base) {
-  /* Count PCI base address registers & allocate memory */
-  unsigned nbars = 0;
-
-  for (int j = 0; j < pcibus->ndevs; j++) {
-    pci_device_t *pcidev = &pcibus->dev[j];
-    nbars += pcidev->nbars;
-  }
-
-  pci_bar_t **bars = kmalloc(mp, sizeof(pci_bar_t *) * nbars, M_ZERO);
-
-  for (int j = 0, n = 0; j < pcibus->ndevs; j++) {
-    pci_device_t *pcidev = &pcibus->dev[j];
-    for (int i = 0; i < pcidev->nbars; i++)
-      bars[n++] = &pcidev->bar[i];
-  }
-
-  qsort(bars, nbars, sizeof(pci_bar_t *), pci_bar_compare);
-
-  for (int j = 0; j < nbars; j++) {
-    pci_bar_t *bar = bars[j];
-    if (bar->addr & PCI_BAR_IO) {
-      bar->addr |= io_base;
-      io_base += bar->size;
-    } else {
-      bar->addr |= mem_base;
-      mem_base += bar->size;
-    }
-  }
-
-  kfree(mp, bars);
-}
-
-static void pci_bus_dump(pci_bus_t *pcibus) {
-  for (int j = 0; j < pcibus->ndevs; j++) {
-    pci_device_t *pcidev = &pcibus->dev[j];
-    char devstr[16];
-
-    snprintf(devstr, sizeof(devstr), "[pci:%02x:%02x.%02x]", pcidev->addr.bus,
-             pcidev->addr.device, pcidev->addr.function);
-
-    const pci_vendor_id *vendor = pci_find_vendor(pcidev->vendor_id);
-    const pci_device_id *device = pci_find_device(vendor, pcidev->device_id);
-
-    kprintf("%s %s", devstr, pci_class_code[pcidev->class_code]);
-
-    if (vendor)
-      kprintf(" %s", vendor->name);
-    else
-      kprintf(" vendor:$%04x", pcidev->vendor_id);
-
-    if (device)
-      kprintf(" %s\n", device->name);
-    else
-      kprintf(" device:$%04x\n", pcidev->device_id);
-
-    if (pcidev->pin)
-      kprintf("%s Interrupt: pin %c routed to IRQ %d\n", devstr,
-              'A' + pcidev->pin - 1, pcidev->irq);
-
-    for (int i = 0; i < pcidev->nbars; i++) {
-      pci_bar_t *bar = &pcidev->bar[i];
-      pm_addr_t addr = bar->addr;
-      size_t size = bar->size;
-      char *type;
-
-      if (addr & PCI_BAR_IO) {
-        addr &= ~PCI_BAR_IO_MASK;
-        type = "I/O ports";
-      } else {
-        if (addr & PCI_BAR_PREFETCHABLE)
-          type = "Memory (prefetchable)";
-        else
-          type = "Memory (non-prefetchable)";
-        addr &= ~PCI_BAR_MEMORY_MASK;
-      }
-      kprintf("%s Region %d: %s at %p [size=$%x]\n", devstr, i, type,
-              (void *)addr, (unsigned)size);
-    }
-  }
-}
-
-static pci_bus_t pci_bus[1];
-
-void pci_init() {
-  vm_page_t *pg = pm_alloc(1);
-
-  kmalloc_init(mp);
-  kmalloc_add_arena(mp, pg->vaddr, PG_SIZE(pg));
-
-  pci_bus_enumerate(pci_bus);
-  pci_bus_assign_space(pci_bus, MALTA_PCI0_MEMORY_BASE, PCI_IO_SPACE_BASE);
-  pci_bus_dump(pci_bus);
+  pci_bus_assign_space(pcibus, MALTA_PCI0_MEMORY_BASE, PCI_IO_SPACE_BASE);
 }

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -8,6 +8,7 @@ SOURCES_C  = \
 	dev_null.c \
 	dev_uart.c \
 	devfs.c \
+	devices.c \
 	exception.c \
 	exec.c \
 	file.c \
@@ -19,6 +20,7 @@ SOURCES_C  = \
 	main.c \
 	malloc.c \
 	mutex.c \
+	pci_bus.c \
 	pci_ids.c \
 	pcpu.c \
 	physmem.c \

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -9,6 +9,7 @@ SOURCES_C  = \
 	dev_uart.c \
 	devfs.c \
 	devices.c \
+	drv_82371eb.c \
 	exception.c \
 	exec.c \
 	file.c \
@@ -21,6 +22,7 @@ SOURCES_C  = \
 	malloc.c \
 	mutex.c \
 	pci_bus.c \
+	pci_driver.c \
 	pci_ids.c \
 	pcpu.c \
 	physmem.c \

--- a/sys/devices.c
+++ b/sys/devices.c
@@ -1,16 +1,64 @@
 #include <drivers.h>
 #include <common.h>
 #include <stdc.h>
+#include <pci_drivers.h>
 
 int bus_register(bus_type_t *bus) {
   log("Registering a bus");
+  TAILQ_INIT(&bus->devices);
+  TAILQ_INIT(&bus->drivers);
   return 0;
 }
 int device_register(device_t *device) {
   log("Registering a device");
+
+  device->driver = NULL;
+  device->driver_data = NULL;
+  TAILQ_INIT(&device->children);
+
+  bus_type_t *bus = device->bus;
+  TAILQ_INSERT_TAIL(&bus->devices, device, bus_dev_entry);
+
+  if (device->parent)
+    TAILQ_INSERT_TAIL(&device->parent->children, device, children_entry);
+
+  driver_t *driver;
+  TAILQ_FOREACH (driver, &bus->drivers, bus_drv_entry) {
+    int res = bus->match(device, driver);
+    if (!res)
+      continue;
+    device->driver = driver;
+    res = driver->probe(device);
+    if (res)
+      goto bound;
+  }
+  device->driver = NULL;
+  return 1;
+
+bound:
+
+  TAILQ_INSERT_TAIL(&driver->devices, device, drv_dev_entry);
+
   return 0;
 }
+
 int driver_register(driver_t *driver) {
   log("Registering a driver");
+
+  TAILQ_INIT(&driver->devices);
+  TAILQ_INSERT_TAIL(&driver->bus->drivers, driver, bus_drv_entry);
+
   return 0;
+}
+
+extern pci_driver_t piix4_isa_driver;
+
+void register_builtin_drivers() {
+
+  /* TODO: Register built-in drivers, pci_drivers and buses using a linker set.
+   */
+
+  bus_register(&pci_bus_type);
+
+  pci_driver_register(&piix4_isa_driver);
 }

--- a/sys/devices.c
+++ b/sys/devices.c
@@ -1,0 +1,16 @@
+#include <drivers.h>
+#include <common.h>
+#include <stdc.h>
+
+int bus_register(bus_type_t *bus) {
+  log("Registering a bus");
+  return 0;
+}
+int device_register(device_t *device) {
+  log("Registering a device");
+  return 0;
+}
+int driver_register(driver_t *driver) {
+  log("Registering a driver");
+  return 0;
+}

--- a/sys/drv_82371eb.c
+++ b/sys/drv_82371eb.c
@@ -1,0 +1,24 @@
+#include <pci_drivers.h>
+
+/* NOTE: This file implements a driver - we'll probably want to move it to a
+   separate directory in the source tree .*/
+
+#define PCI_VENDOR_INTEL 0x8086
+#define PCI_DEVICE_82371EB_ISA 0x7110
+
+static pci_devid_t piix4_isa_ids[] = {
+  {PCI_VENDOR_INTEL, PCI_DEVICE_82371EB_ISA},
+  {0, }
+};
+
+static int piix4_isa_probe(pci_device_t* dev, pci_devid_t* id);
+
+pci_driver_t piix4_isa_driver = {
+  .name = "piix4_isa",
+  .devids = piix4_isa_ids,
+  .probe = piix4_isa_probe
+};
+
+static int piix4_isa_probe(pci_device_t* dev, pci_devid_t* id){
+  return 1;
+}

--- a/sys/pci_bus.c
+++ b/sys/pci_bus.c
@@ -1,0 +1,150 @@
+#include <pci.h>
+#include <stdc.h>
+#include <malloc.h>
+
+static MALLOC_DEFINE(mp, "PCI bus discovery memory pool");
+
+static const pci_device_id *pci_find_device(const pci_vendor_id *vendor,
+                                            uint16_t device_id) {
+  if (vendor) {
+    const pci_device_id *device = vendor->devices;
+    while (device->name) {
+      if (device->id == device_id)
+        return device;
+      device++;
+    }
+  }
+  return NULL;
+}
+
+static const pci_vendor_id *pci_find_vendor(uint16_t vendor_id) {
+  const pci_vendor_id *vendor = pci_vendor_list;
+  while (vendor->name) {
+    if (vendor->id == vendor_id)
+      return vendor;
+    vendor++;
+  }
+  return NULL;
+}
+
+static int pci_bar_compare(const void *a, const void *b) {
+  const pci_bar_t *bar0 = *(const pci_bar_t **)a;
+  const pci_bar_t *bar1 = *(const pci_bar_t **)b;
+
+  if (bar0->size < bar1->size)
+    return 1;
+  if (bar0->size > bar1->size)
+    return -1;
+  return 0;
+}
+
+void pci_bus_assign_space(pci_bus_t *pcibus, intptr_t mem_base,
+                          intptr_t io_base) {
+  /* Count PCI base address registers & allocate memory */
+  unsigned nbars = 0;
+
+  for (int j = 0; j < pcibus->ndevs; j++) {
+    pci_device_t *pcidev = &pcibus->dev[j];
+    nbars += pcidev->nbars;
+  }
+
+  pci_bar_t **bars = kmalloc(mp, sizeof(pci_bar_t *) * nbars, M_ZERO);
+
+  for (int j = 0, n = 0; j < pcibus->ndevs; j++) {
+    pci_device_t *pcidev = &pcibus->dev[j];
+    for (int i = 0; i < pcidev->nbars; i++)
+      bars[n++] = &pcidev->bar[i];
+  }
+
+  qsort(bars, nbars, sizeof(pci_bar_t *), pci_bar_compare);
+
+  for (int j = 0; j < nbars; j++) {
+    pci_bar_t *bar = bars[j];
+    if (bar->addr & PCI_BAR_IO) {
+      bar->addr |= io_base;
+      io_base += bar->size;
+    } else {
+      bar->addr |= mem_base;
+      mem_base += bar->size;
+    }
+  }
+
+  kfree(mp, bars);
+}
+
+int pci_bus_match(device_t *device, driver_t *driver) {
+  return 0;
+}
+
+static void pci_bus_dump(pci_bus_t *pcibus) {
+  for (int j = 0; j < pcibus->ndevs; j++) {
+    pci_device_t *pcidev = &pcibus->dev[j];
+    char devstr[16];
+
+    snprintf(devstr, sizeof(devstr), "[pci:%02x:%02x.%02x]", pcidev->addr.bus,
+             pcidev->addr.device, pcidev->addr.function);
+
+    const pci_vendor_id *vendor = pci_find_vendor(pcidev->vendor_id);
+    const pci_device_id *device = pci_find_device(vendor, pcidev->device_id);
+
+    kprintf("%s %s", devstr, pci_class_code[pcidev->class_code]);
+
+    if (vendor)
+      kprintf(" %s", vendor->name);
+    else
+      kprintf(" vendor:$%04x", pcidev->vendor_id);
+
+    if (device)
+      kprintf(" %s\n", device->name);
+    else
+      kprintf(" device:$%04x\n", pcidev->device_id);
+
+    if (pcidev->pin)
+      kprintf("%s Interrupt: pin %c routed to IRQ %d\n", devstr,
+              'A' + pcidev->pin - 1, pcidev->irq);
+
+    for (int i = 0; i < pcidev->nbars; i++) {
+      pci_bar_t *bar = &pcidev->bar[i];
+      pm_addr_t addr = bar->addr;
+      size_t size = bar->size;
+      char *type;
+
+      if (addr & PCI_BAR_IO) {
+        addr &= ~PCI_BAR_IO_MASK;
+        type = "I/O ports";
+      } else {
+        if (addr & PCI_BAR_PREFETCHABLE)
+          type = "Memory (prefetchable)";
+        else
+          type = "Memory (non-prefetchable)";
+        addr &= ~PCI_BAR_MEMORY_MASK;
+      }
+      kprintf("%s Region %d: %s at %p [size=$%x]\n", devstr, i, type,
+              (void *)addr, (unsigned)size);
+    }
+  }
+}
+
+bus_type_t pci_bus_type = {.name = "pci", .match = pci_bus_match};
+
+static pci_bus_t pci_bus[1];
+
+void pci_init() {
+  vm_page_t *pg = pm_alloc(1);
+
+  kmalloc_init(mp);
+  kmalloc_add_arena(mp, pg->vaddr, PG_SIZE(pg));
+
+  bus_register(&pci_bus_type);
+  pci_bus->ndevs = platform_pci_bus_count();
+  pci_bus->dev = kmalloc(mp, sizeof(pci_device_t) * pci_bus->ndevs, M_ZERO);
+  platform_pci_bus_enumerate(pci_bus);
+  pci_bus_dump(pci_bus);
+
+  for (int i = 0; i < pci_bus->ndevs; i++) {
+    pci_device_t *pcidev = &pci_bus->dev[i];
+
+    pcidev->dev.bus = &pci_bus_type;
+    device_register(&pcidev->dev);
+  }
+}

--- a/sys/pci_driver.c
+++ b/sys/pci_driver.c
@@ -1,0 +1,22 @@
+#include <pci.h>
+#include <pci_drivers.h>
+
+#include <stdc.h>
+#include <common.h>
+
+int pci_driver_probe(device_t *device) {
+  // Perform pci-specific probing
+  return 0;
+}
+
+int pci_driver_register(pci_driver_t *drv) {
+  drv->driver.name = drv->name;
+  drv->driver.bus = &pci_bus_type;
+  drv->driver.probe = pci_driver_probe;
+
+  driver_register(&drv->driver);
+  return 0;
+}
+
+// Example pci driver
+pci_driver_t vga_driver = {.name = "vga"};

--- a/sys/pci_driver.c
+++ b/sys/pci_driver.c
@@ -1,12 +1,16 @@
 #include <pci.h>
 #include <pci_drivers.h>
+#include <drivers.h>
 
 #include <stdc.h>
 #include <common.h>
 
 int pci_driver_probe(device_t *device) {
-  // Perform pci-specific probing
-  return 0;
+  pci_device_t *pcidev = device_to_pci_device(device);
+  pci_driver_t *pcidrv = driver_to_pci_driver(device->driver);
+  pci_devid_t devid = {.vendor = pcidev->vendor_id,
+                       .device = pcidev->device_id};
+  return pcidrv->probe(pcidev, &devid);
 }
 
 int pci_driver_register(pci_driver_t *drv) {
@@ -14,9 +18,5 @@ int pci_driver_register(pci_driver_t *drv) {
   drv->driver.bus = &pci_bus_type;
   drv->driver.probe = pci_driver_probe;
 
-  driver_register(&drv->driver);
-  return 0;
+  return driver_register(&drv->driver);
 }
-
-// Example pci driver
-pci_driver_t vga_driver = {.name = "vga"};

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -15,6 +15,7 @@
 #include <mount.h>
 #include <devfs.h>
 #include <initrd.h>
+#include <drivers.h>
 
 extern void main(void *);
 
@@ -24,7 +25,6 @@ int kernel_init(int argc, char **argv) {
     kprintf("%s ", argv[i]);
   kprintf("\n");
 
-  pci_init();
   callout_init();
   pmap_init();
   vm_object_init();
@@ -37,6 +37,10 @@ int kernel_init(int argc, char **argv) {
   vfs_init();
   file_init();
   fd_init();
+
+  register_builtin_drivers();
+
+  pci_init();
 
   kprintf("[startup] kernel initialized\n");
 


### PR DESCRIPTION
Here are my initial attempts at preparing a driver interface. I've decided to open this PR very early, so that you can comment on whether my direction is sound.

This interface is mostly inspired by LDD3 (https://lwn.net/Kernel/LDD3/) with some details based on FreeBSD implementation. My version is stripped down to absolute minimum, so that we have a solid hierarchy of data structures and their responsibilities, without cluttering the interface with features we won't be using right now.

At this point there is some partial support for PCI bus (for the most part I've extracted platform-independent parts from `mips/pci.c` to `sys/pci_bus.c`), PCI drivers (an example driver for `82371EB` is present, but it doesn't do anything at all) and device-driver matching and probing.

I will continue this work so that the `82371EB` actually does something useful - ideally I would use it to access the 16550 beneath it.

Note that I am **NOT** using any source code from Linux.