### PR TITLE
Minor debugging experience improvements

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,7 +1,8 @@
 set tcp connect-timeout 30
 target remote localhost:1234
-break main
+break kernel_init
 break assert_fail
+break panic_fail
 continue
 
 source debug/ktrace.py

--- a/.gdbinit.template
+++ b/.gdbinit.template
@@ -1,5 +1,5 @@
 set tcp connect-timeout 30
-target remote localhost:GDB_PORT
+target remote localhost:${GDB_PORT}
 break kernel_init
 break assert_fail
 break panic_fail

--- a/.gdbinit.template
+++ b/.gdbinit.template
@@ -1,5 +1,5 @@
 set tcp connect-timeout 30
-target remote localhost:1234
+target remote localhost:GDB_PORT
 break kernel_init
 break assert_fail
 break panic_fail

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ cache
 
 # Dynamically created sysroot
 sysroot
+
+# Dynamically generated gdb config
+.gdbinit

--- a/include/common.h
+++ b/include/common.h
@@ -105,12 +105,12 @@ typedef uint16_t ino_t;
 #ifndef _USERSPACE
 
 /* Terminate thread. */
-noreturn void thread_exit();
+noreturn void panic_fail();
 
 #define panic(FMT, ...)                                                        \
   __extension__({                                                              \
-    kprintf("[%s:%d] " FMT "\n", __FILE__, __LINE__, ##__VA_ARGS__);           \
-    thread_exit(-1);                                                           \
+    kprintf("[%s:%d] PANIC: " FMT "\n", __FILE__, __LINE__, ##__VA_ARGS__);    \
+    panic_fail();                                                              \
   })
 
 #ifdef DEBUG

--- a/launch
+++ b/launch
@@ -6,7 +6,7 @@ import os.path
 import signal
 import launcher
 
-UART_PORT = 8000
+UART_PORT_BASE = 8000
 
 if __name__ == '__main__':
     # Probe which tools are available.
@@ -71,15 +71,18 @@ if __name__ == '__main__':
         raise SystemExit('ERROR: Unable to start both debugger and simulator in'
                          ' stdio output mode.')
 
+    port = UART_PORT_BASE + os.getuid()
+    print(port)
+    
     sim = simulators[args.simulator]
     out = outputs[args.output]
     dbg = debuggers[args.debugger]
-
+    
     cfg_args = {'kernel': args.kernel,
                 'args': ' '.join(args.args),
                 'debug': debug,
                 'graphics': args.graphics,
-                'uart_port': UART_PORT}
+                'uart_port': port}
 
     sim.configure(**cfg_args)
     out.configure(**cfg_args)

--- a/launch
+++ b/launch
@@ -72,7 +72,6 @@ if __name__ == '__main__':
                          ' stdio output mode.')
 
     port = UART_PORT_BASE + os.getuid()
-    print(port)
     
     sim = simulators[args.simulator]
     out = outputs[args.output]

--- a/launch
+++ b/launch
@@ -7,6 +7,7 @@ import signal
 import launcher
 
 UART_PORT_BASE = 8000
+GDB_PORT_BASE = 9100
 
 if __name__ == '__main__':
     # Probe which tools are available.
@@ -71,7 +72,10 @@ if __name__ == '__main__':
         raise SystemExit('ERROR: Unable to start both debugger and simulator in'
                          ' stdio output mode.')
 
-    port = UART_PORT_BASE + os.getuid()
+    uart_port = UART_PORT_BASE + os.getuid()
+    gdb_port = GDB_PORT_BASE + os.getuid();
+
+    launcher.prepare_gdbinit(gdb_port)
     
     sim = simulators[args.simulator]
     out = outputs[args.output]
@@ -81,7 +85,8 @@ if __name__ == '__main__':
                 'args': ' '.join(args.args),
                 'debug': debug,
                 'graphics': args.graphics,
-                'uart_port': port}
+                'gdb_port': gdb_port,
+                'uart_port': uart_port}
 
     sim.configure(**cfg_args)
     out.configure(**cfg_args)

--- a/launch
+++ b/launch
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     parser.add_argument('-s', action='store_true',
                         help='Shorthand for --output server')
     parser.add_argument('-d', action='store_true',
-                        help='Shorthand for --debugger cgdb.')
+                        help='Shorthand for --debugger gdb.')
     parser.add_argument('-g', '--graphics', action='store_true',
                         help='Enable VGA output.')
     args = parser.parse_args()
@@ -64,7 +64,7 @@ if __name__ == '__main__':
 
     # Support -d option
     if args.d:
-        args.debugger = 'cgdb'
+        args.debugger = 'gdb'
 
     debug = args.debugger != 'none'
 

--- a/launcher/common.py
+++ b/launcher/common.py
@@ -81,3 +81,12 @@ def wait_any(launchables):
                 return
         except subprocess.TimeoutExpired:
             continue
+
+def prepare_gdbinit(gdb_port):
+    with open('.gdbinit.template', 'r') as file:
+        gdbinit = file.read()
+        
+    gdbinit = gdbinit.replace('GDB_PORT', str(gdb_port))
+    
+    with open('.gdbinit', 'w') as file:
+        file.write(gdbinit)

--- a/launcher/common.py
+++ b/launcher/common.py
@@ -2,9 +2,11 @@ import subprocess
 import itertools
 import shutil
 import signal
+import string
 import os
 
 TRIPLET = 'mipsel-mimiker-elf'
+
 
 def set_as_tty_foreground():
     # Create a new process group just for us
@@ -68,8 +70,8 @@ class Launchable:
             self.process.send_signal(signal.SIGINT)
 
     @staticmethod
-    # The items on these lists should be ordered from the most desirable. The first
-    # available item will become the default option.
+    # The items on these lists should be ordered from the most desirable.
+    # The first available item will become the default option.
     def find_available(l):
         result, default = {}, None
         for item in reversed(l):
@@ -77,6 +79,7 @@ class Launchable:
                 result[item.name] = item
                 default = item.name
         return (result, default)
+
 
 def wait_any(launchables):
     for l in itertools.cycle(launchables):
@@ -87,11 +90,12 @@ def wait_any(launchables):
         except subprocess.TimeoutExpired:
             continue
 
+
 def prepare_gdbinit(gdb_port):
-    with open('.gdbinit.template', 'r') as file:
-        gdbinit = file.read()
-        
-    gdbinit = gdbinit.replace('GDB_PORT', str(gdb_port))
-    
-    with open('.gdbinit', 'w') as file:
-        file.write(gdbinit)
+    with open('.gdbinit.template', 'r') as f:
+        gdbinit = string.Template(f.read())
+
+    subs = {'GDB_PORT': gdb_port}
+
+    with open('.gdbinit', 'w') as f:
+        f.write(gdbinit.substitute(subs))

--- a/launcher/outputs.py
+++ b/launcher/outputs.py
@@ -24,11 +24,30 @@ class XTermOutput(Launchable):
         return self.cmd is not None
 
     def configure(self, **kwargs):
+        port = kwargs['uart_port']
         # The simulator will only open the server after some time has
         # passed. OVPsim needs as much as 1 second. To minimize the delay, keep
         # reconnecting until success.
         self.options = ['-title', 'UART2', '-e',
-                        'socat STDIO tcp:localhost:%d,retry,forever' % kwargs['uart_port']]
+                        'socat STDIO tcp:localhost:%d,retry,forever' % port]
+
+
+class UrxvtOutput(Launchable):
+
+    def __init__(self):
+        Launchable.__init__(self, 'urxvt')
+
+    def probe(self):
+        self.cmd = shutil.which('urxvt')
+        return self.cmd is not None
+
+    def configure(self, **kwargs):
+        port = kwargs['uart_port']
+        # The simulator will only open the server after some time has
+        # passed. OVPsim needs as much as 1 second. To minimize the delay, keep
+        # reconnecting until success.
+        self.options = ['-title', 'UART2', '-e', 'sh', '-c',
+                        'socat STDIO tcp:localhost:%d,retry,forever' % port]
 
 
 class StdIOOutput(Launchable):
@@ -40,13 +59,15 @@ class StdIOOutput(Launchable):
         return True
 
     def configure(self, **kwargs):
+        port = kwargs['uart_port']
         # The simulator will only open the server after some time has
         # passed. OVPsim needs as much as 1 second. To minimize the delay, keep
         # reconnecting until success.
         self.cmd = 'socat'
-        self.options = ['STDIO', 'tcp:localhost:%d,retry,forever' % kwargs['uart_port']]
+        self.options = ['STDIO', 'tcp:localhost:%d,retry,forever' % port]
 
 
-OUTPUTS = [XTermOutput(),
+OUTPUTS = [UrxvtOutput(),
+           XTermOutput(),
            StdIOOutput(),
            ServerOutput()]

--- a/launcher/simulators.py
+++ b/launcher/simulators.py
@@ -46,7 +46,7 @@ class OVPsim(Launchable):
             self.options += ['--nographics']
         
         if kwargs['debug']:
-            self.options += ['--port', '1234']
+            self.options += ['--port', str(kwargs['gdb_port'])]
 
         for item in OVPSIM_OVERRIDES.items():
             self.options += ['--override', '%s=%s' % item]
@@ -68,7 +68,7 @@ class QEMU(Launchable):
                         '-cpu', '24Kf',
                         '-kernel', kwargs['kernel'],
                         '-append', kwargs['args'],
-                        '-gdb', 'tcp::1234',
+                        '-gdb', 'tcp::%d' % kwargs['gdb_port'],
                         '-initrd', 'initrd.cpio',
                         '-serial', 'none',
                         '-serial', 'null',

--- a/mips/exc.S
+++ b/mips/exc.S
@@ -175,6 +175,8 @@ user_exc_leave:
         LOAD_REG($v0, V0, $k0)
         LOAD_REG($at, AT, $k0)
 
+        # This label is useful for debugging.
+user_return:
         sync
         eret
 

--- a/sys/assert.c
+++ b/sys/assert.c
@@ -1,6 +1,17 @@
 #include <common.h>
 #include <stdc.h>
 #include <ktest.h>
+#include <sync.h>
+
+noreturn void panic_fail() {
+  /* We used to terminate the current thread, but that is not a great way of
+     panicking, as other threads will continue executing, and our panic might go
+     unnoticed. */
+  /* Permanently lock the kernel. */
+  critical_enter();
+  while (1)
+    ;
+}
 
 void assert_fail(const char *expr, const char *file, unsigned int line) {
   kprintf("Assertion \"%s\" at [%s:%d] failed!", expr, file, line);


### PR DESCRIPTION
- I've added a `user_return` label user before `eret` in `user_exc_leave`. When debugging user programs and/or syscalls, it is very convenient to place a `tbreak` on this label, to continue debugging the user application from the moment the current system call returns.

- As our kernel `main` no longer does anything interesting, I've changed the implicit breakpoint from `main` to `kernel_init`, so that a default debugging session starts there.

- I've added a boring `panic_fail` function (similar to `assert_fail`) so that I could add an implicit breakpoint on it. This way a default debugging session will not only automatically stop at failed assertions, but also at any panic condition.