### PR TITLE
Fixed occasional deadlock on `thread_join`

### DIFF
--- a/sys/sched.c
+++ b/sys/sched.c
@@ -83,7 +83,7 @@ void sched_switch(thread_t *newtd) {
   newtd->td_state = TDS_RUNNING;
   critical_leave();
 
-  if (td != newtd){
+  if (td != newtd) {
     log("ss %lu | %lu", td->td_tid, newtd->td_tid);
     ctx_switch(td, newtd);
   }

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -83,8 +83,10 @@ void sched_switch(thread_t *newtd) {
   newtd->td_state = TDS_RUNNING;
   critical_leave();
 
-  if (td != newtd)
+  if (td != newtd){
+    log("ss %lu | %lu", td->td_tid, newtd->td_tid);
     ctx_switch(td, newtd);
+  }
 }
 
 noreturn void sched_run() {

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -82,10 +82,9 @@ void sched_switch(thread_t *newtd) {
 
   newtd->td_state = TDS_RUNNING;
 
-  if (td != newtd) {
-    // log("ss %lu | %lu", td->td_tid, newtd->td_tid);
+  if (td != newtd)
     ctx_switch(td, newtd);
-  }
+
   critical_leave();
 }
 

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -83,7 +83,7 @@ void sched_switch(thread_t *newtd) {
   newtd->td_state = TDS_RUNNING;
 
   if (td != newtd) {
-    //log("ss %lu | %lu", td->td_tid, newtd->td_tid);
+    // log("ss %lu | %lu", td->td_tid, newtd->td_tid);
     ctx_switch(td, newtd);
   }
   critical_leave();

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -81,12 +81,12 @@ void sched_switch(thread_t *newtd) {
     newtd = sched_choose();
 
   newtd->td_state = TDS_RUNNING;
-  critical_leave();
 
   if (td != newtd) {
-    log("ss %lu | %lu", td->td_tid, newtd->td_tid);
+    //log("ss %lu | %lu", td->td_tid, newtd->td_tid);
     ctx_switch(td, newtd);
   }
+  critical_leave();
 }
 
 noreturn void sched_run() {


### PR DESCRIPTION
A closer investigation uncovered that `sched_switch` is flawed and it's critical section ended too soon. Before `ctx_switch` re-disables interrupts, they are enabled for a short while by `critical_leave()`. If the thread gets preempted at that very moment, we end up with multiple threads marked as `RUNNING`, neither are added to run queue, etc. which caused the deadlock we occasionally observed in Travis results.

This fix extends the critical section until after `ctx_switch`, which prevents the described problem. I've restarted the Travis test 10+ times without a single failure.

I expect this is the last change needed to fix Travis false negatives.