### PR TITLE
Decouple ns16550 driver code from hw resource access method

### DIFF
--- a/include/bus.h
+++ b/include/bus.h
@@ -1,0 +1,52 @@
+#ifndef _SYS_BUS_H_
+#define _SYS_BUS_H_
+
+#include <common.h>
+
+typedef struct resource resource_t;
+typedef struct bus_space bus_space_t;
+
+/* `bus space` accessor routines */
+typedef uint8_t (*bus_space_read_1_t)(resource_t *handle, unsigned offset);
+typedef void (*bus_space_write_1_t)(resource_t *handle, unsigned offset,
+                                    uint8_t value);
+
+/* `bus space` describes a method to access hardware resources mapped at some
+ * address. We make no distinction between different kinds of physical address
+ * spaces. Same hardware resource can be accessed in many different ways
+ * depending on which bus it was attached to (e.g. I/O ports vs. MMIO) */
+struct bus_space {
+  bus_space_read_1_t read_1;   /* how to read one byte? */
+  bus_space_write_1_t write_1; /* how to write one byte? */
+};
+
+#define BUS_SPACE_DEFINE(name)                                                 \
+  bus_space_t name##_bus_space[1] = {{                                         \
+    .read_1 = name##_read_1, .write_1 = name##_write_1,                        \
+  }}
+
+#define BUS_SPACE_DECLARE(name) extern bus_space_t name##_bus_space[1]
+
+/* `resource` describes a range of addresses where a resource is mapped within
+ * given bus space. A driver will use addresses from `r_start` to `r_end` and
+ * `r_bus_space` routines to access hardware resource, so that the actual
+ * driver code is not tied to way handled device is attached to the system. */
+struct resource {
+  bus_space_t *r_bus_space; /* bus space accessor descriptor */
+  intptr_t r_addr;  /* address of a set of resources mapped onto the bus */
+  intptr_t r_start; /* first address of the resource */
+  intptr_t r_end;   /* last address of the resource */
+};
+
+#define RESOURCE_DECLARE(name) extern resource_t name[1]
+
+static inline uint8_t bus_space_read_1(resource_t *handle, unsigned offset) {
+  return handle->r_bus_space->read_1(handle, offset);
+}
+
+static inline void bus_space_write_1(resource_t *handle, unsigned offset,
+                                     uint8_t value) {
+  handle->r_bus_space->write_1(handle, offset, value);
+}
+
+#endif

--- a/include/bus.h
+++ b/include/bus.h
@@ -20,12 +20,7 @@ struct bus_space {
   bus_space_write_1_t write_1; /* how to write one byte? */
 };
 
-#define BUS_SPACE_DEFINE(name)                                                 \
-  bus_space_t name##_bus_space[1] = {{                                         \
-    .read_1 = name##_read_1, .write_1 = name##_write_1,                        \
-  }}
-
-#define BUS_SPACE_DECLARE(name) extern bus_space_t name##_bus_space[1]
+#define BUS_SPACE_DECLARE(name) extern bus_space_t name[1]
 
 /* `resource` describes a range of addresses where a resource is mapped within
  * given bus space. A driver will use addresses from `r_start` to `r_end` and

--- a/include/common.h
+++ b/include/common.h
@@ -31,7 +31,6 @@ typedef uint16_t ino_t;
 #define __section(s) __attribute__((__section__(#s)))
 #define __unused __attribute__((unused))
 #define __used __attribute__((used))
-#define __weak_alias(s) __attribute__((weak, alias(#s)))
 
 /* Macros for counting and rounding. */
 #ifndef howmany

--- a/include/common.h
+++ b/include/common.h
@@ -31,6 +31,7 @@ typedef uint16_t ino_t;
 #define __section(s) __attribute__((__section__(#s)))
 #define __unused __attribute__((unused))
 #define __used __attribute__((used))
+#define __weak_alias(s) __attribute__((weak, alias(#s)))
 
 /* Macros for counting and rounding. */
 #ifndef howmany

--- a/include/ns16550.h
+++ b/include/ns16550.h
@@ -3,6 +3,18 @@
 
 /* Described in http://www.ti.com/product/pc16550d */
 
+#define RBR 0 /* Receiver Buffer, read-only, DLAB = 0 */
+#define THR 0 /* Transmitter Holding, write-only, DLAB = 0 */
+#define DLL 0 /* Divisor Latch LSB, read-write, DLAB = 1 */
+#define IER 1 /* Interrupt Enable, read-write, DLAB = 0 */
+#define DLM 1 /* Divisor Latch LSB read-write, DLAB = 1 */
+#define IIR 2 /* Interrupt Identification, read-only */
+#define FCR 2 /* FIFO Control, write-only */
+#define LCR 3 /* Line Control, read-write */
+#define MCR 4 /* Modem Control, read-write */
+#define LSR 5 /* Line Status, read-only */
+#define MSR 6 /* Modem Status, read-only */
+
 #define IER_ERXRDY 0x1
 #define IER_ETXRDY 0x2
 

--- a/mips/Makefile
+++ b/mips/Makefile
@@ -1,6 +1,6 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab:
 
-SOURCES_C = atomic.c clock.c context.c cpu.c intr.c pci.c pmap.c \
+SOURCES_C = atomic.c cbus.c clock.c context.c cpu.c intr.c pci.c pmap.c \
 	    stack.c tlb.c uart_cbus.c malta.c
 SOURCES_ASM = boot.S copy.S exc.S switch.S syscall.S tlb_ops.S ebase.S
 

--- a/mips/cbus.c
+++ b/mips/cbus.c
@@ -11,9 +11,12 @@ static void cbus_write_1(resource_t *handle, unsigned offset, uint8_t value) {
   *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(addr)) = value;
 }
 
-static BUS_SPACE_DEFINE(cbus);
+static bus_space_t cbus_bus_space = {
+  .read_1 = cbus_read_1,
+  .write_1 = cbus_write_1,
+};
 
-resource_t cbus_uart[1] = {{.r_bus_space = cbus_bus_space,
+resource_t cbus_uart[1] = {{.r_bus_space = &cbus_bus_space,
                             .r_addr = MALTA_CBUS_UART,
                             .r_start = 0,
                             .r_end = 7}};

--- a/mips/cbus.c
+++ b/mips/cbus.c
@@ -12,8 +12,7 @@ static void cbus_write_1(resource_t *handle, unsigned offset, uint8_t value) {
 }
 
 static bus_space_t cbus_bus_space = {
-  .read_1 = cbus_read_1,
-  .write_1 = cbus_write_1,
+  .read_1 = cbus_read_1, .write_1 = cbus_write_1,
 };
 
 resource_t cbus_uart[1] = {{.r_bus_space = &cbus_bus_space,

--- a/mips/cbus.c
+++ b/mips/cbus.c
@@ -1,0 +1,19 @@
+#include <mips/malta.h>
+#include <bus.h>
+
+static uint8_t cbus_read_1(resource_t *handle, unsigned offset) {
+  intptr_t addr = handle->r_addr + offset * sizeof(uint64_t);
+  return *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(addr));
+}
+
+static void cbus_write_1(resource_t *handle, unsigned offset, uint8_t value) {
+  intptr_t addr = handle->r_addr + offset * sizeof(uint64_t);
+  *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(addr)) = value;
+}
+
+static BUS_SPACE_DEFINE(cbus);
+
+resource_t cbus_uart[1] = {{.r_bus_space = cbus_bus_space,
+                            .r_addr = MALTA_CBUS_UART,
+                            .r_start = 0,
+                            .r_end = 7}};

--- a/mips/uart_cbus.c
+++ b/mips/uart_cbus.c
@@ -24,7 +24,7 @@ static void clr(unsigned offset, uint8_t mask) {
 }
 
 static bool is_set(unsigned offset, uint8_t mask) {
-  return in(offset) & mask;
+  return in(offset)&mask;
 }
 
 static void cbus_uart_init(console_t *dev __unused) {


### PR DESCRIPTION
Main purpose of this PR is to show how `bus_space` and `resource` structures help to decouple driver code from actual hardware resource(s) (in this case 16550 UART register set). Same code should be capable of handling `tty0` and `tty1` by just replacing `cbus_uart` in `in` and `out` functions to resources describing UART devices in *FDC37M81x* controller attached to ISA bus in *PIIX4* chipset.

Next step is to perform similar task (i.e. decoupling) for *GT-64120* PCI-bridge chipset by introducing `pci_read_config` and `pci_write_config` functions and corresponding function table.