### PR TITLE
M_DEV memory pool

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -3,6 +3,7 @@
 
 #include <queue.h>
 #include <uio.h>
+#include <malloc.h>
 
 typedef struct device device_t;
 
@@ -24,5 +25,8 @@ struct device {
   d_read_t *d_read;
   d_write_t *d_write;
 };
+
+/* A universal memory pool to be used by all drivers. */
+MALLOC_DECLARE(M_DEV);
 
 #endif /* _SYS_DEVICE_H_ */

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -58,7 +58,7 @@ typedef struct kmem_pool {
   kmem_pool_t *pool = KMEM_POOL((desc), (npages), (maxpages));                 \
   SET_ENTRY(kmem_pool_table, pool)
 
-#define MALLOC_DECLARE(pool) extern kmem_pool_t pool[1]
+#define MALLOC_DECLARE(pool) extern kmem_pool_t *pool;
 
 /* Flags to malloc */
 #define M_WAITOK 0x0000 /* always returns memory block, but can sleep */

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -6,6 +6,7 @@ SOURCES_C  = \
 	clock.c \
 	condvar.c \
 	console.c \
+	device.c \
 	dev_cons.c \
 	dev_null.c \
 	dev_vga.c \
@@ -33,7 +34,7 @@ SOURCES_C  = \
 	sched.c \
 	sleepq.c \
 	startup.c \
-	stdvga.c \
+	drv_stdvga.c \
 	sync.c \
 	sysent.c \
 	mmap.c \

--- a/sys/device.c
+++ b/sys/device.c
@@ -1,0 +1,3 @@
+#include <device.h>
+
+MALLOC_DEFINE(M_DEV, "device/driver pool", 128, 1024);

--- a/sys/drv_stdvga.c
+++ b/sys/drv_stdvga.c
@@ -3,12 +3,9 @@
 #include <stdc.h>
 #include <malloc.h>
 #include <errno.h>
+#include <device.h>
 
 #define VGA_PALETTE_SIZE (256 * 3)
-
-/* TODO: It'd be better to have global memory pool for device drives as *BSD
- * does with M_DEVBUF, but for now we have to create local one. */
-MALLOC_DEFINE(M_STDVGA, "stdvga", 128, 256);
 
 typedef struct stdvga_device {
   pci_device_t *pci_device;
@@ -127,9 +124,9 @@ static int stdvga_set_videomode(vga_device_t *vga, unsigned xres, unsigned yres,
   stdvga_vbe_write(stdvga, VBE_DISPI_INDEX_BPP, stdvga->bpp);
 
   if (stdvga->fb_buffer)
-    kfree(M_STDVGA, stdvga->fb_buffer);
+    kfree(M_DEV, stdvga->fb_buffer);
   stdvga->fb_buffer =
-    kmalloc(M_STDVGA, sizeof(uint8_t) * stdvga->width * stdvga->height, M_ZERO);
+    kmalloc(M_DEV, sizeof(uint8_t) * stdvga->width * stdvga->height, M_ZERO);
 
   return 0;
 }
@@ -153,8 +150,7 @@ int stdvga_pci_attach(pci_device_t *pci) {
       pci->device_id != VGA_QEMU_STDVGA_DEVICE_ID)
     return 0;
 
-  /* XXX: This assumes `stdvga_pci_attach` will only get called once. */
-  stdvga_device_t *stdvga = kmalloc(M_STDVGA, sizeof(stdvga_device_t), M_ZERO);
+  stdvga_device_t *stdvga = kmalloc(M_DEV, sizeof(stdvga_device_t), M_ZERO);
 
   /* TODO: Enabling PCI regions should probably be performed by PCI bus resource
    * reservation code. */
@@ -176,7 +172,7 @@ int stdvga_pci_attach(pci_device_t *pci) {
 
   /* Prepare palette buffer */
   stdvga->palette_buffer =
-    kmalloc(M_STDVGA, sizeof(uint8_t) * VGA_PALETTE_SIZE, M_ZERO);
+    kmalloc(M_DEV, sizeof(uint8_t) * VGA_PALETTE_SIZE, M_ZERO);
 
   /* Apply resolution */
   stdvga_vbe_write(stdvga, VBE_DISPI_INDEX_XRES, stdvga->width);


### PR DESCRIPTION
I've removed `M_STDVGA` memory pool and created a generic `M_DEV`. I also took the opportunity to rename `stdvga.c` to `drv_stdvga.c`.

By the way, could we please merge [`device`](https://github.com/cahirwpz/mimiker/tree/device) branch ASAP and fix it later? Pretty much everything I'm trying to experiment with requires these `device` and `driver` structures to be present.