### PR TITLE
Simplified mount interface

### DIFF
--- a/include/malloc.h
+++ b/include/malloc.h
@@ -74,4 +74,6 @@ void *kmalloc(kmem_pool_t *mp, size_t size, unsigned flags) __warn_unused;
 void kfree(kmem_pool_t *mp, void *addr);
 char *kstrndup(kmem_pool_t *mp, const char *s, size_t maxlen);
 
+MALLOC_DECLARE(M_TEMP);
+
 #endif /* _MALLOC_H_ */

--- a/include/mount.h
+++ b/include/mount.h
@@ -42,6 +42,11 @@ typedef struct vfsconf {
   TAILQ_ENTRY(vfsconf) vfc_list; /* Entry on the list of vfsconfs */
 } vfsconf_t;
 
+/* The list of all installed filesystem types */
+typedef TAILQ_HEAD(, vfsconf) vfsconf_list_t;
+extern vfsconf_list_t vfsconf_list;
+extern mtx_t vfsconf_list_mtx;
+
 /* This structure represents a mount point: a particular instance of a file
    system mounted somewhere in the file tree. */
 typedef struct mount {
@@ -88,9 +93,6 @@ mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc);
 /* Mount a new instance of the filesystem vfc at the vnode v. Does not support
  * remounting. TODO: Additional filesystem-specific arguments. */
 int vfs_domount(vfsconf_t *vfc, vnode_t *v);
-
-/* Mount a new instance of the filesystem named fs at the requested path. */
-int vfs_domount_named(const char *fs, const char *path);
 
 /* Finds the vnode corresponding to the given path.
  * Increases use count on returned vnode. */

--- a/include/mount.h
+++ b/include/mount.h
@@ -74,11 +74,8 @@ static inline int VFS_VGET(mount_t *m, ino_t ino, vnode_t **vp) {
   return m->mnt_vfsops->vfs_vget(m, ino, vp);
 }
 
-/* This is the / node. Since we aren't mounting anything on / just yet, there is
-   also a separate global vnode for /dev .*/
+/* This is the / node.*/
 extern vnode_t *vfs_root_vnode;
-extern vnode_t *vfs_root_dev_vnode;
-extern vnode_t *vfs_root_initrd_vnode;
 
 /* Look up a file system type by name. */
 vfsconf_t *vfs_get_by_name(const char *name);
@@ -91,6 +88,9 @@ mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc);
 /* Mount a new instance of the filesystem vfc at the vnode v. Does not support
  * remounting. TODO: Additional filesystem-specific arguments. */
 int vfs_domount(vfsconf_t *vfc, vnode_t *v);
+
+/* Mount a new instance of the filesystem named fs at the requested path. */
+int vfs_domount_named(const char *fs, const char *path);
 
 /* Finds the vnode corresponding to the given path.
  * Increases use count on returned vnode. */

--- a/include/sysent.h
+++ b/include/sysent.h
@@ -14,8 +14,9 @@
 #define SYS_SBRK 11
 #define SYS_MMAP 12
 #define SYS_FORK 13
+#define SYS_MOUNT 14
 
-#define SYS_LAST 13
+#define SYS_LAST 14
 
 #ifndef __ASSEMBLER__
 

--- a/include/vfs_syscalls.h
+++ b/include/vfs_syscalls.h
@@ -14,6 +14,8 @@ int do_read(thread_t *td, int fd, uio_t *uio);
 int do_write(thread_t *td, int fd, uio_t *uio);
 int do_lseek(thread_t *td, int fd, off_t offset, int whence);
 int do_fstat(thread_t *td, int fd, vattr_t *buf);
+/* Mount a new instance of the filesystem named fs at the requested path. */
+int do_mount(thread_t *td, const char *fs, const char *path);
 
 /* Syscall interface */
 int sys_open(thread_t *td, syscall_args_t *args);
@@ -22,5 +24,6 @@ int sys_read(thread_t *td, syscall_args_t *args);
 int sys_write(thread_t *td, syscall_args_t *args);
 int sys_lseek(thread_t *td, syscall_args_t *args);
 int sys_fstat(thread_t *td, syscall_args_t *args);
+int sys_mount(thread_t *td, syscall_args_t *args);
 
 #endif /* !_SYS_VFS_SYSCALLS_H_ */

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -114,15 +114,8 @@ static int devfs_init(vfsconf_t *vfc) {
   SET_DECLARE(devfs_init, devfs_init_func_t);
   devfs_init_func_t **ptr;
   SET_FOREACH(ptr, devfs_init) {
-    log("Value in devfs_init: %p", **ptr);
     (**ptr)();
   }
-
-  /* Mount devfs at /dev. */
-  /* TODO: This should actually happen somewhere else in the init process, much
-   * later, and is configuration-dependent. */
-  vfs_domount(vfc, vfs_root_dev_vnode);
-
   return 0;
 }
 

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -36,6 +36,8 @@ typedef struct cpio_node {
   const char *c_path; /* contains exact path to file as archived by cpio */
   const char *c_name; /* contains name of file */
   void *c_data;
+  /* Associated vnode. */
+  vnode_t *c_vnode;
 } cpio_node_t;
 
 typedef TAILQ_HEAD(, cpio_node) cpio_list_t;
@@ -185,11 +187,22 @@ static int initrd_vnode_lookup(vnode_t *vdir, const char *name, vnode_t **res) {
 
   TAILQ_FOREACH (it, &cn_dir->c_children, c_siblings) {
     if (strcmp(name, it->c_name) == 0) {
-      vnodetype_t type = V_REG;
-      if (it->c_mode & C_ISDIR)
-        type = V_DIR;
-      *res = vnode_new(type, &initrd_ops);
-      (*res)->v_data = (void *)it;
+      if (it->c_vnode) {
+        *res = it->c_vnode;
+      } else {
+        /* Create new vnode */
+        vnodetype_t type = V_REG;
+        if (it->c_mode & C_ISDIR)
+          type = V_DIR;
+        *res = vnode_new(type, &initrd_ops);
+        (*res)->v_data = (void *)it;
+
+        /* TODO: Only store a token (weak pointer) that allows looking up the
+           vnode, otherwise the vnode will never get freed. */
+        it->c_vnode = *res;
+        vnode_ref(*res);
+      }
+      /* Reference for the caller */
       vnode_ref(*res);
       return 0;
     }
@@ -229,7 +242,6 @@ static int initrd_root(mount_t *m, vnode_t **v) {
 }
 
 static int initrd_init(vfsconf_t *vfc) {
-  vfs_domount(vfc, vfs_root_vnode);
   return 0;
 }
 

--- a/sys/malloc.c
+++ b/sys/malloc.c
@@ -267,3 +267,5 @@ void kmem_dump(kmem_pool_t *mp) {
 /* TODO: missing implementation */
 void kmem_destroy(kmem_pool_t *mp) {
 }
+
+MALLOC_DEFINE(M_TEMP, "temporaries pool", 2, 4);

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -17,6 +17,7 @@
 #include <initrd.h>
 #include <device.h>
 #include <proc.h>
+#include <vfs_syscalls.h>
 
 extern void main(void *);
 
@@ -56,6 +57,6 @@ int kernel_init(int argc, char **argv) {
 /* This function mounts some initial filesystems. Normally this would be done by
    userspace init program. */
 static void mount_fs() {
-  vfs_domount_named("initrd", "/");
-  vfs_domount_named("devfs", "/dev");
+  do_mount(thread_self(), "initrd", "/");
+  do_mount(thread_self(), "devfs", "/dev");
 }

--- a/sys/startup.c
+++ b/sys/startup.c
@@ -20,6 +20,8 @@
 
 extern void main(void *);
 
+static void mount_fs();
+
 int kernel_init(int argc, char **argv) {
   kprintf("Kernel arguments (%d): ", argc);
   for (int i = 0; i < argc; i++)
@@ -41,6 +43,7 @@ int kernel_init(int argc, char **argv) {
   proc_init();
 
   driver_init();
+  mount_fs();
 
   kprintf("[startup] kernel initialized\n");
 
@@ -48,4 +51,11 @@ int kernel_init(int argc, char **argv) {
   sched_add(main_thread);
 
   sched_run();
+}
+
+/* This function mounts some initial filesystems. Normally this would be done by
+   userspace init program. */
+static void mount_fs() {
+  vfs_domount_named("initrd", "/");
+  vfs_domount_named("devfs", "/dev");
 }

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -60,4 +60,4 @@ sysent_t sysent[] = {[SYS_EXIT] = {sys_exit},    [SYS_OPEN] = {sys_open},
                      [SYS_UNLINK] = {sys_nosys}, [SYS_GETPID] = {sys_getpid},
                      [SYS_KILL] = {sys_nosys},   [SYS_FSTAT] = {sys_fstat},
                      [SYS_SBRK] = {sys_sbrk},    [SYS_MMAP] = {sys_mmap},
-                     [SYS_FORK] = {sys_fork}};
+                     [SYS_FORK] = {sys_fork},    [SYS_MOUNT] = {sys_mount}};

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -10,9 +10,8 @@
 static MALLOC_DEFINE(M_VFS, "vfs", 1, 2);
 
 /* The list of all installed filesystem types */
-typedef TAILQ_HEAD(, vfsconf) vfsconf_list_t;
-static vfsconf_list_t vfsconf_list = TAILQ_HEAD_INITIALIZER(vfsconf_list);
-static mtx_t vfsconf_list_mtx;
+vfsconf_list_t vfsconf_list = TAILQ_HEAD_INITIALIZER(vfsconf_list);
+mtx_t vfsconf_list_mtx;
 
 /* The list of all mounts mounted */
 typedef TAILQ_HEAD(, mount) mount_list_t;
@@ -157,22 +156,6 @@ int vfs_domount(vfsconf_t *vfc, vnode_t *v) {
      updates their dirs to reflect on the mounted file system... */
 
   return 0;
-}
-
-int vfs_domount_named(const char *fs, const char *path) {
-  vfsconf_t *vfs;
-  TAILQ_FOREACH (vfs, &vfsconf_list, vfc_list) {
-    if (strncmp(vfs->vfc_name, fs, VFSCONF_NAME_MAX) == 0) {
-      goto found;
-    }
-  }
-  return -EINVAL;
-found:;
-  vnode_t *v;
-  int error = vfs_lookup(path, &v);
-  if (error)
-    return error;
-  return vfs_domount(vfs, v);
 }
 
 int vfs_lookup(const char *path, vnode_t **vp) {

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -9,6 +9,8 @@
 #include <vnode.h>
 #include <proc.h>
 #include <vm_map.h>
+#include <queue.h>
+#include <errno.h>
 
 int do_open(thread_t *td, char *pathname, int flags, int mode, int *fd) {
   /* Allocate a file structure, but do not install descriptor yet. */
@@ -83,6 +85,17 @@ int do_fstat(thread_t *td, int fd, vattr_t *buf) {
   res = f->f_ops->fo_getattr(f, td, buf);
   file_unref(f);
   return res;
+}
+
+int do_mount(thread_t *td, const char *fs, const char *path) {
+  vfsconf_t *vfs = vfs_get_by_name(fs);
+  if (vfs == NULL)
+    return -EINVAL;
+  vnode_t *v;
+  int error = vfs_lookup(path, &v);
+  if (error)
+    return error;
+  return vfs_domount(vfs, v);
 }
 
 /* == System calls interface === */
@@ -172,4 +185,28 @@ int sys_fstat(thread_t *td, syscall_args_t *args) {
   if (error < 0)
     return error;
   return 0;
+}
+
+int sys_mount(thread_t *td, syscall_args_t *args) {
+  char *user_fsysname = (char *)args->args[0];
+  char *user_pathname = (char *)args->args[1];
+
+  int error = 0;
+  char fsysname[256];
+  char pathname[256];
+  size_t n = 0;
+
+  /* Copyout fsysname. */
+  error = copyinstr(user_fsysname, fsysname, sizeof(fsysname), &n);
+  if (error < 0)
+    return error;
+  n = 0;
+  /* Copyout pathname. */
+  error = copyinstr(user_pathname, pathname, sizeof(pathname), &n);
+  if (error < 0)
+    return error;
+
+  log("mount(\"%s\", \"%s\")", pathname, fsysname);
+
+  return do_mount(td, fsysname, pathname);
 }

--- a/sys/vfs_syscalls.c
+++ b/sys/vfs_syscalls.c
@@ -194,8 +194,8 @@ int sys_mount(thread_t *td, syscall_args_t *args) {
 
   int error = 0;
   const int PATHSIZE_MAX = 256;
-  char* fsysname = kmalloc(M_TEMP, PATHSIZE_MAX, 0);
-  char* pathname = kmalloc(M_TEMP, PATHSIZE_MAX, 0);
+  char *fsysname = kmalloc(M_TEMP, PATHSIZE_MAX, 0);
+  char *pathname = kmalloc(M_TEMP, PATHSIZE_MAX, 0);
   size_t n = 0;
 
   /* Copyout fsysname. */
@@ -211,7 +211,7 @@ int sys_mount(thread_t *td, syscall_args_t *args) {
   log("mount(\"%s\", \"%s\")", pathname, fsysname);
 
   error = do_mount(td, fsysname, pathname);
- end:
+end:
   kfree(M_TEMP, fsysname);
   kfree(M_TEMP, pathname);
   return error;

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -15,7 +15,7 @@ static int test_vfs() {
   assert(error == 0 && v == vfs_root_vnode);
   vnode_unref(v);
   error = vfs_lookup("/dev////", &v);
-  assert(error == 0 && v == vfs_root_dev_vnode);
+  assert(error == 0);
   vnode_unref(v);
 
   vnode_t *dev_null, *dev_zero;


### PR DESCRIPTION
Initially I only wanted to remove the `if (strncmp(path, "/dev/", 5) == 0)` and associated `vfs_root_dev_vnode`, turned out some extra cleanup to the mount process was required, and I ended up with an elegant
```c
vfs_domount_named("initrd", "/");
vfs_domount_named("devfs", "/dev");
```
in `kernel_init(...)`.