### PR TITLE
Improved devfs_install

### DIFF
--- a/include/devfs.h
+++ b/include/devfs.h
@@ -5,7 +5,9 @@
 
 typedef struct vnode vnode_t;
 
+#define DEVFS_INSTALL_FLAG_NUMBERED 0x1
+
 /* Installs a new device into the devfs */
-int devfs_install(const char *name, vnode_t *device);
+int devfs_install(const char *name, vnode_t *device, unsigned flags);
 
 #endif /* !_SYS_DEVFS_H_ */

--- a/sys/dev_cons.c
+++ b/sys/dev_cons.c
@@ -51,7 +51,7 @@ vnodeops_t dev_cons_vnodeops = {
 
 void init_dev_cons() {
   dev_cons_device = vnode_new(V_DEV, &dev_cons_vnodeops);
-  devfs_install("cons", dev_cons_device);
+  devfs_install("cons", dev_cons_device, DEVFS_INSTALL_FLAG_NUMBERED);
 }
 
 SET_ENTRY(devfs_init, init_dev_cons);

--- a/sys/dev_null.c
+++ b/sys/dev_null.c
@@ -67,8 +67,8 @@ static void init_dev_null() {
   dev_null_device = vnode_new(V_DEV, &dev_null_vnodeops);
   dev_zero_device = vnode_new(V_DEV, &dev_zero_vnodeops);
 
-  devfs_install("null", dev_null_device);
-  devfs_install("zero", dev_zero_device);
+  devfs_install("null", dev_null_device, 0);
+  devfs_install("zero", dev_zero_device, 0);
 }
 
 SET_ENTRY(devfs_init, init_dev_null);

--- a/sys/dev_vga.c
+++ b/sys/dev_vga.c
@@ -111,11 +111,7 @@ vnodeops_t dev_vga_vnodeops = {
 };
 
 void dev_vga_install(vga_device_t *vga) {
-  static int installed = 0;
-  if (installed++) /* Only a single vga device may be installed at /dev/vga. */
-    return;
-
   vnode_t *dev_vga_device = vnode_new(V_DIR, &dev_vga_vnodeops);
   dev_vga_device->v_data = vga;
-  devfs_install("vga", dev_vga_device);
+  devfs_install("vga", dev_vga_device, DEVFS_INSTALL_FLAG_NUMBERED);
 }


### PR DESCRIPTION
This branch adds an optional `DEVFS_INSTALL_FLAG_NUMBERED` flag for `devfs_install`, which allows installing multiple devices sharing the same name into `/dev` - they will be automatically numbered e.g. `/dev/vga` (== `/dev/vga0`), `/dev/vga1`, `/dev/vga2`, ... This removes the silly assumption that only the first device of a particular driver may expose a `/dev` interface.

I've also fixed a potential race condition in `devfs_install`.