### PR TITLE
Vfs lookup mount fix

### DIFF
--- a/include/vnode.h
+++ b/include/vnode.h
@@ -54,6 +54,10 @@ typedef struct vnode {
   mtx_t v_mtx;
 } vnode_t;
 
+static inline bool is_mountpoint(vnode_t *v) {
+  return v->v_mountedhere != NULL;
+}
+
 #if !defined(IGNORE_NEWLIB_COMPATIBILITY)
 /* This must match newlib's implementation! */
 typedef struct vattr {

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -158,8 +158,7 @@ int vfs_domount(vfsconf_t *vfc, vnode_t *v) {
   return 0;
 }
 
-static int vfs_assign_mounted_child(vnode_t **vnode)
-{
+static int vfs_assign_mounted_child(vnode_t **vnode) {
   vnode_t *v_mntpt;
   int error = VFS_ROOT((*vnode)->v_mountedhere, &v_mntpt);
   vnode_unlock(*vnode);
@@ -201,10 +200,9 @@ int vfs_lookup(const char *path, vnode_t **vp) {
   vnode_ref(v);
   vnode_lock(v);
 
-  while(v->v_mountedhere)
-  {
+  while (v->v_mountedhere) {
     int error = vfs_assign_mounted_child(&v);
-    if(error)
+    if (error)
       return error;
   }
 
@@ -225,10 +223,9 @@ int vfs_lookup(const char *path, vnode_t **vp) {
      * us. */
     vnode_lock(v);
 
-    while(v->v_mountedhere)
-    {
+    while (v->v_mountedhere) {
       int error = vfs_assign_mounted_child(&v);
-      if(error)
+      if (error)
         return error;
     }
   }

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -12,10 +12,18 @@ static int test_vfs() {
   error = vfs_lookup("/dev/SPAM", &v);
   assert(error == -ENOENT);
   error = vfs_lookup("/", &v);
-  assert(error == 0 && v == vfs_root_vnode);
+  assert(error == 0);
+  /* Ensure the v is the initrd mountpoint. */
+  assert(strncmp(v->v_mount->mnt_vfc->vfc_name, "initrd", strlen("initrd")) == 0);
   vnode_unref(v);
   error = vfs_lookup("/dev////", &v);
   assert(error == 0);
+  /* Ensure the v belongs to devfs, not initrd. */
+  assert(strncmp(v->v_mount->mnt_vfc->vfc_name, "devfs", strlen("devfs")) == 0);
+  vnode_unref(v);
+
+  error = vfs_lookup("/dev", &v);
+  assert(error == 0 && v->v_mountedhere == NULL);
   vnode_unref(v);
 
   vnode_t *dev_null, *dev_zero;

--- a/tests/vfs.c
+++ b/tests/vfs.c
@@ -14,7 +14,8 @@ static int test_vfs() {
   error = vfs_lookup("/", &v);
   assert(error == 0);
   /* Ensure the v is the initrd mountpoint. */
-  assert(strncmp(v->v_mount->mnt_vfc->vfc_name, "initrd", strlen("initrd")) == 0);
+  assert(strncmp(v->v_mount->mnt_vfc->vfc_name, "initrd", strlen("initrd")) ==
+         0);
   vnode_unref(v);
   error = vfs_lookup("/dev////", &v);
   assert(error == 0);


### PR DESCRIPTION
In current version of vfs_lookup there was a 'bug' or more likely a misunderstanding with how lookup is supposed to work. The bug is about performing vfs_lookup where the leaf (last directory on path) has something mounted under it, in this case we want to return the mounted child.

I have looked up at FreeBSD implementation to have better understanding and possibly ease implementation, but it is incredibly difficult to read because of all the cases it covers + path caching.

Here is vfs_lookup counterpart in FreeBSD:

[http://bxr.su/FreeBSD/sys/kern/vfs_lookup.c#124](http://bxr.su/FreeBSD/sys/kern/vfs_lookup.c#124)

Note that namei procedure calls lookup in few places, while lookup performs mounting fix in this line:

[http://bxr.su/FreeBSD/sys/kern/vfs_lookup.c#789](http://bxr.su/FreeBSD/sys/kern/vfs_lookup.c#789)

There is no fixing a mounted name before we enter the lookup procedure, but if you look at it's starting argument [http://bxr.su/FreeBSD/sys/sys/namei.h#72](http://bxr.su/FreeBSD/sys/sys/namei.h#72), it is assigned in [http://bxr.su/FreeBSD/sys/kern/vfs_lookup.c#514](http://bxr.su/FreeBSD/sys/kern/vfs_lookup.c#514), meaning that the vnode we pass to lookup is already the deepest mounted subchild. In our case we have only one lookup function getting full path, so we have to fix that assumption before main lookup loop.

Our implementation still lacks a lot of features and It doesn't have to perfect yet. Please don't waste too much time discussing on this simple change, #268 depends on this.