### PR TITLE
Inform the PCI bus about our space assignment

### DIFF
--- a/include/pci.h
+++ b/include/pci.h
@@ -35,7 +35,7 @@ typedef struct {
   pm_addr_t addr;
   size_t size;
   pci_device_t *dev; /* Reference to the parent device. */
-  int i; /* This BAR no in parent device. */
+  int i;             /* This BAR no in parent device. */
 } pci_bar_t;
 
 typedef struct pci_device {

--- a/include/pci.h
+++ b/include/pci.h
@@ -29,12 +29,16 @@ extern const char *pci_class_code[];
 #define PCI_BAR_IO_MASK 3
 #define PCI_BAR_MEMORY_MASK 15
 
+typedef struct pci_device pci_device_t;
+
 typedef struct {
   pm_addr_t addr;
   size_t size;
+  pci_device_t *dev; /* Reference to the parent device. */
+  int i; /* This BAR no in parent device. */
 } pci_bar_t;
 
-typedef struct {
+typedef struct pci_device {
   struct {
     uint8_t bus;
     uint8_t device;

--- a/mips/pci.c
+++ b/mips/pci.c
@@ -156,6 +156,8 @@ static void pci_bus_assign_space(pci_bus_t *pcibus, intptr_t mem_base,
     PCI0_CFG_ADDR_R =
       PCI0_CFG_ENABLE |
       PCI0_CFG_REG(bar->dev->addr.device, bar->dev->addr.function, 4 + bar->i);
+    /* It's safe to write the entire address without masking bits - only base
+       address bits are writable. */
     PCI0_CFG_DATA_R = bar->addr;
   }
 


### PR DESCRIPTION
It took me several weeks to fully debug my VGA driver on QEMU - which made me quite knowledgeable about vga, pci and memory management implementation in QEMU (phew!). My final conclusion is that the BARs on QEMU PCI are uninitialized, and therefore QEMU fails to create memory mapping when we request to enable memory access to a PCI device.

On OVPsim, BARs are (presumably) configured by bootloader/BIOS. We compute the addresses we're going to use in `pci_bus_assign_space`, and it happens that OVPsim's choice matches ours. This is not the case for QEMU, where these registers are uninitialized and contain junk values - which I do have confirmed with QEMU's sources and by tracing a lifetime of a PCI device in QEMU with a debugger, in multiple QEMU versions (2.0, 2.5, 2.8.1).

So if these registers are not initialized, we can set them up on our own. I do not know whose responsibility it *should* be, maybe the bootloader is expected to do that for us - but it does not. Either way it's probably a good idea to set these registers explicitly, so that they always match our space assignment. Without this fix no PCI device memory can be accessed using QEMU.

In some sense this patch is unnecessary, we don't use any PCI devices yet and the (non-generic) VGA driver is the only user of the PCI interface. We also expect a major rewrite to the PCI interface is just around the corner, with bus/device infrastructure coming up soon. However, I want to introduce this fix anyway, because the current implementation of `pci_bus_assign_space` is fundamentally flawed and does not serve its purpose. It will be also a good reference point, so that a proper implementation of the PCI bus interface will take this problem into account.

The other nice thing about this fix is that it is **the last patch** required to run the DOOM demo on QEMU out-of-the-box (except the VGA driver). Pretty cool! On QEMU the demo runs at above 1500 FPS, so we'll have to implement a `nanosleep` soon.