### PR TITLE
Fixed file attr structure's newlib compatibility

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -13,13 +13,13 @@ typedef unsigned long pm_addr_t;
 typedef long off_t;
 typedef long ssize_t;
 typedef int32_t pid_t;
-typedef uint32_t dev_t;
+typedef uint16_t dev_t;
 typedef uint32_t time_t;
 typedef uint16_t uid_t;
 typedef uint16_t gid_t;
-typedef uint16_t mode_t;
+typedef uint32_t mode_t;
 typedef uint16_t nlink_t;
-typedef uint32_t ino_t;
+typedef uint16_t ino_t;
 
 /* Generic preprocessor macros */
 #define __STRING(x) #x

--- a/include/vnode.h
+++ b/include/vnode.h
@@ -53,14 +53,17 @@ typedef struct vnode {
 
 #if !defined(IGNORE_NEWLIB_COMPATIBILITY)
 /* This must match newlib's implementation! */
-typedef struct vattr {
-  dev_t st_dev;
-  ino_t st_ino;
-  mode_t st_mode;
+typedef uint16_t newlib_dev_t;
+typedef uint16_t newlib_ino_t;
+typedef uint32_t newlib_mode_t;
+typedef struct __attribute__((packed)) vattr {
+  newlib_dev_t st_dev;
+  newlib_ino_t st_ino;
+  newlib_mode_t st_mode;
   nlink_t st_nlink;
   uid_t st_uid;
   gid_t st_gid;
-  dev_t st_rdev;
+  newlib_dev_t st_rdev;
   off_t st_size;
   time_t st_atime;
   time_t st_mtime;

--- a/include/vnode.h
+++ b/include/vnode.h
@@ -53,17 +53,14 @@ typedef struct vnode {
 
 #if !defined(IGNORE_NEWLIB_COMPATIBILITY)
 /* This must match newlib's implementation! */
-typedef uint16_t newlib_dev_t;
-typedef uint16_t newlib_ino_t;
-typedef uint32_t newlib_mode_t;
-typedef struct __attribute__((packed)) vattr {
-  newlib_dev_t st_dev;
-  newlib_ino_t st_ino;
-  newlib_mode_t st_mode;
+typedef struct vattr {
+  dev_t st_dev;
+  ino_t st_ino;
+  mode_t st_mode;
   nlink_t st_nlink;
   uid_t st_uid;
   gid_t st_gid;
-  newlib_dev_t st_rdev;
+  dev_t st_rdev;
   off_t st_size;
   time_t st_atime;
   time_t st_mtime;

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -11,19 +11,23 @@
 #include <mount.h>
 #include <linker_set.h>
 
+typedef uint32_t cpio_dev_t;
+typedef uint32_t cpio_ino_t;
+typedef uint16_t cpio_mode_t;
+
 /* ramdisk related data that will be stored in v_data field of vnode */
 typedef struct cpio_node {
   TAILQ_ENTRY(cpio_node) c_list; /* link to global list of all ramdisk nodes */
   TAILQ_HEAD(, cpio_node) c_children; /* head of list of direct descendants */
   TAILQ_ENTRY(cpio_node) c_siblings;  /* nodes that have the same parent */
 
-  dev_t c_dev;
-  ino_t c_ino;
-  mode_t c_mode;
+  cpio_dev_t c_dev;
+  cpio_ino_t c_ino;
+  cpio_mode_t c_mode;
   nlink_t c_nlink;
   uid_t c_uid;
   gid_t c_gid;
-  dev_t c_rdev;
+  cpio_dev_t c_rdev;
   off_t c_size;
   time_t c_mtime;
 


### PR DESCRIPTION
We've recently defined our `dev_t`, `ino_t`, `mode_t` (probably when the cpio ramdisk was introduced). Since then our `struct vattr` is no longer binary compatible with newlib's `struct stat`. This results in user programs being unable to correctly ask about file size etc! This branch fixes our vattr structure definition (in newlib compatibility mode) so that it matches newlib's layout.

I guess we'll have to eventually look into porting newlib, but until then this will be enough to get some userspace programs running correctly.