### PR TITLE
Initializer macro for single UIO transfer

### DIFF
--- a/include/uio.h
+++ b/include/uio.h
@@ -21,6 +21,19 @@ typedef struct uio {
   vm_map_t *uio_vmspace; /* destination address space */
 } uio_t;
 
+#define UIO_SINGLE(op, vm_map, offset, buf, buflen)                            \
+  (uio_t) {                                                                    \
+    .uio_iov = (iovec_t[1]){(iovec_t){(buf), (buflen)}}, .uio_iovcnt = 1,      \
+    .uio_offset = (offset), .uio_resid = (buflen), .uio_op = (op),             \
+    .uio_vmspace = (vm_map)                                                    \
+  }
+
+#define UIO_SINGLE_KERNEL(op, offset, buf, buflen)                             \
+  UIO_SINGLE(op, get_kernel_vm_map(), offset, buf, buflen)
+
+#define UIO_SINGLE_USER(op, offset, buf, buflen)                               \
+  UIO_SINGLE(op, get_user_vm_map(), offset, buf, buflen)
+
 int uiomove(void *buf, size_t n, uio_t *uio);
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio);
 

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -42,17 +42,8 @@ int do_exec(const exec_args_t *args) {
 
   Elf32_Ehdr eh;
   uio_t uio;
-  iovec_t iov;
 
-  /* Read elf header. */
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = &eh;
-  iov.iov_len = sizeof(Elf32_Ehdr);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = sizeof(Elf32_Ehdr);
+  uio = UIO_SINGLE_KERNEL(UIO_READ, 0, &eh, sizeof(Elf32_Ehdr));
   error = VOP_READ(elf_vnode, &uio);
   if (error < 0) {
     log("Exec failed: Elf file reading failed.");
@@ -119,14 +110,7 @@ int do_exec(const exec_args_t *args) {
   char phs[phs_size];
 
   /* Read program headers. */
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = &phs;
-  iov.iov_len = phs_size;
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = eh.e_phoff;
-  uio.uio_resid = phs_size;
+  uio = UIO_SINGLE_KERNEL(UIO_READ, eh.e_phoff, &phs, phs_size);
   error = VOP_READ(elf_vnode, &uio);
   if (error < 0) {
     log("Exec failed: Elf file reading failed.");
@@ -181,14 +165,8 @@ int do_exec(const exec_args_t *args) {
            vm_object associated with the elf vnode, create a shadow vm_object on
            top of it using correct size/offset, and we would use it to page the
            file contents on demand. But we don't have a vnode_pager yet. */
-        uio.uio_op = UIO_READ;
-        uio.uio_vmspace = get_kernel_vm_map();
-        iov.iov_base = (char *)start;
-        iov.iov_len = ph->p_filesz;
-        uio.uio_iovcnt = 1;
-        uio.uio_iov = &iov;
-        uio.uio_offset = ph->p_offset;
-        uio.uio_resid = ph->p_filesz;
+        uio = UIO_SINGLE_KERNEL(UIO_READ, ph->p_offset, (char *)start,
+                                ph->p_filesz);
         error = VOP_READ(elf_vnode, &uio);
         if (error < 0) {
           log("Exec failed: Elf file reading failed.");

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -119,16 +119,7 @@ int sys_read(thread_t *td, syscall_args_t *args) {
   log("sys_read(%d, %p, %zu)", fd, ubuf, count);
 
   uio_t uio;
-  iovec_t iov;
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_user_vm_map();
-  iov.iov_base = ubuf;
-  iov.iov_len = count;
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_resid = count;
-  uio.uio_offset = 0;
-
+  uio = UIO_SINGLE_USER(UIO_READ, 0, ubuf, count);
   int error = do_read(td, fd, &uio);
   if (error)
     return error;
@@ -143,16 +134,7 @@ int sys_write(thread_t *td, syscall_args_t *args) {
   log("sys_write(%d, %p, %zu)", fd, ubuf, count);
 
   uio_t uio;
-  iovec_t iov;
-  uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = get_user_vm_map();
-  iov.iov_base = ubuf;
-  iov.iov_len = count;
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_resid = count;
-  uio.uio_offset = 0;
-
+  uio = UIO_SINGLE_USER(UIO_READ, 0, ubuf, count);
   int error = do_write(td, fd, &uio);
   if (error)
     return error;

--- a/tests/initrd.c
+++ b/tests/initrd.c
@@ -12,19 +12,9 @@ static void dump_file(const char *path) {
 
   char buffer[1000];
   memset(buffer, '\0', sizeof(buffer));
+
   uio_t uio;
-  iovec_t iov;
-  uio.uio_op = UIO_READ;
-
-  /* Read entire file - even too much. */
-  uio.uio_iovcnt = 1;
-  uio.uio_vmspace = get_kernel_vm_map();
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  iov.iov_base = buffer;
-  iov.iov_len = sizeof(buffer);
-  uio.uio_resid = sizeof(buffer);
-
+  uio = UIO_SINGLE_KERNEL(UIO_READ, 0, buffer, sizeof(buffer));
   res = VOP_READ(v, &uio);
 
   kprintf("file %s:\n%s\n", path, buffer);

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -47,31 +47,15 @@ static int test_vfs() {
   memset(buffer, '=', sizeof(buffer));
 
   /* Perform a READ test on /dev/zero, cleaning buffer. */
-  uio.uio_op = UIO_READ;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = buffer;
-  iov.iov_len = sizeof(buffer);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = sizeof(buffer);
-
+  uio = UIO_SINGLE_KERNEL(UIO_READ, 0, buffer, sizeof(buffer));
   res = VOP_READ(dev_zero, &uio);
   assert(res == 0);
   assert(buffer[1] == 0 && buffer[10] == 0);
   assert(uio.uio_resid == 0);
 
   /* Now write some data to /dev/null */
-  uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = buffer;
-  iov.iov_len = sizeof(buffer);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = sizeof(buffer);
-
   assert(dev_null != 0);
+  uio = UIO_SINGLE_KERNEL(UIO_WRITE, 0, buffer, sizeof(buffer));
   res = VOP_WRITE(dev_null, &uio);
   assert(res == 0);
   assert(uio.uio_resid == 0);
@@ -82,15 +66,7 @@ static int test_vfs() {
   assert(error == 0);
   char *str = "Some string for testing UART write\n";
 
-  uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = get_kernel_vm_map();
-  iov.iov_base = str;
-  iov.iov_len = strlen(str);
-  uio.uio_iovcnt = 1;
-  uio.uio_iov = &iov;
-  uio.uio_offset = 0;
-  uio.uio_resid = iov.iov_len;
-
+  uio = UIO_SINGLE_KERNEL(UIO_WRITE, 0, str, strlen(str));
   res = VOP_WRITE(dev_cons, &uio);
   assert(res == 0);
 

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -41,7 +41,6 @@ static int test_vfs() {
   assert(dev_zero->v_usecnt == 1);
 
   uio_t uio;
-  iovec_t iov;
   int res = 0;
   char buffer[100];
   memset(buffer, '=', sizeof(buffer));


### PR DESCRIPTION
This is alternative solution to PR #274. I think I've found the cleanest solution to the problem, that does not require using rare C extensions.