### PR TITLE
Fixed seeking for write-only files

### DIFF
--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -60,7 +60,7 @@ int do_lseek(thread_t *td, int fd, off_t offset, int whence) {
   /* TODO: Whence! Now we assume whence == SEEK_SET */
   /* TODO: RW file flag! For now we just file_get_read */
   file_t *f;
-  int res = fdtab_get_file(td->td_fdtable, fd, FF_READ, &f);
+  int res = fdtab_get_file(td->td_fdtable, fd, 0, &f);
   if (res)
     return res;
   f->f_offset = offset;


### PR DESCRIPTION
Fixed a tiny bug in `do_lseek`, where the file requested with a descriptor was assumed to be readable. This is not the case e.g. for `/dev/vga/fb`, and thus user programs were unable to seek back to framebuffer start.