### PR TITLE
Increased stack size to 8 MiB

### DIFF
--- a/sys/exec.c
+++ b/sys/exec.c
@@ -223,7 +223,7 @@ int do_exec(const exec_args_t *args) {
    * when the stack underflows.
    */
   vm_addr_t stack_bottom = 0x70000000;
-  const size_t stack_size = PAGESIZE * 2;
+  const size_t stack_size = 8 * 1024 * 1024; /* 8 MiB */
 
   vm_addr_t stack_start = stack_bottom - stack_size;
   vm_addr_t stack_end = stack_bottom;


### PR DESCRIPTION
We've discussed this some long time ago, and I though I've already fixed this - but apparently not. Our user program stack is far too small and does not grow. This tiny patch increases stack size to 8MiB, which should be enough for most programs. Since the underlying pages are provided on-demand, this change has no performance penalties.