### PR TITLE
Decouple console functionality from UART driver code

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -43,9 +43,9 @@ LDLIBS += -L$(TOPDIR)/sys -L$(TOPDIR)/mips -L$(TOPDIR)/stdc -L$(TOPDIR)/tests \
 	  -Wl,--start-group \
         -Wl,--whole-archive \
           -lsys \
+	  -lmips \
           -ltests \
         -Wl,--no-whole-archive \
-        -lmips \
         -lstdc \
         -lgcc \
       -Wl,--end-group

--- a/include/console.h
+++ b/include/console.h
@@ -1,0 +1,37 @@
+#ifndef _SYS_CONSOLE_H_
+#define _SYS_CONSOLE_H_
+
+#include <linker_set.h>
+
+typedef struct console console_t;
+
+typedef void (*cn_init_t)(console_t *);
+typedef int (*cn_getc_t)(console_t *);
+typedef void (*cn_putc_t)(console_t *, int);
+
+typedef struct console {
+  cn_init_t cn_init;
+  cn_getc_t cn_getc;
+  cn_putc_t cn_putc;
+  int cn_prio;
+} console_t;
+
+#define CONSOLE_DEFINE(name, prio) \
+  console_t name##_console = { \
+    .cn_init = name##_init, \
+    .cn_getc = name##_getc, \
+    .cn_putc = name##_putc, \
+    .cn_prio = (prio),\
+  }; \
+  SET_ENTRY(cn_table, name##_console)
+
+#define CONSOLE_DECLARE(name) \
+  extern console_t name##_console
+
+void cn_init();
+int cn_getc();
+void cn_putc(int c);
+int cn_puts(const char *s);
+int cn_write(const char *s, unsigned n);
+
+#endif

--- a/include/console.h
+++ b/include/console.h
@@ -16,17 +16,16 @@ typedef struct console {
   int cn_prio;
 } console_t;
 
-#define CONSOLE_DEFINE(name, prio) \
-  console_t name##_console = { \
-    .cn_init = name##_init, \
-    .cn_getc = name##_getc, \
-    .cn_putc = name##_putc, \
-    .cn_prio = (prio),\
-  }; \
+#define CONSOLE_DEFINE(name, prio)                                             \
+  console_t name##_console = {                                                 \
+    .cn_init = name##_init,                                                    \
+    .cn_getc = name##_getc,                                                    \
+    .cn_putc = name##_putc,                                                    \
+    .cn_prio = (prio),                                                         \
+  };                                                                           \
   SET_ENTRY(cn_table, name##_console)
 
-#define CONSOLE_DECLARE(name) \
-  extern console_t name##_console
+#define CONSOLE_DECLARE(name) extern console_t name##_console
 
 void cn_init();
 int cn_getc();

--- a/include/console.h
+++ b/include/console.h
@@ -16,16 +16,7 @@ typedef struct console {
   int cn_prio;
 } console_t;
 
-#define CONSOLE_DEFINE(name, prio)                                             \
-  console_t name##_console = {                                                 \
-    .cn_init = name##_init,                                                    \
-    .cn_getc = name##_getc,                                                    \
-    .cn_putc = name##_putc,                                                    \
-    .cn_prio = (prio),                                                         \
-  };                                                                           \
-  SET_ENTRY(cn_table, name##_console)
-
-#define CONSOLE_DECLARE(name) extern console_t name##_console
+#define CONSOLE_ADD(name) SET_ENTRY(cn_table, name)
 
 void cn_init();
 int cn_getc();

--- a/include/mips/uart_cbus.h
+++ b/include/mips/uart_cbus.h
@@ -1,42 +1,8 @@
-#ifndef UART_CBUS_H
-#define UART_CBUS_H
+#ifndef _UART_CBUS_H_
+#define _UART_CBUS_H_
 
-#include <stddef.h>
+#include <console.h>
 
-/*
- * Raw UART2 interface. Useful for debugging.
- * A higher-level solution will have to be implemented eventually, but
- * temporarily this should be fine.
- */
+CONSOLE_DECLARE(uart_cbus);
 
-/*
- * This procedure initializes UART.
- * It must be called (once) before any other uart_* functions.
- */
-void uart_init();
-
-/*
- * Transmits a single byte via UART1.
- * Returns the transmitted character.
- */
-int uart_putchar(int c);
-
-/*
- * Transmits a string and a trailing newline via UART1.
- * Returns the number of bytes transmitted.
- */
-int uart_puts(const char *str);
-
-/*
- * Transmits n bytes via UART1.
- * Returns the number of bytes transmitted.
- */
-int uart_write(const char *str, size_t n);
-
-/*
- * Receives a single byte from UART.
- * This function blocks execution until a byte is available.
- */
-int uart_getchar();
-
-#endif // UART_RAW_H
+#endif /* _UART_CBUS_H_ */

--- a/include/mips/uart_cbus.h
+++ b/include/mips/uart_cbus.h
@@ -1,8 +1,0 @@
-#ifndef _UART_CBUS_H_
-#define _UART_CBUS_H_
-
-#include <console.h>
-
-CONSOLE_DECLARE(uart_cbus);
-
-#endif /* _UART_CBUS_H_ */

--- a/include/stdc.h
+++ b/include/stdc.h
@@ -62,16 +62,13 @@ char *strrchr(const char *s, int c);
 char *strsep(char **stringp, const char *delim);
 size_t strspn(const char *s1, const char *s2);
 
-/* Write a formatted string to UART.
- * Equivalent to standard printf. */
+/* Write a formatted string to default console. */
 int kprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 
-/* Write a character string and a trailing newline to UART.
- * Equivalent to standard puts */
+/* Write a character string and a trailing newline to default console. */
 int kputs(const char *s);
 
-/* Write a character to UART.
- * Equivalent to standard putchar */
+/* Write a character to default console. */
 int kputchar(int c);
 
 #endif /* __STDLIB_H__ */

--- a/mips/malta.c
+++ b/mips/malta.c
@@ -4,7 +4,7 @@
 #include <mips/malta.h>
 #include <mips/intr.h>
 #include <mips/tlb.h>
-#include <mips/uart_cbus.h>
+#include <console.h>
 #include <pcpu.h>
 #include <stdc.h>
 #include <thread.h>
@@ -172,7 +172,7 @@ void platform_init(int argc, char **argv, char **envp, unsigned memsize) {
 
   setup_kenv(argc, argv, envp);
 
-  uart_init();
+  cn_init();
   pcpu_init();
   cpu_init();
   tlb_init();

--- a/mips/uart_cbus.c
+++ b/mips/uart_cbus.c
@@ -57,11 +57,9 @@ static int cbus_uart_getc(console_t *dev __unused) {
   return RBR;
 }
 
-static console_t cbus_uart_console = {
-  .cn_init = cbus_uart_init,
-  .cn_getc = cbus_uart_getc,
-  .cn_putc = cbus_uart_putc,
-  .cn_prio = 10
-};
+static console_t cbus_uart_console = {.cn_init = cbus_uart_init,
+                                      .cn_getc = cbus_uart_getc,
+                                      .cn_putc = cbus_uart_putc,
+                                      .cn_prio = 10};
 
 CONSOLE_ADD(cbus_uart_console);

--- a/mips/uart_cbus.c
+++ b/mips/uart_cbus.c
@@ -1,4 +1,6 @@
 #include <common.h>
+#include <console.h>
+#include <linker_set.h>
 #include <ns16550.h>
 #include <mips/malta.h>
 #include <mips/uart_cbus.h>
@@ -18,7 +20,7 @@
 #define LSR CBUS_UART_R(0x28) /* Line Status, read-only */
 #define MSR CBUS_UART_R(0x30) /* Modem Status, read-only */
 
-void uart_init() {
+static void cbus_uart_init(console_t *dev __unused) {
   LCR |= LCR_DLAB;
   DLM = 0;
   DLL = 1; /* 115200 */
@@ -29,7 +31,7 @@ void uart_init() {
   LCR = LCR_8BITS; /* 8-bit data, no parity */
 }
 
-int uart_putchar(int c) {
+static void cbus_uart_putc(console_t *dev __unused, int c) {
   /* Wait for transmitter hold register empty. */
   while (!(LSR & LSR_THRE))
     ;
@@ -46,33 +48,14 @@ again:
     c = '\r';
     goto again;
   }
-  return c;
 }
 
-int kputchar(int c) __attribute__((weak, alias("uart_putchar")));
-
-int uart_puts(const char *str) {
-  int n = 0;
-  while (*str) {
-    uart_putchar(*str++);
-    n++;
-  }
-  uart_putchar('\n');
-  return n + 1;
-}
-
-int kputs(const char *str) __attribute__((weak, alias("uart_puts")));
-
-int uart_write(const char *str, size_t n) {
-  while (n--)
-    uart_putchar(*str++);
-  return n;
-}
-
-int uart_getchar() {
+static int cbus_uart_getc(console_t *dev __unused) {
   /* Wait until receive data available. */
   while (!(LSR & LSR_RXRDY))
     ;
 
   return RBR;
 }
+
+CONSOLE_DEFINE(cbus_uart, 10);

--- a/mips/uart_cbus.c
+++ b/mips/uart_cbus.c
@@ -3,7 +3,6 @@
 #include <linker_set.h>
 #include <ns16550.h>
 #include <mips/malta.h>
-#include <mips/uart_cbus.h>
 
 #define CBUS_UART_R(x)                                                         \
   *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(MALTA_CBUS_UART) + (x))
@@ -58,4 +57,11 @@ static int cbus_uart_getc(console_t *dev __unused) {
   return RBR;
 }
 
-CONSOLE_DEFINE(cbus_uart, 10);
+static console_t cbus_uart_console = {
+  .cn_init = cbus_uart_init,
+  .cn_getc = cbus_uart_getc,
+  .cn_putc = cbus_uart_putc,
+  .cn_prio = 10
+};
+
+CONSOLE_ADD(cbus_uart_console);

--- a/stdc/kprintf.c
+++ b/stdc/kprintf.c
@@ -1,11 +1,11 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <low/_stdio.h>
-#include <mips/uart_cbus.h>
+#include <console.h>
 
 int __low_kprintf(ReadWriteInfo *rw __attribute__((unused)), const void *src,
                   size_t len) {
-  return uart_write(src, len);
+  return cn_write(src, len);
 }
 
 /* Print a formatted string to UART. */

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -5,8 +5,9 @@ SOURCES_C  = \
 	callout.c \
 	clock.c \
 	condvar.c \
+	console.c \
+	dev_cons.c \
 	dev_null.c \
-	dev_uart.c \
 	devfs.c \
 	exception.c \
 	exec.c \

--- a/sys/console.c
+++ b/sys/console.c
@@ -5,9 +5,13 @@
 
 static console_t *cn;
 
-static void dummy_init(console_t *dev __unused) {}
-static void dummy_putc(console_t *dev __unused, int c __unused) {}
-static int dummy_getc(console_t *dev __unused) { return 0; }
+static void dummy_init(console_t *dev __unused) {
+}
+static void dummy_putc(console_t *dev __unused, int c __unused) {
+}
+static int dummy_getc(console_t *dev __unused) {
+  return 0;
+}
 
 CONSOLE_DEFINE(dummy, -10);
 

--- a/sys/console.c
+++ b/sys/console.c
@@ -1,0 +1,50 @@
+#include <common.h>
+#include <limits.h>
+#include <console.h>
+#include <linker_set.h>
+
+static console_t *cn;
+
+static void dummy_init(console_t *dev __unused) {}
+static void dummy_putc(console_t *dev __unused, int c __unused) {}
+static int dummy_getc(console_t *dev __unused) { return 0; }
+
+CONSOLE_DEFINE(dummy, -10);
+
+void cn_init() {
+  SET_DECLARE(cn_table, console_t);
+  int prio = INT_MIN;
+  console_t **ptr;
+  SET_FOREACH(ptr, cn_table) {
+    console_t *cn_ = *ptr;
+    cn_->cn_init(cn_);
+    if (prio < cn_->cn_prio) {
+      prio = cn_->cn_prio;
+      cn = cn_;
+    }
+  }
+}
+
+void cn_putc(int c) {
+  cn->cn_putc(cn, c);
+}
+
+int cn_getc() {
+  return cn->cn_getc(cn);
+}
+
+int cn_puts(const char *str) {
+  int n = 0;
+  while (*str) {
+    cn_putc(*str++);
+    n++;
+  }
+  cn_putc('\n');
+  return n + 1;
+}
+
+int cn_write(const char *str, unsigned n) {
+  while (n--)
+    cn_putc(*str++);
+  return n;
+}

--- a/sys/console.c
+++ b/sys/console.c
@@ -13,7 +13,14 @@ static int dummy_getc(console_t *dev __unused) {
   return 0;
 }
 
-CONSOLE_DEFINE(dummy, -10);
+static console_t dummy_console = {
+  .cn_init = dummy_init,
+  .cn_getc = dummy_getc,
+  .cn_putc = dummy_putc,
+  .cn_prio = -10,
+};
+
+CONSOLE_ADD(dummy_console);
 
 void cn_init() {
   SET_DECLARE(cn_table, console_t);

--- a/sys/dev_cons.c
+++ b/sys/dev_cons.c
@@ -3,29 +3,29 @@
 #include <devfs.h>
 #include <errno.h>
 #include <uio.h>
-#include <mips/uart_cbus.h>
+#include <console.h>
 #include <linker_set.h>
 
-static vnode_t *dev_uart_device;
+static vnode_t *dev_cons_device;
 
 #define UART_BUF_MAX 100
 
-static int dev_uart_write(vnode_t *t, uio_t *uio) {
+static int dev_cons_write(vnode_t *t, uio_t *uio) {
   char buffer[UART_BUF_MAX];
   size_t n = uio->uio_resid;
   int res = uiomove(buffer, UART_BUF_MAX - 1, uio);
   if (res)
     return res;
   size_t moved = n - uio->uio_resid;
-  uart_write(buffer, moved);
+  cn_write(buffer, moved);
   return 0;
 }
 
-static int dev_uart_read(vnode_t *t, uio_t *uio) {
+static int dev_cons_read(vnode_t *t, uio_t *uio) {
   char buffer[UART_BUF_MAX];
   unsigned curr = 0;
   while (curr < UART_BUF_MAX && curr < uio->uio_resid) {
-    buffer[curr] = uart_getchar();
+    buffer[curr] = cn_getc();
     if (buffer[curr] == '\n')
       break;
     curr++;
@@ -36,22 +36,22 @@ static int dev_uart_read(vnode_t *t, uio_t *uio) {
   return 0;
 }
 
-static int dev_uart_getattr(vnode_t *t, vattr_t *buf) {
+static int dev_cons_getattr(vnode_t *t, vattr_t *buf) {
   return -ENOTSUP;
 }
 
-vnodeops_t dev_uart_vnodeops = {
+vnodeops_t dev_cons_vnodeops = {
   .v_lookup = vnode_op_notsup,
   .v_readdir = vnode_op_notsup,
-  .v_getattr = dev_uart_getattr,
+  .v_getattr = dev_cons_getattr,
   .v_open = vnode_open_generic,
-  .v_write = dev_uart_write,
-  .v_read = dev_uart_read,
+  .v_write = dev_cons_write,
+  .v_read = dev_cons_read,
 };
 
-void init_dev_uart() {
-  dev_uart_device = vnode_new(V_DEV, &dev_uart_vnodeops);
-  devfs_install("uart", dev_uart_device);
+void init_dev_cons() {
+  dev_cons_device = vnode_new(V_DEV, &dev_cons_vnodeops);
+  devfs_install("cons", dev_cons_device);
 }
 
-SET_ENTRY(devfs_init, init_dev_uart);
+SET_ENTRY(devfs_init, init_dev_cons);

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -246,9 +246,9 @@ int do_exec(const exec_args_t *args) {
   /* Before we have a working fork, let's initialize file descriptors required
      by the standard library. */
   int ignore;
-  do_open(td, "/dev/uart", O_RDONLY, 0, &ignore);
-  do_open(td, "/dev/uart", O_WRONLY, 0, &ignore);
-  do_open(td, "/dev/uart", O_WRONLY, 0, &ignore);
+  do_open(td, "/dev/cons", O_RDONLY, 0, &ignore);
+  do_open(td, "/dev/cons", O_WRONLY, 0, &ignore);
+  do_open(td, "/dev/cons", O_WRONLY, 0, &ignore);
 
   /* ... sbrk segment ... */
   sbrk_create(vmap);

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -79,8 +79,8 @@ static int test_vfs() {
   assert(uio.uio_resid == 0);
 
   /* Test writing to UART */
-  vnode_t *dev_uart;
-  error = vfs_lookup("/dev/uart", &dev_uart);
+  vnode_t *dev_cons;
+  error = vfs_lookup("/dev/cons", &dev_cons);
   assert(error == 0);
   char *str = "Some string for testing UART write\n";
 
@@ -93,7 +93,7 @@ static int test_vfs() {
   uio.uio_offset = 0;
   uio.uio_resid = iov.iov_len;
 
-  res = VOP_WRITE(dev_uart, &uio);
+  res = VOP_WRITE(dev_cons, &uio);
   assert(res == 0);
 
   return KTEST_SUCCESS;


### PR DESCRIPTION
The change aims at decoupling CBUS UART driver code from console-like device functionality. The interface is loosely based on *BSD console device interface present in [cons.h](http://bxr.su/NetBSD/sys/dev/cons.h) and described in [cons(9)](http://netbsd.gw.com/cgi-bin/man-cgi?cons+9+NetBSD-current).

To make linker sets work for files in `mips` subdirectory I had to modify top-level `Makefile` (that took me some time to figure out).

In long run I'm aiming at decoupling driver code from hardware resource with help of [bus_space(9)](http://netbsd.gw.com/cgi-bin/man-cgi?bus_space+9+NetBSD-current)-like interface which has been partially implemented in [bus-space](https://github.com/cahirwpz/mimiker/compare/bus-space) branch.