### PR TITLE
Function helpers to create uio_t structure for single transfer

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -35,7 +35,7 @@ GCC_INSTALL_PATH = $(shell LANG=C $(CC)  -print-search-dirs | sed -n -e 's/insta
 GCC_SYSTEM_INC = -I$(GCC_INSTALL_PATH)include/ -I$(GCC_INSTALL_PATH)include-fixed/ -D_LIBC_LIMITS_H_
 
 ASFLAGS  =
-CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -nostdinc -nostdlib $(GCC_SYSTEM_INC) -ffreestanding
+CFLAGS   = -fplan9-extensions -std=gnu11 -Og -Wall -Werror -fno-builtin -nostdinc -nostdlib $(GCC_SYSTEM_INC) -ffreestanding
 CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDFLAGS  = -nostdlib -T $(TOPDIR)/mips/malta.ld
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -35,7 +35,7 @@ GCC_INSTALL_PATH = $(shell LANG=C $(CC)  -print-search-dirs | sed -n -e 's/insta
 GCC_SYSTEM_INC = -I$(GCC_INSTALL_PATH)include/ -I$(GCC_INSTALL_PATH)include-fixed/ -D_LIBC_LIMITS_H_
 
 ASFLAGS  =
-CFLAGS   = -fplan9-extensions -std=gnu11 -Og -Wall -Werror -fno-builtin -nostdinc -nostdlib $(GCC_SYSTEM_INC) -ffreestanding
+CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -nostdinc -nostdlib $(GCC_SYSTEM_INC) -ffreestanding
 CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDFLAGS  = -nostdlib -T $(TOPDIR)/mips/malta.ld
 

--- a/include/uio.h
+++ b/include/uio.h
@@ -23,23 +23,23 @@ typedef struct uio {
 
 /* Uses -fplan9-extensions described in:
  * https://gcc.gnu.org/onlinedocs/gcc/Unnamed-Fields.html */
-#define MAKE_UIO(name, op, vm_map, buf, buflen)                                \
+#define MAKE_UIO(name, op, vm_map, buf, count, offset)                         \
   struct {                                                                     \
     uio_t;                                                                     \
     iovec_t iov;                                                               \
   } name = {(uio_t){.uio_iov = &name.iov,                                      \
                     .uio_iovcnt = 1,                                           \
-                    .uio_offset = 0,                                           \
-                    .uio_resid = (buflen),                                     \
+                    .uio_offset = (offset),                                    \
+                    .uio_resid = (count),                                      \
                     .uio_op = (op),                                            \
                     .uio_vmspace = (vm_map)},                                  \
-            (iovec_t){(buf), (buflen)}}
+            (iovec_t){(buf), (count)}}
 
-#define MAKE_UIO_USER(name, op, buf, buflen) \
-  MAKE_UIO(name, op, get_user_vm_map(), buf, buflen)
+#define MAKE_UIO_USER(name, op, buf, count, offset)                            \
+  MAKE_UIO(name, op, get_user_vm_map(), buf, count, offset)
 
-#define MAKE_UIO_KERNEL(name, op, buf, buflen) \
-  MAKE_UIO(name, op, get_kernel_vm_map(), buf, buflen)
+#define MAKE_UIO_KERNEL(name, op, buf, count, offset)                          \
+  MAKE_UIO(name, op, get_kernel_vm_map(), buf, count, offset)
 
 int uiomove(void *buf, size_t n, uio_t *uio);
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio);

--- a/include/uio.h
+++ b/include/uio.h
@@ -21,10 +21,8 @@ typedef struct uio {
   vm_map_t *uio_vmspace; /* destination address space */
 } uio_t;
 
-/* Uses struct subtyping enabled by `-fplan9-extensions` flag described in:
- * https://gcc.gnu.org/onlinedocs/gcc/Unnamed-Fields.html */
 typedef struct uio_single {
-  uio_t;
+  uio_t uio;
   iovec_t iov;
 } uio_single_t;
 

--- a/include/uio.h
+++ b/include/uio.h
@@ -21,6 +21,13 @@ typedef struct uio {
   vm_map_t *uio_vmspace; /* destination address space */
 } uio_t;
 
+void prepare_uio(uio_t *uio, iovec_t *iov, uio_op_t op, vm_map_t *vm_map,
+                 void *buffer, size_t buflen);
+void prepare_user_uio(uio_t *uio, iovec_t *iov, uio_op_t op, void *buffer,
+                      size_t buflen);
+void prepare_kernel_uio(uio_t *uio, iovec_t *iov, uio_op_t op, void *buffer,
+                        size_t buflen);
+
 int uiomove(void *buf, size_t n, uio_t *uio);
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio);
 

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -40,18 +40,17 @@ int do_exec(const exec_args_t *args) {
     return -ENOEXEC;
   }
 
+  uio_single_t uio;
   Elf32_Ehdr eh;
 
   /* Read elf header. */
-  {
-    MAKE_UIO_KERNEL(uio, UIO_READ, &eh, sizeof(eh), 0);
-    error = VOP_READ(elf_vnode, &uio);
-    if (error < 0) {
-      log("Exec failed: Elf file reading failed.");
-      return error;
-    }
-    assert(uio.uio_resid == 0);
+  make_uio_kernel(&uio, UIO_READ, &eh, sizeof(eh), 0);
+  error = VOP_READ(elf_vnode, &uio);
+  if (error < 0) {
+    log("Exec failed: Elf file reading failed.");
+    return error;
   }
+  assert(uio.uio_resid == 0);
 
   /* Start by determining the validity of the elf file. */
 
@@ -112,15 +111,13 @@ int do_exec(const exec_args_t *args) {
   char phs[phs_size];
 
   /* Read program headers. */
-  {
-    MAKE_UIO_KERNEL(uio, UIO_READ, &phs, phs_size, eh.e_phoff);
-    error = VOP_READ(elf_vnode, &uio);
-    if (error < 0) {
-      log("Exec failed: Elf file reading failed.");
-      return error;
-    }
-    assert(uio.uio_resid == 0);
+  make_uio_kernel(&uio, UIO_READ, &phs, phs_size, eh.e_phoff);
+  error = VOP_READ(elf_vnode, &uio);
+  if (error < 0) {
+    log("Exec failed: Elf file reading failed.");
+    return error;
   }
+  assert(uio.uio_resid == 0);
 
   for (uint8_t i = 0; i < eh.e_phnum; i++) {
     const Elf32_Phdr *ph = (Elf32_Phdr *)(phs + i * eh.e_phentsize);
@@ -169,16 +166,14 @@ int do_exec(const exec_args_t *args) {
            vm_object associated with the elf vnode, create a shadow vm_object on
            top of it using correct size/offset, and we would use it to page the
            file contents on demand. But we don't have a vnode_pager yet. */
-        {
-          MAKE_UIO_KERNEL(uio, UIO_READ, (char *)start, ph->p_filesz,
-                          ph->p_offset);
-          error = VOP_READ(elf_vnode, &uio);
-          if (error < 0) {
-            log("Exec failed: Elf file reading failed.");
-            goto exec_fail;
-          }
-          assert(uio.uio_resid == 0);
+        make_uio_kernel(&uio, UIO_READ, (char *)start, ph->p_filesz,
+                        ph->p_offset);
+        error = VOP_READ(elf_vnode, &uio);
+        if (error < 0) {
+          log("Exec failed: Elf file reading failed.");
+          goto exec_fail;
         }
+        assert(uio.uio_resid == 0);
 
         /* Zero the rest */
         if (ph->p_filesz < ph->p_memsz) {

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -41,24 +41,17 @@ int do_exec(const exec_args_t *args) {
   }
 
   Elf32_Ehdr eh;
-  uio_t uio;
-  iovec_t iov;
 
   /* Read elf header. */
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = &eh;
-  iov.iov_len = sizeof(Elf32_Ehdr);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = sizeof(Elf32_Ehdr);
-  error = VOP_READ(elf_vnode, &uio);
-  if (error < 0) {
-    log("Exec failed: Elf file reading failed.");
-    return error;
+  {
+    MAKE_UIO_KERNEL(uio, UIO_READ, &eh, sizeof(eh), 0);
+    error = VOP_READ(elf_vnode, &uio);
+    if (error < 0) {
+      log("Exec failed: Elf file reading failed.");
+      return error;
+    }
+    assert(uio.uio_resid == 0);
   }
-  assert(uio.uio_resid == 0);
 
   /* Start by determining the validity of the elf file. */
 
@@ -119,20 +112,15 @@ int do_exec(const exec_args_t *args) {
   char phs[phs_size];
 
   /* Read program headers. */
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = &phs;
-  iov.iov_len = phs_size;
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = eh.e_phoff;
-  uio.uio_resid = phs_size;
-  error = VOP_READ(elf_vnode, &uio);
-  if (error < 0) {
-    log("Exec failed: Elf file reading failed.");
-    return error;
+  {
+    MAKE_UIO_KERNEL(uio, UIO_READ, &phs, phs_size, eh.e_phoff);
+    error = VOP_READ(elf_vnode, &uio);
+    if (error < 0) {
+      log("Exec failed: Elf file reading failed.");
+      return error;
+    }
+    assert(uio.uio_resid == 0);
   }
-  assert(uio.uio_resid == 0);
 
   for (uint8_t i = 0; i < eh.e_phnum; i++) {
     const Elf32_Phdr *ph = (Elf32_Phdr *)(phs + i * eh.e_phentsize);
@@ -181,20 +169,16 @@ int do_exec(const exec_args_t *args) {
            vm_object associated with the elf vnode, create a shadow vm_object on
            top of it using correct size/offset, and we would use it to page the
            file contents on demand. But we don't have a vnode_pager yet. */
-        uio.uio_op = UIO_READ;
-        uio.uio_vmspace = get_kernel_vm_map();
-        iov.iov_base = (char *)start;
-        iov.iov_len = ph->p_filesz;
-        uio.uio_iovcnt = 1;
-        uio.uio_iov = &iov;
-        uio.uio_offset = ph->p_offset;
-        uio.uio_resid = ph->p_filesz;
-        error = VOP_READ(elf_vnode, &uio);
-        if (error < 0) {
-          log("Exec failed: Elf file reading failed.");
-          goto exec_fail;
+        {
+          MAKE_UIO_KERNEL(uio, UIO_READ, (char *)start, ph->p_filesz,
+                          ph->p_offset);
+          error = VOP_READ(elf_vnode, &uio);
+          if (error < 0) {
+            log("Exec failed: Elf file reading failed.");
+            goto exec_fail;
+          }
+          assert(uio.uio_resid == 0);
         }
-        assert(uio.uio_resid == 0);
 
         /* Zero the rest */
         if (ph->p_filesz < ph->p_memsz) {

--- a/sys/uio.c
+++ b/sys/uio.c
@@ -77,28 +77,6 @@ int uiomove(void *buf, size_t n, uio_t *uio) {
   return error;
 }
 
-void prepare_uio(uio_t *uio, iovec_t *iov, uio_op_t op, vm_map_t *vm_map,
-                 void *buffer, size_t buflen) {
-  uio->uio_op = op;
-  uio->uio_iovcnt = 1;
-  uio->uio_vmspace = vm_map;
-  uio->uio_iov = iov;
-  uio->uio_offset = 0;
-  iov->iov_base = buffer;
-  iov->iov_len = buflen;
-  uio->uio_resid = buflen;
-}
-
-void prepare_user_uio(uio_t *uio, iovec_t *iov, uio_op_t op, void *buffer,
-                      size_t buflen) {
-  prepare_uio(uio, iov, op, get_user_vm_map(), buffer, buflen);
-}
-
-void prepare_kernel_uio(uio_t *uio, iovec_t *iov, uio_op_t op, void *buffer,
-                        size_t buflen) {
-  prepare_uio(uio, iov, op, get_kernel_vm_map(), buffer, buflen);
-}
-
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio) {
   size_t offset = uio->uio_offset;
   assert(offset < buflen);

--- a/sys/uio.c
+++ b/sys/uio.c
@@ -77,6 +77,28 @@ int uiomove(void *buf, size_t n, uio_t *uio) {
   return error;
 }
 
+void prepare_uio(uio_t *uio, iovec_t *iov, uio_op_t op, vm_map_t *vm_map,
+                 void *buffer, size_t buflen) {
+  uio->uio_op = op;
+  uio->uio_iovcnt = 1;
+  uio->uio_vmspace = vm_map;
+  uio->uio_iov = iov;
+  uio->uio_offset = 0;
+  iov->iov_base = buffer;
+  iov->iov_len = buflen;
+  uio->uio_resid = buflen;
+}
+
+void prepare_user_uio(uio_t *uio, iovec_t *iov, uio_op_t op, void *buffer,
+                      size_t buflen) {
+  prepare_uio(uio, iov, op, get_user_vm_map(), buffer, buflen);
+}
+
+void prepare_kernel_uio(uio_t *uio, iovec_t *iov, uio_op_t op, void *buffer,
+                        size_t buflen) {
+  prepare_uio(uio, iov, op, get_kernel_vm_map(), buffer, buflen);
+}
+
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio) {
   size_t offset = uio->uio_offset;
   assert(offset < buflen);

--- a/sys/uio.c
+++ b/sys/uio.c
@@ -84,3 +84,24 @@ int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio) {
 
   return (uiomove((char *)buf + offset, buflen - offset, uio));
 }
+
+void make_uio(uio_single_t *uio, uio_op_t op, vm_map_t *vm_map, void *buf,
+              size_t count, off_t offset) {
+  *uio = (uio_single_t){{.uio_iov = &uio->iov,
+                         .uio_iovcnt = 1,
+                         .uio_offset = offset,
+                         .uio_resid = count,
+                         .uio_op = op,
+                         .uio_vmspace = vm_map},
+                        {buf, count}};
+}
+
+void make_uio_kernel(uio_single_t *uio, uio_op_t op, void *buf, size_t count,
+                     off_t offset) {
+  make_uio(uio, op, get_kernel_vm_map(), buf, count, offset);
+}
+
+void make_uio_user(uio_single_t *uio, uio_op_t op, void *buf, size_t count,
+                   off_t offset) {
+  make_uio(uio, op, get_user_vm_map(), buf, count, offset);
+}

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -118,7 +118,8 @@ int sys_read(thread_t *td, syscall_args_t *args) {
 
   log("sys_read(%d, %p, %zu)", fd, ubuf, count);
 
-  MAKE_UIO_USER(uio, UIO_READ, ubuf, count, 0);
+  uio_single_t uio;
+  make_uio_user(&uio, UIO_READ, ubuf, count, 0);
 
   int error = do_read(td, fd, &uio);
   if (error)
@@ -133,7 +134,8 @@ int sys_write(thread_t *td, syscall_args_t *args) {
 
   log("sys_write(%d, %p, %zu)", fd, ubuf, count);
 
-  MAKE_UIO_USER(uio, UIO_WRITE, ubuf, count, 0);
+  uio_single_t uio;
+  make_uio_user(&uio, UIO_WRITE, ubuf, count, 0);
 
   int error = do_write(td, fd, &uio);
   if (error)

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -121,10 +121,10 @@ int sys_read(thread_t *td, syscall_args_t *args) {
   uio_single_t uio;
   make_uio_user(&uio, UIO_READ, ubuf, count, 0);
 
-  int error = do_read(td, fd, &uio);
+  int error = do_read(td, fd, &uio.uio);
   if (error)
     return error;
-  return count - uio.uio_resid;
+  return count - uio.uio.uio_resid;
 }
 
 int sys_write(thread_t *td, syscall_args_t *args) {
@@ -137,10 +137,10 @@ int sys_write(thread_t *td, syscall_args_t *args) {
   uio_single_t uio;
   make_uio_user(&uio, UIO_WRITE, ubuf, count, 0);
 
-  int error = do_write(td, fd, &uio);
+  int error = do_write(td, fd, &uio.uio);
   if (error)
     return error;
-  return count - uio.uio_resid;
+  return count - uio.uio.uio_resid;
 }
 
 int sys_lseek(thread_t *td, syscall_args_t *args) {

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -118,7 +118,7 @@ int sys_read(thread_t *td, syscall_args_t *args) {
 
   log("sys_read(%d, %p, %zu)", fd, ubuf, count);
 
-  MAKE_UIO_USER(uio, UIO_READ, ubuf, count);
+  MAKE_UIO_USER(uio, UIO_READ, ubuf, count, 0);
 
   int error = do_read(td, fd, &uio);
   if (error)
@@ -133,7 +133,7 @@ int sys_write(thread_t *td, syscall_args_t *args) {
 
   log("sys_write(%d, %p, %zu)", fd, ubuf, count);
 
-  MAKE_UIO_USER(uio, UIO_WRITE, ubuf, count);
+  MAKE_UIO_USER(uio, UIO_WRITE, ubuf, count, 0);
 
   int error = do_write(td, fd, &uio);
   if (error)

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -120,14 +120,8 @@ int sys_read(thread_t *td, syscall_args_t *args) {
 
   uio_t uio;
   iovec_t iov;
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_user_vm_map();
-  iov.iov_base = ubuf;
-  iov.iov_len = count;
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_resid = count;
-  uio.uio_offset = 0;
+
+  prepare_user_uio(&uio, &iov, UIO_READ, ubuf, count);
 
   int error = do_read(td, fd, &uio);
   if (error)
@@ -144,14 +138,8 @@ int sys_write(thread_t *td, syscall_args_t *args) {
 
   uio_t uio;
   iovec_t iov;
-  uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = get_user_vm_map();
-  iov.iov_base = ubuf;
-  iov.iov_len = count;
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_resid = count;
-  uio.uio_offset = 0;
+
+  prepare_user_uio(&uio, &iov, UIO_WRITE, ubuf, count);
 
   int error = do_write(td, fd, &uio);
   if (error)

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -118,10 +118,7 @@ int sys_read(thread_t *td, syscall_args_t *args) {
 
   log("sys_read(%d, %p, %zu)", fd, ubuf, count);
 
-  uio_t uio;
-  iovec_t iov;
-
-  prepare_user_uio(&uio, &iov, UIO_READ, ubuf, count);
+  MAKE_UIO_USER(uio, UIO_READ, ubuf, count);
 
   int error = do_read(td, fd, &uio);
   if (error)
@@ -136,10 +133,7 @@ int sys_write(thread_t *td, syscall_args_t *args) {
 
   log("sys_write(%d, %p, %zu)", fd, ubuf, count);
 
-  uio_t uio;
-  iovec_t iov;
-
-  prepare_user_uio(&uio, &iov, UIO_WRITE, ubuf, count);
+  MAKE_UIO_USER(uio, UIO_WRITE, ubuf, count);
 
   int error = do_write(td, fd, &uio);
   if (error)

--- a/tests/initrd.c
+++ b/tests/initrd.c
@@ -14,16 +14,7 @@ static void dump_file(const char *path) {
   memset(buffer, '\0', sizeof(buffer));
   uio_t uio;
   iovec_t iov;
-  uio.uio_op = UIO_READ;
-
-  /* Read entire file - even too much. */
-  uio.uio_iovcnt = 1;
-  uio.uio_vmspace = get_kernel_vm_map();
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  iov.iov_base = buffer;
-  iov.iov_len = sizeof(buffer);
-  uio.uio_resid = sizeof(buffer);
+  prepare_kernel_uio(&uio, &iov, UIO_READ, buffer, sizeof(buffer));
 
   res = VOP_READ(v, &uio);
 

--- a/tests/initrd.c
+++ b/tests/initrd.c
@@ -13,7 +13,8 @@ static void dump_file(const char *path) {
   char buffer[1000];
   memset(buffer, '\0', sizeof(buffer));
 
-  MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer), 0);
+  uio_single_t uio;
+  make_uio_kernel(&uio, UIO_READ, buffer, sizeof(buffer), 0);
   res = VOP_READ(v, &uio);
 
   kprintf("file %s:\n%s\n", path, buffer);

--- a/tests/initrd.c
+++ b/tests/initrd.c
@@ -15,7 +15,7 @@ static void dump_file(const char *path) {
 
   uio_single_t uio;
   make_uio_kernel(&uio, UIO_READ, buffer, sizeof(buffer), 0);
-  res = VOP_READ(v, &uio);
+  res = VOP_READ(v, &uio.uio);
 
   kprintf("file %s:\n%s\n", path, buffer);
 }

--- a/tests/initrd.c
+++ b/tests/initrd.c
@@ -13,8 +13,7 @@ static void dump_file(const char *path) {
   char buffer[1000];
   memset(buffer, '\0', sizeof(buffer));
 
-  MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer));
-
+  MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer), 0);
   res = VOP_READ(v, &uio);
 
   kprintf("file %s:\n%s\n", path, buffer);

--- a/tests/initrd.c
+++ b/tests/initrd.c
@@ -12,9 +12,8 @@ static void dump_file(const char *path) {
 
   char buffer[1000];
   memset(buffer, '\0', sizeof(buffer));
-  uio_t uio;
-  iovec_t iov;
-  prepare_kernel_uio(&uio, &iov, UIO_READ, buffer, sizeof(buffer));
+
+  MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer));
 
   res = VOP_READ(v, &uio);
 

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -43,18 +43,12 @@ static int test_vfs() {
   uio_t uio;
   iovec_t iov;
   int res = 0;
+
   char buffer[100];
   memset(buffer, '=', sizeof(buffer));
 
   /* Perform a READ test on /dev/zero, cleaning buffer. */
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = buffer;
-  iov.iov_len = sizeof(buffer);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = sizeof(buffer);
+  prepare_kernel_uio(&uio, &iov, UIO_READ, buffer, sizeof(buffer));
 
   res = VOP_READ(dev_zero, &uio);
   assert(res == 0);
@@ -62,14 +56,7 @@ static int test_vfs() {
   assert(uio.uio_resid == 0);
 
   /* Now write some data to /dev/null */
-  uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = buffer;
-  iov.iov_len = sizeof(buffer);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = sizeof(buffer);
+  prepare_kernel_uio(&uio, &iov, UIO_WRITE, buffer, sizeof(buffer));
 
   assert(dev_null != 0);
   res = VOP_WRITE(dev_null, &uio);
@@ -82,14 +69,7 @@ static int test_vfs() {
   assert(error == 0);
   char *str = "Some string for testing UART write\n";
 
-  uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = str;
-  iov.iov_len = strlen(str);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = iov.iov_len;
+  prepare_kernel_uio(&uio, &iov, UIO_WRITE, str, strlen(str));
 
   res = VOP_WRITE(dev_cons, &uio);
   assert(res == 0);

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -49,18 +49,18 @@ static int test_vfs() {
   /* Perform a READ test on /dev/zero, cleaning buffer. */
   make_uio_kernel(&uio, UIO_READ, buffer, sizeof(buffer), 0);
 
-  res = VOP_READ(dev_zero, &uio);
+  res = VOP_READ(dev_zero, &uio.uio);
   assert(res == 0);
   assert(buffer[1] == 0 && buffer[10] == 0);
-  assert(uio.uio_resid == 0);
+  assert(uio.uio.uio_resid == 0);
 
   /* Now write some data to /dev/null */
   make_uio_kernel(&uio, UIO_WRITE, buffer, sizeof(buffer), 0);
 
   assert(dev_null != 0);
-  res = VOP_WRITE(dev_null, &uio);
+  res = VOP_WRITE(dev_null, &uio.uio);
   assert(res == 0);
-  assert(uio.uio_resid == 0);
+  assert(uio.uio.uio_resid == 0);
 
   /* Test writing to UART */
   vnode_t *dev_cons;
@@ -70,7 +70,7 @@ static int test_vfs() {
 
   make_uio_kernel(&uio, UIO_WRITE, str, strlen(str), 0);
 
-  res = VOP_WRITE(dev_cons, &uio);
+  res = VOP_WRITE(dev_cons, &uio.uio);
   assert(res == 0);
 
   return KTEST_SUCCESS;

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -41,42 +41,37 @@ static int test_vfs() {
   assert(dev_zero->v_usecnt == 1);
 
   int res = 0;
+  uio_single_t uio;
 
   char buffer[100];
   memset(buffer, '=', sizeof(buffer));
 
   /* Perform a READ test on /dev/zero, cleaning buffer. */
-  {
-    MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer), 0);
+  make_uio_kernel(&uio, UIO_READ, buffer, sizeof(buffer), 0);
 
-    res = VOP_READ(dev_zero, &uio);
-    assert(res == 0);
-    assert(buffer[1] == 0 && buffer[10] == 0);
-    assert(uio.uio_resid == 0);
-  }
+  res = VOP_READ(dev_zero, &uio);
+  assert(res == 0);
+  assert(buffer[1] == 0 && buffer[10] == 0);
+  assert(uio.uio_resid == 0);
 
   /* Now write some data to /dev/null */
-  {
-    MAKE_UIO_KERNEL(uio, UIO_WRITE, buffer, sizeof(buffer), 0);
+  make_uio_kernel(&uio, UIO_WRITE, buffer, sizeof(buffer), 0);
 
-    assert(dev_null != 0);
-    res = VOP_WRITE(dev_null, &uio);
-    assert(res == 0);
-    assert(uio.uio_resid == 0);
-  }
+  assert(dev_null != 0);
+  res = VOP_WRITE(dev_null, &uio);
+  assert(res == 0);
+  assert(uio.uio_resid == 0);
 
   /* Test writing to UART */
-  {
-    vnode_t *dev_cons;
-    error = vfs_lookup("/dev/cons", &dev_cons);
-    assert(error == 0);
-    char *str = "Some string for testing UART write\n";
+  vnode_t *dev_cons;
+  error = vfs_lookup("/dev/cons", &dev_cons);
+  assert(error == 0);
+  char *str = "Some string for testing UART write\n";
 
-    MAKE_UIO_KERNEL(uio, UIO_WRITE, str, strlen(str), 0);
+  make_uio_kernel(&uio, UIO_WRITE, str, strlen(str), 0);
 
-    res = VOP_WRITE(dev_cons, &uio);
-    assert(res == 0);
-  }
+  res = VOP_WRITE(dev_cons, &uio);
+  assert(res == 0);
 
   return KTEST_SUCCESS;
 }

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -47,7 +47,7 @@ static int test_vfs() {
 
   /* Perform a READ test on /dev/zero, cleaning buffer. */
   {
-    MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer));
+    MAKE_UIO_KERNEL(uio, UIO_READ, buffer, sizeof(buffer), 0);
 
     res = VOP_READ(dev_zero, &uio);
     assert(res == 0);
@@ -57,7 +57,7 @@ static int test_vfs() {
 
   /* Now write some data to /dev/null */
   {
-    MAKE_UIO_KERNEL(uio, UIO_WRITE, buffer, sizeof(buffer));
+    MAKE_UIO_KERNEL(uio, UIO_WRITE, buffer, sizeof(buffer), 0);
 
     assert(dev_null != 0);
     res = VOP_WRITE(dev_null, &uio);
@@ -67,15 +67,15 @@ static int test_vfs() {
 
   /* Test writing to UART */
   {
-  vnode_t *dev_cons;
-  error = vfs_lookup("/dev/cons", &dev_cons);
-  assert(error == 0);
-  char *str = "Some string for testing UART write\n";
+    vnode_t *dev_cons;
+    error = vfs_lookup("/dev/cons", &dev_cons);
+    assert(error == 0);
+    char *str = "Some string for testing UART write\n";
 
-  MAKE_UIO_KERNEL(uio, UIO_WRITE, str, strlen(str));
+    MAKE_UIO_KERNEL(uio, UIO_WRITE, str, strlen(str), 0);
 
-  res = VOP_WRITE(dev_cons, &uio);
-  assert(res == 0);
+    res = VOP_WRITE(dev_cons, &uio);
+    assert(res == 0);
   }
 
   return KTEST_SUCCESS;


### PR DESCRIPTION
This change introduces macro `MAKE_UIO` that defines `uio_t` structure with single I/O operation. With it we capture common use case into a single line. This is an alternative to #274.

I'm planning to use `-fplan9-extensions` features in our code. I find it extremely convenient to use camouflaged subtyping for structures. This works as follows:

```c
struct A {
  int foo;
};

struct B {
  struct A;
  unsigned bar;
};

void incr(struct A *a) {
 a->foo++;
}

void func() {
 struct B b = { -1, 2 };
 incr(&b);
}
``` 