### PR TITLE
Process structure stub

### DIFF
--- a/include/mutex.h
+++ b/include/mutex.h
@@ -34,7 +34,7 @@ void mtx_unlock(mtx_t *m);
    leaving current scope. */
 DEFINE_CLEANUP_FUNCTION(mtx_t *, mtx_unlock);
 #define mtx_scoped_lock(pmtx)                                                  \
-  mtx_t *mtx_scoped_lock_##__LINE__ cleanup(mtx_unlock) = pmtx;                \
+  mtx_t *__CONCAT(mtx_scoped_lock_, __LINE__) cleanup(mtx_unlock) = pmtx;      \
   mtx_lock(pmtx);
 
 #endif /* !_SYS_MUTEX_H_ */

--- a/include/proc.h
+++ b/include/proc.h
@@ -6,23 +6,26 @@
 #include <mutex.h>
 
 typedef struct thread thread_t;
+typedef struct proc proc_t;
+typedef TAILQ_HEAD(, thread) thread_list_t;
+typedef TAILQ_HEAD(, proc) proc_list_t;
 
-typedef struct proc {
-  mtx_t p_lock;                   /* Process lock */
-  TAILQ_ENTRY(proc) p_all;        /* A link on all processes list */
-  TAILQ_HEAD(, thread) p_threads; /* Threads belonging to this process */
-  pid_t p_pid;                    /* Process ID */
-  struct proc *p_parent;          /* Parent process */
-} proc_t;
+struct proc {
+  mtx_t p_lock;            /* Process lock */
+  TAILQ_ENTRY(proc) p_all; /* A link on all processes list */
+  thread_list_t p_threads; /* Threads belonging to this process */
+  pid_t p_pid;             /* Process ID */
+  proc_t *p_parent;        /* Parent process */
+};
 
 void proc_init();
 
 proc_t *proc_create();
 
 /* Links a thread with a process, setting td_proc and updating p_threads. */
-void proc_add_thread(proc_t *p, thread_t *td);
+void proc_populate(proc_t *p, thread_t *td);
 
 /* Searches for a process with the given PID, returns NULL if not found. */
-proc_t *proc_get_by_pid(pid_t pid);
+proc_t *proc_find(pid_t pid);
 
 #endif /* _SYS_PROC_H_ */

--- a/include/proc.h
+++ b/include/proc.h
@@ -1,0 +1,25 @@
+#ifndef _SYS_PROC_H_
+#define _SYS_PROC_H_
+
+#include <common.h>
+#include <queue.h>
+#include <mutex.h>
+
+typedef struct thread thread_t;
+
+typedef struct proc {
+  mtx_t p_lock;                   /* Process lock */
+  TAILQ_ENTRY(proc) p_all;        /* A link on all processes list */
+  TAILQ_HEAD(, thread) p_threads; /* Threads belonging to this process */
+  pid_t p_pid;                    /* Process ID */
+  struct proc *p_parent;          /* Parent process */
+} proc_t;
+
+void proc_init();
+
+proc_t *proc_create();
+
+/* Links a thread with a process, setting td_proc and updating p_threads. */
+void proc_add_thread(proc_t *p, thread_t *td);
+
+#endif /* _SYS_PROC_H_ */

--- a/include/proc.h
+++ b/include/proc.h
@@ -22,4 +22,7 @@ proc_t *proc_create();
 /* Links a thread with a process, setting td_proc and updating p_threads. */
 void proc_add_thread(proc_t *p, thread_t *td);
 
+/* Searches for a process with the given PID, returns NULL if not found. */
+proc_t *proc_get_by_pid(pid_t pid);
+
 #endif /* _SYS_PROC_H_ */

--- a/include/thread.h
+++ b/include/thread.h
@@ -14,6 +14,7 @@ typedef uint32_t tid_t;
 typedef struct vm_page vm_page_t;
 typedef struct vm_map vm_map_t;
 typedef struct fdtab fdtab_t;
+typedef struct proc proc_t;
 
 #define TD_NAME_MAX 32
 
@@ -25,10 +26,13 @@ typedef struct thread {
   mtx_t td_lock;
   condvar_t td_waitcv; /* CV for thread exit, used by join */
   /* List links */
-  TAILQ_ENTRY(thread) td_all;     /* a link on all threads list */
-  TAILQ_ENTRY(thread) td_runq;    /* a link on run queue */
-  TAILQ_ENTRY(thread) td_sleepq;  /* a link on sleep queue */
-  TAILQ_ENTRY(thread) td_zombieq; /* a link on zombie queue */
+  TAILQ_ENTRY(thread) td_all;         /* a link on all threads list */
+  TAILQ_ENTRY(thread) td_runq;        /* a link on run queue */
+  TAILQ_ENTRY(thread) td_sleepq;      /* a link on sleep queue */
+  TAILQ_ENTRY(thread) td_zombieq;     /* a link on zombie queue */
+  TAILQ_ENTRY(thread) td_procthreadq; /* a link on process threads queue */
+  /* Properties */
+  proc_t *td_proc; /* Parent process, NULL for kernel threads. */
   char *td_name;
   tid_t td_tid;
   /* thread state */

--- a/include/thread.h
+++ b/include/thread.h
@@ -26,11 +26,11 @@ typedef struct thread {
   mtx_t td_lock;
   condvar_t td_waitcv; /* CV for thread exit, used by join */
   /* List links */
-  TAILQ_ENTRY(thread) td_all;         /* a link on all threads list */
-  TAILQ_ENTRY(thread) td_runq;        /* a link on run queue */
-  TAILQ_ENTRY(thread) td_sleepq;      /* a link on sleep queue */
-  TAILQ_ENTRY(thread) td_zombieq;     /* a link on zombie queue */
-  TAILQ_ENTRY(thread) td_procthreadq; /* a link on process threads queue */
+  TAILQ_ENTRY(thread) td_all;     /* a link on all threads list */
+  TAILQ_ENTRY(thread) td_runq;    /* a link on run queue */
+  TAILQ_ENTRY(thread) td_sleepq;  /* a link on sleep queue */
+  TAILQ_ENTRY(thread) td_zombieq; /* a link on zombie queue */
+  TAILQ_ENTRY(thread) td_procq;   /* a link on process threads queue */
   /* Properties */
   proc_t *td_proc; /* Parent process, NULL for kernel threads. */
   char *td_name;

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -26,6 +26,7 @@ SOURCES_C  = \
 	pcpu.c \
 	physmem.c \
 	pool.c \
+	proc.c \
 	runq.c \
 	rwlock.c \
 	sbrk.c \

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -261,7 +261,7 @@ int do_exec(const exec_args_t *args) {
    * (the first!) process. */
   if (!td->td_proc) {
     proc_t *proc = proc_create();
-    proc_add_thread(proc, td);
+    proc_populate(proc, td);
   }
 
   /*

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -13,6 +13,7 @@
 #include <mips/stack.h>
 #include <mount.h>
 #include <vnode.h>
+#include <proc.h>
 
 int do_exec(const exec_args_t *args) {
   log("Loading user ELF: %s", args->prog_name);
@@ -255,6 +256,13 @@ int do_exec(const exec_args_t *args) {
 
   /* ... and user context. */
   uctx_init(thread_self(), eh.e_entry, stack_bottom);
+
+  /* If this is a kernel thread becoming a user thread, then we need to create
+   * (the first!) process. */
+  if (!td->td_proc) {
+    proc_t *proc = proc_create();
+    proc_add_thread(proc, td);
+  }
 
   /*
    * At this point we are certain that exec suceeds.

--- a/sys/fork.c
+++ b/sys/fork.c
@@ -5,6 +5,7 @@
 #include <sched.h>
 #include <stdc.h>
 #include <vm_map.h>
+#include <proc.h>
 
 int do_fork() {
   thread_t *td = thread_self();
@@ -49,7 +50,12 @@ int do_fork() {
 
   newtd->td_prio = td->td_prio;
 
+  /* Now, prepare a new process. */
+  assert(td->td_proc);
+  proc_t *proc = proc_create();
+  proc_add_thread(proc, newtd);
+
   sched_add(newtd);
 
-  return newtd->td_tid;
+  return proc->p_pid;
 }

--- a/sys/fork.c
+++ b/sys/fork.c
@@ -53,7 +53,7 @@ int do_fork() {
   /* Now, prepare a new process. */
   assert(td->td_proc);
   proc_t *proc = proc_create();
-  proc_add_thread(proc, newtd);
+  proc_populate(proc, newtd);
 
   sched_add(newtd);
 

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -40,3 +40,13 @@ void proc_add_thread(proc_t *p, thread_t *td) {
   td->td_proc = p;
   TAILQ_INSERT_TAIL(&p->p_threads, td, td_procthreadq);
 }
+
+proc_t *proc_get_by_pid(pid_t pid) {
+  proc_t *p = NULL;
+  mtx_scoped_lock(&all_proc_list_mtx);
+  TAILQ_FOREACH (p, &all_proc_list, p_all) {
+    if (p->p_pid == pid)
+      break;
+  }
+  return p;
+}

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -5,7 +5,7 @@
 static MALLOC_DEFINE(proc_pool, "proc pool");
 
 static mtx_t all_proc_list_mtx;
-static TAILQ_HEAD(, proc) all_proc_list;
+static proc_list_t all_proc_list;
 
 static mtx_t last_pid_mtx;
 static pid_t last_pid;
@@ -34,14 +34,14 @@ proc_t *proc_create() {
   return proc;
 }
 
-void proc_add_thread(proc_t *p, thread_t *td) {
+void proc_populate(proc_t *p, thread_t *td) {
   mtx_scoped_lock(&p->p_lock);
   mtx_scoped_lock(&td->td_lock);
   td->td_proc = p;
-  TAILQ_INSERT_TAIL(&p->p_threads, td, td_procthreadq);
+  TAILQ_INSERT_TAIL(&p->p_threads, td, td_procq);
 }
 
-proc_t *proc_get_by_pid(pid_t pid) {
+proc_t *proc_find(pid_t pid) {
   proc_t *p = NULL;
   mtx_scoped_lock(&all_proc_list_mtx);
   TAILQ_FOREACH (p, &all_proc_list, p_all) {

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -1,0 +1,42 @@
+#include <proc.h>
+#include <malloc.h>
+#include <thread.h>
+
+static MALLOC_DEFINE(proc_pool, "proc pool");
+
+static mtx_t all_proc_list_mtx;
+static TAILQ_HEAD(, proc) all_proc_list;
+
+static mtx_t last_pid_mtx;
+static pid_t last_pid;
+
+void proc_init() {
+  kmalloc_init(proc_pool, 2, 2);
+  mtx_init(&all_proc_list_mtx, MTX_DEF);
+  TAILQ_INIT(&all_proc_list);
+  mtx_init(&last_pid_mtx, MTX_DEF);
+  last_pid = 0;
+}
+
+proc_t *proc_create() {
+  proc_t *proc = kmalloc(proc_pool, sizeof(proc_t), M_ZERO);
+  mtx_init(&proc->p_lock, MTX_DEF);
+  TAILQ_INIT(&proc->p_threads);
+
+  mtx_lock(&all_proc_list_mtx);
+  TAILQ_INSERT_TAIL(&all_proc_list, proc, p_all);
+  mtx_unlock(&all_proc_list_mtx);
+
+  mtx_lock(&last_pid_mtx);
+  proc->p_pid = last_pid++;
+  mtx_unlock(&last_pid_mtx);
+
+  return proc;
+}
+
+void proc_add_thread(proc_t *p, thread_t *td) {
+  mtx_scoped_lock(&p->p_lock);
+  mtx_scoped_lock(&td->td_lock);
+  td->td_proc = p;
+  TAILQ_INSERT_TAIL(&p->p_threads, td, td_procthreadq);
+}

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -16,6 +16,7 @@
 #include <devfs.h>
 #include <initrd.h>
 #include <vga.h>
+#include <proc.h>
 
 extern void main(void *);
 
@@ -38,6 +39,7 @@ int kernel_init(int argc, char **argv) {
   vfs_init();
   file_init();
   fd_init();
+  proc_init();
 
   vga_init();
 

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -8,6 +8,7 @@
 #include <vfs_syscalls.h>
 #include <fork.h>
 #include <sbrk.h>
+#include <proc.h>
 
 int sys_nosys(thread_t *td, syscall_args_t *args) {
   kprintf("[syscall] unimplemented system call %ld\n", args->code);
@@ -47,11 +48,16 @@ int sys_fork(thread_t *td, syscall_args_t *args) {
   return do_fork();
 }
 
+int sys_getpid(thread_t *td, syscall_args_t *args) {
+  kprintf("[syscall] fork()\n");
+  return td->td_proc->p_pid;
+}
+
 /* clang-format hates long arrays. */
 sysent_t sysent[] = {[SYS_EXIT] = {sys_exit},    [SYS_OPEN] = {sys_open},
                      [SYS_CLOSE] = {sys_close},  [SYS_READ] = {sys_read},
                      [SYS_WRITE] = {sys_write},  [SYS_LSEEK] = {sys_lseek},
-                     [SYS_UNLINK] = {sys_nosys}, [SYS_GETPID] = {sys_nosys},
+                     [SYS_UNLINK] = {sys_nosys}, [SYS_GETPID] = {sys_getpid},
                      [SYS_KILL] = {sys_nosys},   [SYS_FSTAT] = {sys_fstat},
                      [SYS_SBRK] = {sys_sbrk},    [SYS_MMAP] = {sys_mmap},
                      [SYS_FORK] = {sys_fork}};

--- a/user/test_fork/test_fork.c
+++ b/user/test_fork/test_fork.c
@@ -6,9 +6,10 @@ int main() {
 
   int n = fork();
   if (n == 0) {
-    printf("This is child!\n");
+    printf("This is child, my pid is %d!\n", getpid());
   } else {
-    printf("This is parent! (%d)\n", n);
+    printf("This is parent, my pid is %d, I was told child is %d!\n", getpid(),
+           n);
   }
 
   return 0;


### PR DESCRIPTION
This branch introduces `proc` structure. In order to keep this change minimal, I've not removed any fields from `thread` structure, and `proc` is not very useful at the moment. I suggest introducing more fields to `proc` in subsequent PRs.

I've modified `fork` so that it creates a new process for the new thread, and `exec` so that it creates new process for current thread (if called by a kernel thread). I've also implemented `getpid` syscall and `proc_get_by_pid` convenience function.

This should be enough to push #271 (Basic signal support) forward.