### PR TITLE
Change compiled flag from -Og to -O0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -41,7 +41,7 @@ GCC_SYSTEM_INC = -I$(GCC_INSTALL_PATH)include/ \
                  -D_LIBC_LIMITS_H_
 
 ASFLAGS  =
-CFLAGS   = -std=gnu11 -Og -Wall -Werror -fno-builtin -nostdinc -nostdlib \
+CFLAGS   = -std=gnu11 -O0 -Wall -Werror -fno-builtin -nostdinc -nostdlib \
            $(GCC_SYSTEM_INC) -ffreestanding
 CPPFLAGS = -Wall -Werror -DDEBUG -I$(TOPDIR)/include
 LDFLAGS  = -nostdlib -T $(TOPDIR)/mips/malta.ld


### PR DESCRIPTION
It is said that -Og flag is supposed not to interfere with debugging, but in fact it does. Apparently this makes register allocation, making gdb print message that value is in register instead of just printing it, and possibly some other optimizations. I find this rather annoying than useful, and obviously we don't need any kind of optimization. In future, when our kernel has more functionalities we might introduce `release` and `debug` builds.