### PR TITLE
High resolution timer

### DIFF
--- a/include/clock.h
+++ b/include/clock.h
@@ -1,9 +1,7 @@
 #ifndef __CLOCK_H__
 #define __CLOCK_H__
 
-#include <stdint.h>
-
-typedef int64_t realtime_t;
+#include <time.h>
 
 realtime_t clock_get();
 void clock(realtime_t ms);

--- a/include/time.h
+++ b/include/time.h
@@ -1,0 +1,45 @@
+#ifndef _SYS_TIME_H_
+#define _SYS_TIME_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef long realtime_t;
+
+typedef struct timeval {
+  long tv_sec;  /* seconds */
+  long tv_usec; /* microseconds */
+} timeval_t;
+
+/* Operations on timevals. */
+static inline void timerclear(timeval_t *tvp) {
+  *tvp = (timeval_t){.tv_sec = 0, .tv_usec = 0};
+}
+
+static inline bool timerisset(timeval_t *tvp) {
+  return tvp->tv_sec || tvp->tv_usec;
+}
+
+#define timercmp(tvp, uvp, cmp)                                                \
+  (((tvp)->tv_sec == (uvp)->tv_sec) ? (((tvp)->tv_usec)cmp((uvp)->tv_usec))    \
+                                    : (((tvp)->tv_sec)cmp((uvp)->tv_sec)))
+
+static inline void timeradd(timeval_t *tvp, timeval_t *uvp, timeval_t *vvp) {
+  vvp->tv_sec = tvp->tv_sec + uvp->tv_sec;
+  vvp->tv_usec = tvp->tv_usec + uvp->tv_usec;
+  if (vvp->tv_usec >= 1000000) {
+    vvp->tv_sec++;
+    vvp->tv_usec -= 1000000;
+  }
+}
+
+static inline void timersub(timeval_t *tvp, timeval_t *uvp, timeval_t *vvp) {
+  vvp->tv_sec = tvp->tv_sec - uvp->tv_sec;
+  vvp->tv_usec = tvp->tv_usec - uvp->tv_usec;
+  if (vvp->tv_usec < 0) {
+    vvp->tv_sec--;
+    vvp->tv_usec += 1000000;
+  }
+}
+
+#endif /* !_SYS_TIME_H_ */


### PR DESCRIPTION
To increase the resolution of kernel clock we should probably migrate from `realtime_t` to `timeval_t`. Firstly hardware clock in [mips/clock.c](https://github.com/cahirwpz/mimiker/blob/master/mips/clock.c) should be rewritten to maintain `timeval_t` time, then [sys/clock.c](https://github.com/cahirwpz/mimiker/blob/master/sys/clock.c) should follow. @czapiga After that's done you can continue with #253.