### PR TITLE
Uiomove offset

### DIFF
--- a/include/uio.h
+++ b/include/uio.h
@@ -22,5 +22,6 @@ typedef struct uio {
 } uio_t;
 
 int uiomove(void *buf, size_t n, uio_t *uio);
+int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio);
 
 #endif /* !_SYS_UIO_H_ */

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -195,7 +195,7 @@ static int initrd_vnode_lookup(vnode_t *vdir, const char *name, vnode_t **res) {
 static int initrd_vnode_read(vnode_t *v, uio_t *uio) {
   cpio_node_t *cn = (cpio_node_t *)v->v_data;
   int count = uio->uio_resid;
-  int error = uiomove(cn->c_data + uio->uio_offset, cn->c_size, uio);
+  int error = uiomove_frombuf(cn->c_data, cn->c_size, uio);
 
   if (error < 0)
     return -error;

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -195,7 +195,7 @@ static int initrd_vnode_lookup(vnode_t *vdir, const char *name, vnode_t **res) {
 static int initrd_vnode_read(vnode_t *v, uio_t *uio) {
   cpio_node_t *cn = (cpio_node_t *)v->v_data;
   int count = uio->uio_resid;
-  int error = uiomove(cn->c_data+uio->uio_offset, cn->c_size, uio);
+  int error = uiomove(cn->c_data + uio->uio_offset, cn->c_size, uio);
 
   if (error < 0)
     return -error;

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -245,6 +245,7 @@ void ramdisk_init() {
   if (rd_size) {
     initrd_ops.v_lookup = initrd_vnode_lookup;
     initrd_ops.v_read = initrd_vnode_read;
+    initrd_ops.v_open = vnode_open_generic;
     log("parsing cpio archive of %zu bytes", rd_size);
     read_cpio_archive();
     initrd_build_tree_and_names();

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -195,7 +195,7 @@ static int initrd_vnode_lookup(vnode_t *vdir, const char *name, vnode_t **res) {
 static int initrd_vnode_read(vnode_t *v, uio_t *uio) {
   cpio_node_t *cn = (cpio_node_t *)v->v_data;
   int count = uio->uio_resid;
-  int error = uiomove(cn->c_data, cn->c_size, uio);
+  int error = uiomove(cn->c_data+uio->uio_offset, cn->c_size, uio);
 
   if (error < 0)
     return -error;

--- a/sys/uio.c
+++ b/sys/uio.c
@@ -34,7 +34,7 @@ static int copyout_vmspace(vm_map_t *vm, const void *restrict kaddr,
 /* Heavily inspired by NetBSD's uiomove */
 /* This function modifies uio to reflect on the progress. */
 int uiomove(void *buf, size_t n, uio_t *uio) {
-  char *cbuf = buf + uio->uio_offset;
+  char *cbuf = buf;
   int error = 0;
 
   assert(uio->uio_op == UIO_READ || uio->uio_op == UIO_WRITE);
@@ -68,6 +68,7 @@ int uiomove(void *buf, size_t n, uio_t *uio) {
     iov->iov_base = (char *)iov->iov_base + cnt;
     iov->iov_len -= cnt;
     uio->uio_resid -= cnt;
+    uio->uio_offset += cnt;
     cbuf += cnt;
     n -= cnt;
   }

--- a/sys/uio.c
+++ b/sys/uio.c
@@ -76,3 +76,13 @@ int uiomove(void *buf, size_t n, uio_t *uio) {
   /* Invert error sign, because copy routines use negative error codes */
   return error;
 }
+
+int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio)
+{
+    size_t offset = uio->uio_offset;
+    assert(offset < buflen);
+    assert(uio->uio_offset >= 0);
+
+    return (uiomove((char *)buf + offset, buflen - offset, uio));
+}
+

--- a/sys/uio.c
+++ b/sys/uio.c
@@ -77,12 +77,10 @@ int uiomove(void *buf, size_t n, uio_t *uio) {
   return error;
 }
 
-int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio)
-{
-    size_t offset = uio->uio_offset;
-    assert(offset < buflen);
-    assert(uio->uio_offset >= 0);
+int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio) {
+  size_t offset = uio->uio_offset;
+  assert(offset < buflen);
+  assert(uio->uio_offset >= 0);
 
-    return (uiomove((char *)buf + offset, buflen - offset, uio));
+  return (uiomove((char *)buf + offset, buflen - offset, uio));
 }
-

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -37,7 +37,9 @@ int do_read(thread_t *td, int fd, uio_t *uio) {
   int res = fdtab_get_file(td->td_fdtable, fd, FF_READ, &f);
   if (res)
     return res;
+  uio->uio_offset = f->f_offset;
   res = FOP_READ(f, td, uio);
+  f->f_offset = uio->uio_offset;
   file_unref(f);
   return res;
 }
@@ -47,7 +49,9 @@ int do_write(thread_t *td, int fd, uio_t *uio) {
   int res = fdtab_get_file(td->td_fdtable, fd, FF_WRITE, &f);
   if (res)
     return res;
+  uio->uio_offset = f->f_offset;
   res = FOP_WRITE(f, td, uio);
+  f->f_offset = uio->uio_offset;
   file_unref(f);
   return res;
 }

--- a/sys/vnode.c
+++ b/sys/vnode.c
@@ -54,12 +54,10 @@ int vnode_op_notsup() {
 }
 
 static int vnode_generic_read(file_t *f, thread_t *td, uio_t *uio) {
-  uio->uio_offset += f->f_offset;
   return VOP_READ(f->f_vnode, uio);
 }
 
 static int vnode_generic_write(file_t *f, thread_t *td, uio_t *uio) {
-  uio->uio_offset += f->f_offset;
   return VOP_WRITE(f->f_vnode, uio);
 }
 

--- a/tests/uiomove.c
+++ b/tests/uiomove.c
@@ -32,7 +32,7 @@ static int test_uiomove() {
   uio.uio_offset = 0;
   uio.uio_resid = 8 + 5 + 12;
 
-  res = uiomove(buffer1+5, sizeof(buffer1)-5, &uio);
+  res = uiomove(buffer1 + 5, sizeof(buffer1) - 5, &uio);
   assert(res == 0);
   res = strcmp(buffer1, "=====Example data operations.");
   assert(res == 0);

--- a/tests/uiomove.c
+++ b/tests/uiomove.c
@@ -29,10 +29,10 @@ static int test_uiomove() {
   iov[2].iov_len = 12;
   uio.uio_iovcnt = 3;
   uio.uio_iov = &iov[0];
-  uio.uio_offset = 0;
+  uio.uio_offset = 5;
   uio.uio_resid = 8 + 5 + 12;
 
-  res = uiomove(buffer1 + 5, sizeof(buffer1) - 5, &uio);
+  res = uiomove_frombuf(buffer1, sizeof(buffer1), &uio);
   assert(res == 0);
   res = strcmp(buffer1, "=====Example data operations.");
   assert(res == 0);

--- a/tests/uiomove.c
+++ b/tests/uiomove.c
@@ -29,10 +29,10 @@ static int test_uiomove() {
   iov[2].iov_len = 12;
   uio.uio_iovcnt = 3;
   uio.uio_iov = &iov[0];
-  uio.uio_offset = 5;
+  uio.uio_offset = 0;
   uio.uio_resid = 8 + 5 + 12;
 
-  res = uiomove(buffer1, sizeof(buffer1), &uio);
+  res = uiomove(buffer1+5, sizeof(buffer1)-5, &uio);
   assert(res == 0);
   res = strcmp(buffer1, "=====Example data operations.");
   assert(res == 0);

--- a/user/fd_test/fd_test.c
+++ b/user/fd_test/fd_test.c
@@ -114,12 +114,12 @@ void test_read() {
   /* Read all at once */
   const char *contents = "This is the content of file \"file1\" in directory "
                          "\"initrd_test_files/directory1\"!";
-  assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
+  assert_open_ok(0, "/tests/initrd/directory1/file1", 0, O_RDONLY);
   assert_read_equal(0, buf, contents);
   assert_close_ok(0);
 
   /* Read in parts */
-  assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
+  assert_open_ok(0, "/tests/initrd/directory1/file1", 0, O_RDONLY);
   assert_read_equal(0, buf, "This is the ");
   assert_read_equal(0, buf, "content of file ");
   assert_read_equal(0, buf, "\"file1\" in directory ");
@@ -127,7 +127,7 @@ void test_read() {
   assert_close_ok(0);
 
   /* Read in parts, using lseek aswell */
-  assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
+  assert_open_ok(0, "/tests/initrd/directory1/file1", 0, O_RDONLY);
   assert_lseek_ok(0, strlen("This is the "), SEEK_SET);
   assert_read_equal(0, buf, "content of file ");
   assert_lseek_ok(0, strlen("This is the "), SEEK_SET);

--- a/user/fd_test/fd_test.c
+++ b/user/fd_test/fd_test.c
@@ -18,7 +18,6 @@ char buf[100];
   n = open(file, flag, 0);                                                     \
   assert(n == fd + FD_OFFSET);
 
-
 #define assert_open_fail(file, mode, flag, err)                                \
   n = open(file, flag, 0);                                                     \
   assert(n < 0);                                                               \
@@ -28,12 +27,12 @@ char buf[100];
   n = read(fd + FD_OFFSET, buf, len);                                          \
   assert(n >= 0);
 
-#define assert_read_equal(fd, buf, str)                                           \
-  {         \
-    int len = strlen(str); \
-    n = read(fd + FD_OFFSET, buf, len);                                          \
-    assert(strncmp(str, buf, len) == 0);\
-    assert(n >= 0); \
+#define assert_read_equal(fd, buf, str)                                        \
+  {                                                                            \
+    int len = strlen(str);                                                     \
+    n = read(fd + FD_OFFSET, buf, len);                                        \
+    assert(strncmp(str, buf, len) == 0);                                       \
+    assert(n >= 0);                                                            \
   }
 
 #define assert_read_fail(fd, buf, len, err)                                    \
@@ -59,8 +58,8 @@ char buf[100];
   assert(n < 0);                                                               \
   assert(errno == err);
 
-#define assert_lseek_ok(fd, offset, whence)                                   \
-  n = lseek(fd + FD_OFFSET, offset, whence);                                                     \
+#define assert_lseek_ok(fd, offset, whence)                                    \
+  n = lseek(fd + FD_OFFSET, offset, whence);                                   \
   assert(n >= 0);
 
 /* Just the basic, correct operations on a single /dev/null */
@@ -111,10 +110,10 @@ void test_readwrite() {
   assert_close_ok(2);
 }
 
-void test_read()
-{
+void test_read() {
   /* Read all at once */
-  const char *contents = "This is the content of file \"file1\" in directory \"initrd_test_files/directory1\"!";
+  const char *contents = "This is the content of file \"file1\" in directory "
+                         "\"initrd_test_files/directory1\"!";
   assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
   assert_read_equal(0, buf, contents);
   assert_close_ok(0);

--- a/user/fd_test/fd_test.c
+++ b/user/fd_test/fd_test.c
@@ -18,6 +18,7 @@ char buf[100];
   n = open(file, flag, 0);                                                     \
   assert(n == fd + FD_OFFSET);
 
+
 #define assert_open_fail(file, mode, flag, err)                                \
   n = open(file, flag, 0);                                                     \
   assert(n < 0);                                                               \
@@ -26,6 +27,14 @@ char buf[100];
 #define assert_read_ok(fd, buf, len)                                           \
   n = read(fd + FD_OFFSET, buf, len);                                          \
   assert(n >= 0);
+
+#define assert_read_equal(fd, buf, str)                                           \
+  {         \
+    int len = strlen(str); \
+    n = read(fd + FD_OFFSET, buf, len);                                          \
+    assert(strncmp(str, buf, len) == 0);\
+    assert(n >= 0); \
+  }
 
 #define assert_read_fail(fd, buf, len, err)                                    \
   n = read(fd + FD_OFFSET, buf, len);                                          \
@@ -49,6 +58,10 @@ char buf[100];
   n = close(fd + FD_OFFSET);                                                   \
   assert(n < 0);                                                               \
   assert(errno == err);
+
+#define assert_lseek_ok(fd, offset, whence)                                   \
+  n = lseek(fd + FD_OFFSET, offset, whence);                                                     \
+  assert(n >= 0);
 
 /* Just the basic, correct operations on a single /dev/null */
 void test_devnull() {
@@ -96,6 +109,33 @@ void test_readwrite() {
   assert_close_ok(0);
   assert_close_ok(1);
   assert_close_ok(2);
+}
+
+void test_read()
+{
+  /* Read all at once */
+  const char *contents = "This is the content of file \"file1\" in directory \"initrd_test_files/directory1\"!";
+  assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
+  assert_read_equal(0, buf, contents);
+  assert_close_ok(0);
+
+  /* Read in parts */
+  assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
+  assert_read_equal(0, buf, "This is the ");
+  assert_read_equal(0, buf, "content of file ");
+  assert_read_equal(0, buf, "\"file1\" in directory ");
+  assert_read_equal(0, buf, "\"initrd_test_files/directory1\"!");
+  assert_close_ok(0);
+
+  /* Read in parts, using lseek aswell */
+  assert_open_ok(0, "/initrd/tests/initrd/directory1/file1", 0, O_RDONLY);
+  assert_lseek_ok(0, strlen("This is the "), SEEK_SET);
+  assert_read_equal(0, buf, "content of file ");
+  assert_lseek_ok(0, strlen("This is the "), SEEK_SET);
+  assert_read_equal(0, buf, "content of file ");
+  assert_read_equal(0, buf, "\"file1\" in directory ");
+  assert_read_equal(0, buf, "\"initrd_test_files/directory1\"!");
+  assert_close_ok(0);
 }
 
 /* Try passing invalid pointers as arguments to open,read,write. */
@@ -152,6 +192,7 @@ void test_open_path() {
 }
 
 int main(int argc, char **argv) {
+  test_read();
   test_devnull();
   test_multiple_descriptors();
   test_readwrite();


### PR DESCRIPTION
While I've been working on getdirents syscall I had 'elegancy problem'. My implementation of getdirents system call was incredibly ugly and I couldn't really come up with elegant way of fixing it.

 I have looked into NetBSD code and noticed that it is indeed fault of our implementation of 'uiomove'. In our case `uio_offset` is IN argument of uio, while in fact this argument is 'OUT' argument supposed to show how much of the entire UIO operation was shifted. This argument is also used in setting proper file reading offsets. I can explain it in more details on seminary. Here is link to the NetBSD's implementaiton of uiomove:

http://bxr.su/NetBSD/sys/kern/subr_copy.c#99

Here is example usage in tmpfs in getdirents operation:

http://bxr.su/NetBSD/sys/fs/tmpfs/tmpfs_subr.c#807

Note how they check `uio->uio_offset` in their implementation and based on that they do something. I haven't looked into other operations, but I'm pretty confident `uio_offset` is also used there in similar way.