### PR TITLE
Moved fdtable from thread_t to proc_t

### DIFF
--- a/include/proc.h
+++ b/include/proc.h
@@ -7,6 +7,7 @@
 
 typedef struct thread thread_t;
 typedef struct proc proc_t;
+typedef struct fdtab fdtab_t;
 typedef TAILQ_HEAD(, thread) thread_list_t;
 typedef TAILQ_HEAD(, proc) proc_list_t;
 
@@ -16,6 +17,8 @@ struct proc {
   thread_list_t p_threads; /* Threads belonging to this process */
   pid_t p_pid;             /* Process ID */
   proc_t *p_parent;        /* Parent process */
+  /* file descriptors table */
+  fdtab_t *p_fdtable;
 };
 
 void proc_init();

--- a/include/thread.h
+++ b/include/thread.h
@@ -49,8 +49,6 @@ typedef struct thread {
   vm_page_t *td_kstack_obj;
   stack_t td_kstack;
   vm_map_t *td_uspace; /* thread's user space map */
-  /* file descriptors table */
-  fdtab_t *td_fdtable;
   /* waiting channel */
   sleepq_t *td_sleepqueue;
   void *td_wchan;

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -216,18 +216,6 @@ int do_exec(const exec_args_t *args) {
   prepare_program_stack(args, &stack_bottom);
 
   thread_t *td = thread_self();
-  /* ... file descriptor table ... */
-  /* TODO: Copy/share file descriptor table! */
-  fdtab_t *fdt = fdtab_alloc();
-  fdtab_ref(fdt);
-  td->td_fdtable = fdt;
-
-  /* Before we have a working fork, let's initialize file descriptors required
-     by the standard library. */
-  int ignore;
-  do_open(td, "/dev/cons", O_RDONLY, 0, &ignore);
-  do_open(td, "/dev/cons", O_WRONLY, 0, &ignore);
-  do_open(td, "/dev/cons", O_WRONLY, 0, &ignore);
 
   /* ... sbrk segment ... */
   sbrk_create(vmap);
@@ -241,6 +229,19 @@ int do_exec(const exec_args_t *args) {
     proc_t *proc = proc_create();
     proc_populate(proc, td);
   }
+
+  /* Prepare file descriptor table */
+  /* TODO: Copy/share file descriptor table! */
+  fdtab_t *fdt = fdtab_alloc();
+  fdtab_ref(fdt);
+  td->td_proc->p_fdtable = fdt;
+
+  /* Before we have a working fork, let's initialize file descriptors required
+     by the standard library. */
+  int ignore;
+  do_open(td, "/dev/cons", O_RDONLY, 0, &ignore);
+  do_open(td, "/dev/cons", O_WRONLY, 0, &ignore);
+  do_open(td, "/dev/cons", O_WRONLY, 0, &ignore);
 
   /*
    * At this point we are certain that exec suceeds.

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -228,13 +228,12 @@ int do_exec(const exec_args_t *args) {
   if (!td->td_proc) {
     proc_t *proc = proc_create();
     proc_populate(proc, td);
-  }
 
-  /* Prepare file descriptor table */
-  /* TODO: Copy/share file descriptor table! */
-  fdtab_t *fdt = fdtab_alloc();
-  fdtab_ref(fdt);
-  td->td_proc->p_fdtable = fdt;
+    /* Prepare file descriptor table */
+    fdtab_t *fdt = fdtab_alloc();
+    fdtab_ref(fdt);
+    td->td_proc->p_fdtable = fdt;
+  }
 
   /* Before we have a working fork, let's initialize file descriptors required
      by the standard library. */

--- a/sys/fork.c
+++ b/sys/fork.c
@@ -53,6 +53,7 @@ int do_fork() {
   proc_populate(proc, newtd);
 
   /* Copy the parent descriptor table. */
+  /* TODO: Optionally share the descriptor table between processes. */
   proc->p_fdtable = fdtab_copy(td->td_proc->p_fdtable);
 
   sched_add(newtd);

--- a/sys/fork.c
+++ b/sys/fork.c
@@ -41,9 +41,6 @@ int do_fork() {
   /* Clone the entire process memory space. */
   newtd->td_uspace = vm_map_clone(td->td_uspace);
 
-  /* Copy the parent descriptor table. */
-  newtd->td_fdtable = fdtab_copy(td->td_fdtable);
-
   newtd->td_sleepqueue = sleepq_alloc();
   newtd->td_wchan = NULL;
   newtd->td_wmesg = NULL;
@@ -54,6 +51,9 @@ int do_fork() {
   assert(td->td_proc);
   proc_t *proc = proc_create();
   proc_populate(proc, newtd);
+
+  /* Copy the parent descriptor table. */
+  proc->p_fdtable = fdtab_copy(td->td_proc->p_fdtable);
 
   sched_add(newtd);
 

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -132,8 +132,6 @@ noreturn void thread_exit(int exitcode) {
       critical_leave();
   }
 
-  fdtab_release(td->td_fdtable);
-
   mtx_lock(&zombie_threads_mtx);
   TAILQ_INSERT_TAIL(&zombie_threads, td, td_zombieq);
   mtx_unlock(&zombie_threads_mtx);

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -7,6 +7,7 @@
 #include <thread.h>
 #include <vfs_syscalls.h>
 #include <vnode.h>
+#include <proc.h>
 #include <vm_map.h>
 
 int do_open(thread_t *td, char *pathname, int flags, int mode, int *fd) {
@@ -17,7 +18,8 @@ int do_open(thread_t *td, char *pathname, int flags, int mode, int *fd) {
   if (error)
     goto fail;
   /* Now install the file in descriptor table. */
-  error = fdtab_install_file(td->td_fdtable, f, fd);
+  assert(td->td_proc);
+  error = fdtab_install_file(td->td_proc->p_fdtable, f, fd);
   if (error)
     goto fail;
 
@@ -29,12 +31,14 @@ fail:
 }
 
 int do_close(thread_t *td, int fd) {
-  return fdtab_close_fd(td->td_fdtable, fd);
+  assert(td->td_proc);
+  return fdtab_close_fd(td->td_proc->p_fdtable, fd);
 }
 
 int do_read(thread_t *td, int fd, uio_t *uio) {
   file_t *f;
-  int res = fdtab_get_file(td->td_fdtable, fd, FF_READ, &f);
+  assert(td->td_proc);
+  int res = fdtab_get_file(td->td_proc->p_fdtable, fd, FF_READ, &f);
   if (res)
     return res;
   uio->uio_offset = f->f_offset;
@@ -46,7 +50,8 @@ int do_read(thread_t *td, int fd, uio_t *uio) {
 
 int do_write(thread_t *td, int fd, uio_t *uio) {
   file_t *f;
-  int res = fdtab_get_file(td->td_fdtable, fd, FF_WRITE, &f);
+  assert(td->td_proc);
+  int res = fdtab_get_file(td->td_proc->p_fdtable, fd, FF_WRITE, &f);
   if (res)
     return res;
   uio->uio_offset = f->f_offset;
@@ -60,7 +65,8 @@ int do_lseek(thread_t *td, int fd, off_t offset, int whence) {
   /* TODO: Whence! Now we assume whence == SEEK_SET */
   /* TODO: RW file flag! For now we just file_get_read */
   file_t *f;
-  int res = fdtab_get_file(td->td_fdtable, fd, 0, &f);
+  assert(td->td_proc);
+  int res = fdtab_get_file(td->td_proc->p_fdtable, fd, 0, &f);
   if (res)
     return res;
   f->f_offset = offset;
@@ -70,7 +76,8 @@ int do_lseek(thread_t *td, int fd, off_t offset, int whence) {
 
 int do_fstat(thread_t *td, int fd, vattr_t *buf) {
   file_t *f;
-  int res = fdtab_get_file(td->td_fdtable, fd, FF_READ, &f);
+  assert(td->td_proc);
+  int res = fdtab_get_file(td->td_proc->p_fdtable, fd, FF_READ, &f);
   if (res)
     return res;
   res = f->f_ops->fo_getattr(f, td, buf);


### PR DESCRIPTION
This was certainly simpler than `uspace`. Note that until we fix `exit` to kill all process' threads, the file descriptor table never gets released (because processes are never destroyed).