### PR TITLE
Python-like with statement for mutex locking

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -45,7 +45,7 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ TAILQ_FOREACH, SPLAY_FOREACH, RB_FOREACH ]
+ForEachMacros:   [ TAILQ_FOREACH, SPLAY_FOREACH, RB_FOREACH, WITH_MTX_LOCK ]
 IncludeCategories: 
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2

--- a/.clang-format
+++ b/.clang-format
@@ -45,7 +45,8 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ TAILQ_FOREACH, SPLAY_FOREACH, RB_FOREACH, WITH_MTX_LOCK ]
+ForEachMacros:   [ TAILQ_FOREACH, SPLAY_FOREACH, RB_FOREACH, WITH_MTX_LOCK,
+                   IN_CRITICAL_SECTION, WITH_RW_LOCK ]
 IncludeCategories: 
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2

--- a/.clang-format
+++ b/.clang-format
@@ -46,7 +46,7 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ TAILQ_FOREACH, SPLAY_FOREACH, RB_FOREACH, WITH_MTX_LOCK,
-                   IN_CRITICAL_SECTION, WITH_RW_LOCK ]
+                   CRITICAL_SECTION, WITH_RW_LOCK ]
 IncludeCategories: 
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2

--- a/include/common.h
+++ b/include/common.h
@@ -35,6 +35,7 @@ typedef uint32_t tid_t;
 #define __aligned(x) __attribute__((__aligned__(x)))
 #define __warn_unused __attribute__((warn_unused_result));
 #define __unreachable() __builtin_unreachable()
+#define __alias(x) __attribute__((alias(#x)))
 
 /* Macros for counting and rounding. */
 #ifndef howmany

--- a/include/common.h
+++ b/include/common.h
@@ -36,6 +36,7 @@ typedef uint32_t tid_t;
 #define __warn_unused __attribute__((warn_unused_result));
 #define __unreachable() __builtin_unreachable()
 #define __alias(x) __attribute__((alias(#x)))
+#define __cleanup(func) __attribute__((__cleanup__(func)))
 
 /* Macros for counting and rounding. */
 #ifndef howmany
@@ -97,13 +98,14 @@ typedef uint32_t tid_t;
 #define container_of(p, type, field)                                           \
   ((type *)((char *)(p)-offsetof(type, field)))
 
-#define cleanup(func) __attribute__((__cleanup__(cleanup_##func)))
 #define DEFINE_CLEANUP_FUNCTION(type, func)                                    \
-  static inline void cleanup_##func(type *ptr) {                               \
+  static inline void __cleanup_##func(type *ptr) {                             \
     if (*ptr)                                                                  \
       func(*ptr);                                                              \
   }                                                                            \
   struct __force_semicolon__
+
+#define WITH_CLEANUP(func) __cleanup(__cleanup_##func)
 
 #ifndef _USERSPACE
 

--- a/include/common.h
+++ b/include/common.h
@@ -98,14 +98,13 @@ typedef uint32_t tid_t;
 #define container_of(p, type, field)                                           \
   ((type *)((char *)(p)-offsetof(type, field)))
 
+#define USES_CLEANUP(func) __cleanup(__cleanup_##func)
 #define DEFINE_CLEANUP_FUNCTION(type, func)                                    \
   static inline void __cleanup_##func(type *ptr) {                             \
     if (*ptr)                                                                  \
       func(*ptr);                                                              \
   }                                                                            \
   struct __force_semicolon__
-
-#define WITH_CLEANUP(func) __cleanup(__cleanup_##func)
 
 #ifndef _USERSPACE
 

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -35,13 +35,9 @@ void mtx_unlock(mtx_t *m);
 DEFINE_CLEANUP_FUNCTION(mtx_t *, mtx_unlock);
 
 #define SCOPED_MTX_LOCK(mtx_p)                                                 \
-  mtx_t *__CONCAT(__mtx_, __LINE__) USES_CLEANUP(mtx_unlock) = ({              \
-    mtx_lock(mtx_p);                                                           \
-    mtx_p;                                                                     \
-  })
+  SCOPED_STMT(mtx_t, mtx_lock, CLEANUP_FUNCTION(mtx_unlock), mtx_p)
 
 #define WITH_MTX_LOCK(mtx_p)                                                   \
-  for (SCOPED_MTX_LOCK(mtx_p), *__CONCAT(__loop_, __LINE__) = (mtx_t *)1;      \
-       __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = NULL)
+  WITH_STMT(mtx_t, mtx_lock, CLEANUP_FUNCTION(mtx_unlock), mtx_p)
 
 #endif /* !_SYS_MUTEX_H_ */

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -25,6 +25,7 @@ bool mtx_owned(mtx_t *mtx);
 /* Locks the mutex, if the mutex is already owned by someone,
  * then this blocks on sleepqueue, otherwise it takes the mutex. */
 void mtx_lock(mtx_t *m);
+mtx_t *_mtx_lock(mtx_t *m);
 
 /* Unlocks the mutex. If some thread blocked for the mutex,
  * then it wakes up the thread in FIFO manner. */
@@ -33,8 +34,11 @@ void mtx_unlock(mtx_t *m);
 /* Use mtx_lock_guard to lock a mutex and have it automatically unlock when
    leaving current scope. */
 DEFINE_CLEANUP_FUNCTION(mtx_t *, mtx_unlock);
-#define mtx_scoped_lock(pmtx)                                                  \
-  mtx_t *__CONCAT(mtx_scoped_lock_, __LINE__) cleanup(mtx_unlock) = pmtx;      \
-  mtx_lock(pmtx);
+#define mtx_scoped_lock(mtx_p)                                                 \
+  mtx_t *__CONCAT(__mtx_, __LINE__) cleanup(mtx_unlock) = _mtx_lock(mtx_p)
+
+#define WITH_MTX_LOCK(mtx_p)                                                   \
+  for (mtx_scoped_lock(mtx_p), *__CONCAT(__with_, __LINE__) = (mtx_t *)1;      \
+       __CONCAT(__with_, __LINE__); __CONCAT(__with_, __LINE__) = NULL)
 
 #endif /* !_SYS_MUTEX_H_ */

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -33,13 +33,15 @@ void mtx_unlock(mtx_t *m);
 /* Use mtx_scoped_lock to lock a mutex and have it automatically unlock when
    leaving current scope. */
 DEFINE_CLEANUP_FUNCTION(mtx_t *, mtx_unlock);
-mtx_t *_mtx_lock(mtx_t *m);
 
-#define mtx_scoped_lock(mtx_p)                                                 \
-  mtx_t *__CONCAT(__mtx_, __LINE__) WITH_CLEANUP(mtx_unlock) = _mtx_lock(mtx_p)
+#define SCOPED_MTX_LOCK(mtx_p)                                                 \
+  mtx_t *__CONCAT(__mtx_, __LINE__) USES_CLEANUP(mtx_unlock) = ({              \
+    mtx_lock(mtx_p);                                                           \
+    mtx_p;                                                                     \
+  })
 
 #define WITH_MTX_LOCK(mtx_p)                                                   \
-  for (mtx_scoped_lock(mtx_p), *__CONCAT(__loop_, __LINE__) = (mtx_t *)1;      \
+  for (SCOPED_MTX_LOCK(mtx_p), *__CONCAT(__loop_, __LINE__) = (mtx_t *)1;      \
        __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = NULL)
 
 #endif /* !_SYS_MUTEX_H_ */

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -25,20 +25,21 @@ bool mtx_owned(mtx_t *mtx);
 /* Locks the mutex, if the mutex is already owned by someone,
  * then this blocks on sleepqueue, otherwise it takes the mutex. */
 void mtx_lock(mtx_t *m);
-mtx_t *_mtx_lock(mtx_t *m);
 
 /* Unlocks the mutex. If some thread blocked for the mutex,
  * then it wakes up the thread in FIFO manner. */
 void mtx_unlock(mtx_t *m);
 
-/* Use mtx_lock_guard to lock a mutex and have it automatically unlock when
+/* Use mtx_scoped_lock to lock a mutex and have it automatically unlock when
    leaving current scope. */
 DEFINE_CLEANUP_FUNCTION(mtx_t *, mtx_unlock);
+mtx_t *_mtx_lock(mtx_t *m);
+
 #define mtx_scoped_lock(mtx_p)                                                 \
-  mtx_t *__CONCAT(__mtx_, __LINE__) cleanup(mtx_unlock) = _mtx_lock(mtx_p)
+  mtx_t *__CONCAT(__mtx_, __LINE__) WITH_CLEANUP(mtx_unlock) = _mtx_lock(mtx_p)
 
 #define WITH_MTX_LOCK(mtx_p)                                                   \
-  for (mtx_scoped_lock(mtx_p), *__CONCAT(__with_, __LINE__) = (mtx_t *)1;      \
-       __CONCAT(__with_, __LINE__); __CONCAT(__with_, __LINE__) = NULL)
+  for (mtx_scoped_lock(mtx_p), *__CONCAT(__loop_, __LINE__) = (mtx_t *)1;      \
+       __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = NULL)
 
 #endif /* !_SYS_MUTEX_H_ */

--- a/include/rwlock.h
+++ b/include/rwlock.h
@@ -37,14 +37,15 @@ bool rw_try_upgrade(rwlock_t *rw);
 void rw_downgrade(rwlock_t *rw);
 
 DEFINE_CLEANUP_FUNCTION(rwlock_t *, rw_leave);
-rwlock_t *_rw_enter(rwlock_t *rw, rwo_t who);
 
-#define rw_scoped_enter(rwlock_p, who)                                         \
-  rwlock_t *__CONCAT(__rwlock_, __LINE__) WITH_CLEANUP(rw_leave) =             \
-    _rw_enter((rwlock_p), (who))
+#define SCOPED_RW_ENTER(rwlock_p, who)                                         \
+  rwlock_t *__CONCAT(__rwlock_, __LINE__) USES_CLEANUP(rw_leave) = ({          \
+    rw_enter((rwlock_p), (who));                                               \
+    rwlock_p;                                                                  \
+  })
 
 #define WITH_RW_LOCK(rwlock_p, who)                                            \
-  for (rw_scoped_enter((rwlock_p), (who)),                                     \
+  for (SCOPED_RW_ENTER((rwlock_p), (who)),                                     \
        *__CONCAT(__loop_, __LINE__) = (rwlock_t *)1;                           \
        __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = NULL)
 

--- a/include/rwlock.h
+++ b/include/rwlock.h
@@ -39,15 +39,10 @@ void rw_downgrade(rwlock_t *rw);
 DEFINE_CLEANUP_FUNCTION(rwlock_t *, rw_leave);
 
 #define SCOPED_RW_ENTER(rwlock_p, who)                                         \
-  rwlock_t *__CONCAT(__rwlock_, __LINE__) USES_CLEANUP(rw_leave) = ({          \
-    rw_enter((rwlock_p), (who));                                               \
-    rwlock_p;                                                                  \
-  })
+  SCOPED_STMT(rwlock_t, rw_enter, CLEANUP_FUNCTION(rw_leave), rwlock_p, who)
 
 #define WITH_RW_LOCK(rwlock_p, who)                                            \
-  for (SCOPED_RW_ENTER((rwlock_p), (who)),                                     \
-       *__CONCAT(__loop_, __LINE__) = (rwlock_t *)1;                           \
-       __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = NULL)
+  WITH_STMT(rwlock_t, rw_enter, CLEANUP_FUNCTION(rw_leave), rwlock_p, who)
 
 #define rw_assert(rw, what) __rw_assert((rw), (what), __FILE__, __LINE__)
 void __rw_assert(rwlock_t *rw, rwa_t what, const char *file, unsigned line);

--- a/include/sync.h
+++ b/include/sync.h
@@ -17,13 +17,8 @@ void critical_enter();
 void critical_leave();
 
 #define SCOPED_CRITICAL_SECTION()                                              \
-  void *__CONCAT(__cs_, __LINE__) __cleanup(critical_leave) = ({               \
-    critical_enter();                                                          \
-    NULL;                                                                      \
-  })
+  SCOPED_STMT(void, critical_enter, critical_leave, NULL)
 
-#define CRITICAL_SECTION                                                       \
-  for (SCOPED_CRITICAL_SECTION(), *__CONCAT(__loop_, __LINE__) = (void *)1;    \
-       __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = 0)
+#define CRITICAL_SECTION WITH_STMT(void, critical_enter, critical_leave, NULL)
 
 #endif /* !_SYS_SYNC_H_ */

--- a/include/sync.h
+++ b/include/sync.h
@@ -16,14 +16,14 @@
 void critical_enter();
 void critical_leave();
 
-unsigned _critical_enter();
+#define SCOPED_CRITICAL_SECTION()                                              \
+  void *__CONCAT(__cs_, __LINE__) __cleanup(critical_leave) = ({               \
+    critical_enter();                                                          \
+    NULL;                                                                      \
+  })
 
-#define critical_scoped()                                                      \
-  unsigned __CONCAT(__cs_, __LINE__) __cleanup(critical_leave) =               \
-    _critical_enter()
-
-#define IN_CRITICAL_SECTION()                                                  \
-  for (critical_scoped(), __CONCAT(__loop_, __LINE__) = 1;                     \
+#define CRITICAL_SECTION                                                       \
+  for (SCOPED_CRITICAL_SECTION(), *__CONCAT(__loop_, __LINE__) = (void *)1;    \
        __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = 0)
 
 #endif /* !_SYS_SYNC_H_ */

--- a/include/sync.h
+++ b/include/sync.h
@@ -1,6 +1,8 @@
 #ifndef _SYS_SYNC_H_
 #define _SYS_SYNC_H_
 
+#include <common.h>
+
 /*
  * Entering critical section turns off interrupts - use with care!
  *
@@ -13,5 +15,15 @@
  */
 void critical_enter();
 void critical_leave();
+
+unsigned _critical_enter();
+
+#define critical_scoped()                                                      \
+  unsigned __CONCAT(__cs_, __LINE__) __cleanup(critical_leave) =               \
+    _critical_enter()
+
+#define IN_CRITICAL_SECTION()                                                  \
+  for (critical_scoped(), __CONCAT(__loop_, __LINE__) = 1;                     \
+       __CONCAT(__loop_, __LINE__); __CONCAT(__loop_, __LINE__) = 0)
 
 #endif /* !_SYS_SYNC_H_ */

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -292,10 +292,10 @@ void pmap_protect(pmap_t *pmap, vm_addr_t start, vm_addr_t end,
  */
 
 void pmap_activate(pmap_t *pmap) {
-  critical_enter();
+  SCOPED_CRITICAL_SECTION();
+
   PCPU_GET(curpmap) = pmap;
   mips32_set_c0(C0_ENTRYHI, pmap ? pmap->asid : 0);
-  critical_leave();
 }
 
 pmap_t *get_kernel_pmap() {

--- a/mips/signal.c
+++ b/mips/signal.c
@@ -58,7 +58,7 @@ int platform_sig_deliver(signo_t sig, sigaction_t *sa) {
 
 int platform_sig_return() {
   thread_t *td = thread_self();
-  mtx_scoped_lock(&td->td_lock);
+  SCOPED_MTX_LOCK(&td->td_lock);
   sig_ctx_t ksc;
   /* TODO: We assume the stored user context is where user stack is. This
      usually works, but the signal handler may switch the stack, or perform an

--- a/sys/condvar.c
+++ b/sys/condvar.c
@@ -9,7 +9,7 @@ void cv_init(condvar_t *cv, const char *name) {
 }
 
 void cv_wait(condvar_t *cv, mtx_t *mtx) {
-  IN_CRITICAL_SECTION () {
+  CRITICAL_SECTION {
     cv->waiters++;
     mtx_unlock(mtx);
     sleepq_wait(cv, cv->name);
@@ -18,19 +18,17 @@ void cv_wait(condvar_t *cv, mtx_t *mtx) {
 }
 
 void cv_signal(condvar_t *cv) {
-  IN_CRITICAL_SECTION () {
-    if (cv->waiters > 0) {
-      cv->waiters--;
-      sleepq_signal(cv);
-    }
+  SCOPED_CRITICAL_SECTION();
+  if (cv->waiters > 0) {
+    cv->waiters--;
+    sleepq_signal(cv);
   }
 }
 
 void cv_broadcast(condvar_t *cv) {
-  IN_CRITICAL_SECTION () {
-    if (cv->waiters > 0) {
-      cv->waiters = 0;
-      sleepq_broadcast(cv);
-    }
+  SCOPED_CRITICAL_SECTION();
+  if (cv->waiters > 0) {
+    cv->waiters = 0;
+    sleepq_broadcast(cv);
   }
 }

--- a/sys/condvar.c
+++ b/sys/condvar.c
@@ -9,28 +9,28 @@ void cv_init(condvar_t *cv, const char *name) {
 }
 
 void cv_wait(condvar_t *cv, mtx_t *mtx) {
-  critical_enter();
-  cv->waiters++;
-  mtx_unlock(mtx);
-  sleepq_wait(cv, cv->name);
-  critical_leave();
+  IN_CRITICAL_SECTION () {
+    cv->waiters++;
+    mtx_unlock(mtx);
+    sleepq_wait(cv, cv->name);
+  }
   mtx_lock(mtx);
 }
 
 void cv_signal(condvar_t *cv) {
-  critical_enter();
-  if (cv->waiters > 0) {
-    cv->waiters--;
-    sleepq_signal(cv);
+  IN_CRITICAL_SECTION () {
+    if (cv->waiters > 0) {
+      cv->waiters--;
+      sleepq_signal(cv);
+    }
   }
-  critical_leave();
 }
 
 void cv_broadcast(condvar_t *cv) {
-  critical_enter();
-  if (cv->waiters > 0) {
-    cv->waiters = 0;
-    sleepq_broadcast(cv);
+  IN_CRITICAL_SECTION () {
+    if (cv->waiters > 0) {
+      cv->waiters = 0;
+      sleepq_broadcast(cv);
+    }
   }
-  critical_leave();
 }

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -28,12 +28,12 @@ static devfs_device_list_t devfs_device_list =
 static mtx_t devfs_device_list_mtx;
 
 static devfs_device_t *devfs_get_by_name(const char *name) {
+  SCOPED_MTX_LOCK(&devfs_device_list_mtx);
+
   devfs_device_t *idev;
-  WITH_MTX_LOCK (&devfs_device_list_mtx) {
-    TAILQ_FOREACH (idev, &devfs_device_list, list)
-      if (!strcmp(name, idev->name))
-        return idev;
-  }
+  TAILQ_FOREACH (idev, &devfs_device_list, list)
+    if (!strcmp(name, idev->name))
+      return idev;
   return NULL;
 }
 

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -49,9 +49,8 @@ int devfs_install(const char *name, vnode_t *device) {
   strlcpy(idev->name, name, DEVFS_NAME_MAX);
   idev->dev = device;
 
-  mtx_lock(&devfs_device_list_mtx);
-  TAILQ_INSERT_TAIL(&devfs_device_list, idev, list);
-  mtx_unlock(&devfs_device_list_mtx);
+  WITH_MTX_LOCK (&devfs_device_list_mtx)
+    TAILQ_INSERT_TAIL(&devfs_device_list, idev, list);
 
   return 0;
 }

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -29,10 +29,11 @@ static mtx_t devfs_device_list_mtx;
 
 static devfs_device_t *devfs_get_by_name(const char *name) {
   devfs_device_t *idev;
-  mtx_scoped_lock(&devfs_device_list_mtx);
-  TAILQ_FOREACH (idev, &devfs_device_list, list)
-    if (!strcmp(name, idev->name))
-      return idev;
+  WITH_MTX_LOCK (&devfs_device_list_mtx) {
+    TAILQ_FOREACH (idev, &devfs_device_list, list)
+      if (!strcmp(name, idev->name))
+        return idev;
+  }
   return NULL;
 }
 

--- a/sys/exception.c
+++ b/sys/exception.c
@@ -13,7 +13,7 @@ void exc_before_leave(exc_frame_t *kframe) {
 
   /* First thing after switching to a thread: Process pending signals. */
   if (td->td_flags & TDF_NEEDSIGCHK) {
-    mtx_scoped_lock(&td->td_lock);
+    SCOPED_MTX_LOCK(&td->td_lock);
     int sig;
     while ((sig = sig_check(td)) != 0)
       sig_deliver(sig);

--- a/sys/file.c
+++ b/sys/file.c
@@ -12,18 +12,16 @@ void file_init() {
 }
 
 void file_ref(file_t *f) {
-  WITH_MTX_LOCK (&f->f_mtx) {
-    assert(f->f_count >= 0);
-    f->f_count++;
-  }
+  SCOPED_MTX_LOCK(&f->f_mtx);
+  assert(f->f_count >= 0);
+  f->f_count++;
 }
 
 void file_unref(file_t *f) {
-  WITH_MTX_LOCK (&f->f_mtx) {
-    assert(f->f_count > 0);
-    if (--f->f_count == 0)
-      f->f_count = -1;
-  }
+  SCOPED_MTX_LOCK(&f->f_mtx);
+  assert(f->f_count > 0);
+  if (--f->f_count == 0)
+    f->f_count = -1;
 }
 
 file_t *file_alloc() {

--- a/sys/file.c
+++ b/sys/file.c
@@ -12,18 +12,18 @@ void file_init() {
 }
 
 void file_ref(file_t *f) {
-  mtx_lock(&f->f_mtx);
-  assert(f->f_count >= 0);
-  f->f_count++;
-  mtx_unlock(&f->f_mtx);
+  WITH_MTX_LOCK (&f->f_mtx) {
+    assert(f->f_count >= 0);
+    f->f_count++;
+  }
 }
 
 void file_unref(file_t *f) {
-  mtx_lock(&f->f_mtx);
-  assert(f->f_count > 0);
-  if (--f->f_count == 0)
-    f->f_count = -1;
-  mtx_unlock(&f->f_mtx);
+  WITH_MTX_LOCK (&f->f_mtx) {
+    assert(f->f_count > 0);
+    if (--f->f_count == 0)
+      f->f_count = -1;
+  }
 }
 
 file_t *file_alloc() {

--- a/sys/klog.c
+++ b/sys/klog.c
@@ -49,7 +49,7 @@ void klog_append(klog_origin_t origin, const char *file, unsigned line,
 
   klog_entry_t *entry;
 
-  IN_CRITICAL_SECTION () {
+  CRITICAL_SECTION {
     entry = &klog.array[klog.last];
 
     *entry = (klog_entry_t){.kl_timestamp = clock_get(),
@@ -72,7 +72,7 @@ void klog_dump() {
   klog_entry_t entry;
 
   while (klog.first != klog.last) {
-    IN_CRITICAL_SECTION () {
+    CRITICAL_SECTION {
       entry = klog.array[klog.first];
       klog.first = next(klog.first);
     }

--- a/sys/klog.c
+++ b/sys/klog.c
@@ -47,22 +47,22 @@ void klog_append(klog_origin_t origin, const char *file, unsigned line,
   if (!(KL_MASK(origin) & klog.mask))
     return;
 
-  critical_enter();
+  klog_entry_t *entry;
 
-  klog_entry_t *entry = &klog.array[klog.last];
+  IN_CRITICAL_SECTION () {
+    entry = &klog.array[klog.last];
 
-  *entry = (klog_entry_t){.kl_timestamp = clock_get(),
-                          .kl_line = line,
-                          .kl_file = file,
-                          .kl_origin = origin,
-                          .kl_format = format,
-                          .kl_params = {arg1, arg2, arg3, arg4, arg5, arg6}};
+    *entry = (klog_entry_t){.kl_timestamp = clock_get(),
+                            .kl_line = line,
+                            .kl_file = file,
+                            .kl_origin = origin,
+                            .kl_format = format,
+                            .kl_params = {arg1, arg2, arg3, arg4, arg5, arg6}};
 
-  klog.last = next(klog.last);
-  if (klog.first == klog.last)
-    klog.first = next(klog.first);
-
-  critical_leave();
+    klog.last = next(klog.last);
+    if (klog.first == klog.last)
+      klog.first = next(klog.first);
+  }
 
   if (klog.verbose)
     klog_entry_dump(entry);
@@ -72,10 +72,10 @@ void klog_dump() {
   klog_entry_t entry;
 
   while (klog.first != klog.last) {
-    critical_enter();
-    entry = klog.array[klog.first];
-    klog.first = next(klog.first);
-    critical_leave();
+    IN_CRITICAL_SECTION () {
+      entry = klog.array[klog.first];
+      klog.first = next(klog.first);
+    }
     klog_entry_dump(&entry);
   }
 }

--- a/sys/malloc.c
+++ b/sys/malloc.c
@@ -213,12 +213,13 @@ void kfree(kmem_pool_t *mp, void *addr) {
     panic("Memory corruption detected!");
 
   mem_arena_t *current = NULL;
-  mtx_scoped_lock(&mp->mp_lock);
-  TAILQ_FOREACH (current, &mp->mp_arena, ma_list) {
-    char *start = ((char *)current) + sizeof(mem_arena_t);
-    if ((char *)addr >= start && (char *)addr < start + current->ma_size)
-      add_free_memory_block(current, mb,
-                            abs(mb->mb_size) + sizeof(mem_block_t));
+  WITH_MTX_LOCK (&mp->mp_lock) {
+    TAILQ_FOREACH (current, &mp->mp_arena, ma_list) {
+      char *start = ((char *)current) + sizeof(mem_arena_t);
+      if ((char *)addr >= start && (char *)addr < start + current->ma_size)
+        add_free_memory_block(current, mb,
+                              abs(mb->mb_size) + sizeof(mem_block_t));
+    }
   }
 }
 

--- a/sys/mutex.c
+++ b/sys/mutex.c
@@ -16,22 +16,19 @@ void mtx_init(mtx_t *m, unsigned type) {
   m->m_type = type;
 }
 
-mtx_t *_mtx_lock(mtx_t *m) {
+void mtx_lock(mtx_t *m) {
   if (mtx_owned(m)) {
     assert(m->m_type & MTX_RECURSE);
     m->m_count++;
-    return m;
+    return;
   }
 
-  IN_CRITICAL_SECTION () {
-    while (m->m_owner != NULL)
-      sleepq_wait(&m->m_owner, "mutex");
-    m->m_owner = thread_self();
-  }
-  return m;
+  SCOPED_CRITICAL_SECTION();
+
+  while (m->m_owner != NULL)
+    sleepq_wait(&m->m_owner, "mutex");
+  m->m_owner = thread_self();
 }
-
-void mtx_lock(mtx_t *m) __alias(_mtx_lock);
 
 void mtx_unlock(mtx_t *m) {
   assert(mtx_owned(m));
@@ -41,8 +38,8 @@ void mtx_unlock(mtx_t *m) {
     return;
   }
 
-  IN_CRITICAL_SECTION () {
-    m->m_owner = NULL;
-    sleepq_signal(&m->m_owner);
-  }
+  SCOPED_CRITICAL_SECTION();
+
+  m->m_owner = NULL;
+  sleepq_signal(&m->m_owner);
 }

--- a/sys/mutex.c
+++ b/sys/mutex.c
@@ -23,11 +23,11 @@ mtx_t *_mtx_lock(mtx_t *m) {
     return m;
   }
 
-  critical_enter();
-  while (m->m_owner != NULL)
-    sleepq_wait(&m->m_owner, "mutex");
-  m->m_owner = thread_self();
-  critical_leave();
+  IN_CRITICAL_SECTION () {
+    while (m->m_owner != NULL)
+      sleepq_wait(&m->m_owner, "mutex");
+    m->m_owner = thread_self();
+  }
   return m;
 }
 
@@ -41,8 +41,8 @@ void mtx_unlock(mtx_t *m) {
     return;
   }
 
-  critical_enter();
-  m->m_owner = NULL;
-  sleepq_signal(&m->m_owner);
-  critical_leave();
+  IN_CRITICAL_SECTION () {
+    m->m_owner = NULL;
+    sleepq_signal(&m->m_owner);
+  }
 }

--- a/sys/mutex.c
+++ b/sys/mutex.c
@@ -16,11 +16,11 @@ void mtx_init(mtx_t *m, unsigned type) {
   m->m_type = type;
 }
 
-void mtx_lock(mtx_t *m) {
+mtx_t *_mtx_lock(mtx_t *m) {
   if (mtx_owned(m)) {
     assert(m->m_type & MTX_RECURSE);
     m->m_count++;
-    return;
+    return m;
   }
 
   critical_enter();
@@ -28,7 +28,10 @@ void mtx_lock(mtx_t *m) {
     sleepq_wait(&m->m_owner, "mutex");
   m->m_owner = thread_self();
   critical_leave();
+  return m;
 }
+
+void mtx_lock(mtx_t *m) __alias(_mtx_lock);
 
 void mtx_unlock(mtx_t *m) {
   assert(mtx_owned(m));

--- a/sys/pool.c
+++ b/sys/pool.c
@@ -156,10 +156,10 @@ void pool_destroy(pool_t *pool) {
   /* TODO: there is no way to use pool's mutex here because it could already got
    * deallocated and we have no method of marking dead mutexes, that's why
    * low-level sync functions are used here. */
-  critical_enter();
-  assert(pool->pp_state == ALIVE);
-  pool->pp_state = DEAD;
-  critical_leave();
+  IN_CRITICAL_SECTION () {
+    assert(pool->pp_state == ALIVE);
+    pool->pp_state = DEAD;
+  }
 
   destroy_slab_list(pool, &pool->pp_empty_slabs);
   destroy_slab_list(pool, &pool->pp_part_slabs);

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -23,13 +23,11 @@ proc_t *proc_create() {
   TAILQ_INIT(&proc->p_threads);
   proc->p_nthreads = 0;
 
-  mtx_lock(&all_proc_list_mtx);
-  TAILQ_INSERT_TAIL(&all_proc_list, proc, p_all);
-  mtx_unlock(&all_proc_list_mtx);
+  WITH_MTX_LOCK (&all_proc_list_mtx)
+    TAILQ_INSERT_TAIL(&all_proc_list, proc, p_all);
 
-  mtx_lock(&last_pid_mtx);
-  proc->p_pid = last_pid++;
-  mtx_unlock(&last_pid_mtx);
+  WITH_MTX_LOCK (&last_pid_mtx)
+    proc->p_pid = last_pid++;
 
   return proc;
 }

--- a/sys/rwlock.c
+++ b/sys/rwlock.c
@@ -28,80 +28,73 @@ static bool is_wlocked(rwlock_t *rw) {
   return rw->state == RW_WLOCKED;
 }
 
-rwlock_t *_rw_enter(rwlock_t *rw, rwo_t who) {
-  IN_CRITICAL_SECTION () {
-    if (who == RW_READER) {
-      while (is_wlocked(rw) || rw->writers_waiting > 0)
-        sleepq_wait(&rw->readers, rw->name);
-      rw->readers++;
-      rw->state = RW_RLOCKED;
-    } else if (who == RW_WRITER) {
-      if (is_owned(rw)) {
-        assert(rw->recursive);
-        rw->recurse++;
-      } else {
-        rw->writers_waiting++;
-        while (is_locked(rw))
-          sleepq_wait(&rw->writer, rw->name);
-        rw->state = RW_WLOCKED;
-        rw->writer = thread_self();
-        rw->writers_waiting--;
-      }
+void rw_enter(rwlock_t *rw, rwo_t who) {
+  SCOPED_CRITICAL_SECTION();
+  if (who == RW_READER) {
+    while (is_wlocked(rw) || rw->writers_waiting > 0)
+      sleepq_wait(&rw->readers, rw->name);
+    rw->readers++;
+    rw->state = RW_RLOCKED;
+  } else if (who == RW_WRITER) {
+    if (is_owned(rw)) {
+      assert(rw->recursive);
+      rw->recurse++;
+    } else {
+      rw->writers_waiting++;
+      while (is_locked(rw))
+        sleepq_wait(&rw->writer, rw->name);
+      rw->state = RW_WLOCKED;
+      rw->writer = thread_self();
+      rw->writers_waiting--;
     }
   }
-  return rw;
 }
 
-void rw_enter(rwlock_t *rw, rwo_t who) __alias(_rw_enter);
-
 void rw_leave(rwlock_t *rw) {
-  IN_CRITICAL_SECTION () {
-    assert(is_locked(rw));
-    if (is_rlocked(rw)) {
-      rw->readers--;
-      if (rw->readers == 0) {
-        rw->state = RW_UNLOCKED;
-        if (rw->writers_waiting > 0)
-          sleepq_signal(&rw->writer);
-      }
+  SCOPED_CRITICAL_SECTION();
+  assert(is_locked(rw));
+  if (is_rlocked(rw)) {
+    rw->readers--;
+    if (rw->readers == 0) {
+      rw->state = RW_UNLOCKED;
+      if (rw->writers_waiting > 0)
+        sleepq_signal(&rw->writer);
+    }
+  } else {
+    assert(is_owned(rw));
+    if (rw->recurse > 0) {
+      assert(rw->recursive);
+      rw->recurse--;
     } else {
-      assert(is_owned(rw));
-      if (rw->recurse > 0) {
-        assert(rw->recursive);
-        rw->recurse--;
-      } else {
-        rw->state = RW_UNLOCKED;
-        rw->writer = NULL;
-        if (rw->writers_waiting > 0)
-          sleepq_signal(&rw->writer);
-        else
-          sleepq_broadcast(&rw->readers);
-      }
+      rw->state = RW_UNLOCKED;
+      rw->writer = NULL;
+      if (rw->writers_waiting > 0)
+        sleepq_signal(&rw->writer);
+      else
+        sleepq_broadcast(&rw->readers);
     }
   }
 }
 
 bool rw_try_upgrade(rwlock_t *rw) {
-  IN_CRITICAL_SECTION () {
-    assert(is_locked(rw));
-    if (is_rlocked(rw) && rw->readers == 1 && rw->writers_waiting == 0) {
-      rw->state = RW_WLOCKED;
-      rw->writer = thread_self();
-      rw->recurse = 0;
-      return true;
-    }
+  SCOPED_CRITICAL_SECTION();
+  assert(is_locked(rw));
+  if (is_rlocked(rw) && rw->readers == 1 && rw->writers_waiting == 0) {
+    rw->state = RW_WLOCKED;
+    rw->writer = thread_self();
+    rw->recurse = 0;
+    return true;
   }
   return false;
 }
 
 void rw_downgrade(rwlock_t *rw) {
-  IN_CRITICAL_SECTION () {
-    assert(is_owned(rw) && rw->recurse == 0);
-    rw->readers++;
-    rw->state = RW_RLOCKED;
-    rw->writer = NULL;
-    sleepq_broadcast(&rw->readers);
-  }
+  SCOPED_CRITICAL_SECTION();
+  assert(is_owned(rw) && rw->recurse == 0);
+  rw->readers++;
+  rw->state = RW_RLOCKED;
+  rw->writer = NULL;
+  sleepq_broadcast(&rw->readers);
 }
 
 void __rw_assert(rwlock_t *rw, rwa_t what, const char *file, unsigned line) {

--- a/sys/rwlock.c
+++ b/sys/rwlock.c
@@ -28,78 +28,80 @@ static bool is_wlocked(rwlock_t *rw) {
   return rw->state == RW_WLOCKED;
 }
 
-void rw_enter(rwlock_t *rw, rwo_t who) {
-  critical_enter();
-  if (who == RW_READER) {
-    while (is_wlocked(rw) || rw->writers_waiting > 0)
-      sleepq_wait(&rw->readers, rw->name);
-    rw->readers++;
-    rw->state = RW_RLOCKED;
-  } else if (who == RW_WRITER) {
-    if (is_owned(rw)) {
-      assert(rw->recursive);
-      rw->recurse++;
-    } else {
-      rw->writers_waiting++;
-      while (is_locked(rw))
-        sleepq_wait(&rw->writer, rw->name);
-      rw->state = RW_WLOCKED;
-      rw->writer = thread_self();
-      rw->writers_waiting--;
+rwlock_t *_rw_enter(rwlock_t *rw, rwo_t who) {
+  IN_CRITICAL_SECTION () {
+    if (who == RW_READER) {
+      while (is_wlocked(rw) || rw->writers_waiting > 0)
+        sleepq_wait(&rw->readers, rw->name);
+      rw->readers++;
+      rw->state = RW_RLOCKED;
+    } else if (who == RW_WRITER) {
+      if (is_owned(rw)) {
+        assert(rw->recursive);
+        rw->recurse++;
+      } else {
+        rw->writers_waiting++;
+        while (is_locked(rw))
+          sleepq_wait(&rw->writer, rw->name);
+        rw->state = RW_WLOCKED;
+        rw->writer = thread_self();
+        rw->writers_waiting--;
+      }
     }
   }
-  critical_leave();
+  return rw;
 }
 
+void rw_enter(rwlock_t *rw, rwo_t who) __alias(_rw_enter);
+
 void rw_leave(rwlock_t *rw) {
-  critical_enter();
-  assert(is_locked(rw));
-  if (is_rlocked(rw)) {
-    rw->readers--;
-    if (rw->readers == 0) {
-      rw->state = RW_UNLOCKED;
-      if (rw->writers_waiting > 0)
-        sleepq_signal(&rw->writer);
-    }
-  } else {
-    assert(is_owned(rw));
-    if (rw->recurse > 0) {
-      assert(rw->recursive);
-      rw->recurse--;
+  IN_CRITICAL_SECTION () {
+    assert(is_locked(rw));
+    if (is_rlocked(rw)) {
+      rw->readers--;
+      if (rw->readers == 0) {
+        rw->state = RW_UNLOCKED;
+        if (rw->writers_waiting > 0)
+          sleepq_signal(&rw->writer);
+      }
     } else {
-      rw->state = RW_UNLOCKED;
-      rw->writer = NULL;
-      if (rw->writers_waiting > 0)
-        sleepq_signal(&rw->writer);
-      else
-        sleepq_broadcast(&rw->readers);
+      assert(is_owned(rw));
+      if (rw->recurse > 0) {
+        assert(rw->recursive);
+        rw->recurse--;
+      } else {
+        rw->state = RW_UNLOCKED;
+        rw->writer = NULL;
+        if (rw->writers_waiting > 0)
+          sleepq_signal(&rw->writer);
+        else
+          sleepq_broadcast(&rw->readers);
+      }
     }
   }
-  critical_leave();
 }
 
 bool rw_try_upgrade(rwlock_t *rw) {
-  bool success = false;
-  critical_enter();
-  assert(is_locked(rw));
-  if (is_rlocked(rw) && rw->readers == 1 && rw->writers_waiting == 0) {
-    rw->state = RW_WLOCKED;
-    rw->writer = thread_self();
-    rw->recurse = 0;
-    success = true;
+  IN_CRITICAL_SECTION () {
+    assert(is_locked(rw));
+    if (is_rlocked(rw) && rw->readers == 1 && rw->writers_waiting == 0) {
+      rw->state = RW_WLOCKED;
+      rw->writer = thread_self();
+      rw->recurse = 0;
+      return true;
+    }
   }
-  critical_leave();
-  return success;
+  return false;
 }
 
 void rw_downgrade(rwlock_t *rw) {
-  critical_enter();
-  assert(is_owned(rw) && rw->recurse == 0);
-  rw->readers++;
-  rw->state = RW_RLOCKED;
-  rw->writer = NULL;
-  sleepq_broadcast(&rw->readers);
-  critical_leave();
+  IN_CRITICAL_SECTION () {
+    assert(is_owned(rw) && rw->recurse == 0);
+    rw->readers++;
+    rw->state = RW_RLOCKED;
+    rw->writer = NULL;
+    sleepq_broadcast(&rw->readers);
+  }
 }
 
 void __rw_assert(rwlock_t *rw, rwa_t what, const char *file, unsigned line) {

--- a/sys/sbrk.c
+++ b/sys/sbrk.c
@@ -10,45 +10,42 @@
    sbrk. */
 
 vm_addr_t sbrk_create(vm_map_t *map) {
+  SCOPED_RW_ENTER(&map->rwlock, RW_WRITER);
+
+  assert(!map->sbrk_entry);
+
+  size_t size = roundup(SBRK_INITIAL_SIZE, PAGESIZE);
   vm_addr_t addr;
+  int res = vm_map_findspace_nolock(map, BRK_SEARCH_START, size, &addr);
+  assert(res == 0);
+  vm_map_entry_t *entry =
+    vm_map_add_entry(map, addr, addr + size, VM_PROT_READ | VM_PROT_WRITE);
+  entry->object = default_pager->pgr_alloc();
 
-  WITH_RW_LOCK (&map->rwlock, RW_WRITER) {
-    assert(!map->sbrk_entry);
-
-    size_t size = roundup(SBRK_INITIAL_SIZE, PAGESIZE);
-    int res = vm_map_findspace_nolock(map, BRK_SEARCH_START, size, &addr);
-    assert(res == 0);
-    vm_map_entry_t *entry =
-      vm_map_add_entry(map, addr, addr + size, VM_PROT_READ | VM_PROT_WRITE);
-    entry->object = default_pager->pgr_alloc();
-
-    map->sbrk_entry = entry;
-    map->sbrk_end = addr;
-  }
+  map->sbrk_entry = entry;
+  map->sbrk_end = addr;
 
   return addr;
 }
 
 vm_addr_t sbrk_resize(vm_map_t *map, intptr_t increment) {
-  vm_addr_t brk;
+  SCOPED_RW_ENTER(&map->rwlock, RW_WRITER);
 
-  WITH_RW_LOCK (&map->rwlock, RW_WRITER) {
-    assert(map->sbrk_entry);
+  assert(map->sbrk_entry);
 
-    vm_map_entry_t *brk_entry = map->sbrk_entry;
-    brk = map->sbrk_end;
-    if (brk + increment == brk_entry->end) {
-      /* No need to resize the segment. */
-      map->sbrk_end = brk + increment;
-      return brk;
-    }
-    /* Shrink or expand the vm_map_entry */
-    vm_addr_t new_end = roundup(brk + increment, PAGESIZE);
-    if (vm_map_resize(map, brk_entry, new_end) != 0)
-      /* Map entry expansion failed. */
-      return -ENOMEM;
-    map->sbrk_end += increment;
+  vm_map_entry_t *brk_entry = map->sbrk_entry;
+  vm_addr_t brk = map->sbrk_end;
+  if (brk + increment == brk_entry->end) {
+    /* No need to resize the segment. */
+    map->sbrk_end = brk + increment;
+    return brk;
   }
+  /* Shrink or expand the vm_map_entry */
+  vm_addr_t new_end = roundup(brk + increment, PAGESIZE);
+  if (vm_map_resize(map, brk_entry, new_end) != 0)
+    /* Map entry expansion failed. */
+    return -ENOMEM;
+  map->sbrk_end += increment;
 
   return brk;
 }

--- a/sys/sbrk.c
+++ b/sys/sbrk.c
@@ -10,40 +10,45 @@
    sbrk. */
 
 vm_addr_t sbrk_create(vm_map_t *map) {
-  rw_scoped_enter(&map->rwlock, RW_WRITER);
-  assert(!map->sbrk_entry);
-
-  size_t size = roundup(SBRK_INITIAL_SIZE, PAGESIZE);
   vm_addr_t addr;
-  int res = vm_map_findspace_nolock(map, BRK_SEARCH_START, size, &addr);
-  assert(res == 0);
-  vm_map_entry_t *entry =
-    vm_map_add_entry(map, addr, addr + size, VM_PROT_READ | VM_PROT_WRITE);
-  entry->object = default_pager->pgr_alloc();
 
-  map->sbrk_entry = entry;
-  map->sbrk_end = addr;
+  WITH_RW_LOCK (&map->rwlock, RW_WRITER) {
+    assert(!map->sbrk_entry);
+
+    size_t size = roundup(SBRK_INITIAL_SIZE, PAGESIZE);
+    int res = vm_map_findspace_nolock(map, BRK_SEARCH_START, size, &addr);
+    assert(res == 0);
+    vm_map_entry_t *entry =
+      vm_map_add_entry(map, addr, addr + size, VM_PROT_READ | VM_PROT_WRITE);
+    entry->object = default_pager->pgr_alloc();
+
+    map->sbrk_entry = entry;
+    map->sbrk_end = addr;
+  }
 
   return addr;
 }
 
 vm_addr_t sbrk_resize(vm_map_t *map, intptr_t increment) {
-  rw_scoped_enter(&map->rwlock, RW_WRITER);
-  assert(map->sbrk_entry);
+  vm_addr_t brk;
 
-  vm_map_entry_t *brk_entry = map->sbrk_entry;
-  vm_addr_t brk = map->sbrk_end;
-  if (brk + increment == brk_entry->end) {
-    /* No need to resize the segment. */
-    map->sbrk_end = brk + increment;
-    return brk;
+  WITH_RW_LOCK (&map->rwlock, RW_WRITER) {
+    assert(map->sbrk_entry);
+
+    vm_map_entry_t *brk_entry = map->sbrk_entry;
+    brk = map->sbrk_end;
+    if (brk + increment == brk_entry->end) {
+      /* No need to resize the segment. */
+      map->sbrk_end = brk + increment;
+      return brk;
+    }
+    /* Shrink or expand the vm_map_entry */
+    vm_addr_t new_end = roundup(brk + increment, PAGESIZE);
+    if (vm_map_resize(map, brk_entry, new_end) != 0)
+      /* Map entry expansion failed. */
+      return -ENOMEM;
+    map->sbrk_end += increment;
   }
-  /* Shrink or expand the vm_map_entry */
-  vm_addr_t new_end = roundup(brk + increment, PAGESIZE);
-  if (vm_map_resize(map, brk_entry, new_end) != 0) {
-    /* Map entry expansion failed. */
-    return -ENOMEM;
-  }
-  map->sbrk_end += increment;
+
   return brk;
 }

--- a/sys/signal.c
+++ b/sys/signal.c
@@ -78,7 +78,7 @@ int sig_send(proc_t *proc, signo_t sig) {
   if (target->td_state == TDS_INACTIVE)
     return -EINVAL;
 
-  WITH_MTX_LOCK(&target->td_proc->p_lock) {
+  WITH_MTX_LOCK (&target->td_proc->p_lock) {
     /* If the signal is ignored, don't even bother posting it. */
     sighandler_t *handler = target->td_proc->p_sigactions[sig].sa_handler;
     if (handler == SIG_IGN ||

--- a/sys/signal.c
+++ b/sys/signal.c
@@ -34,7 +34,7 @@ int do_kill(pid_t pid, signo_t sig) {
 int do_sigaction(signo_t sig, const sigaction_t *act, sigaction_t *oldact) {
   thread_t *td = thread_self();
   assert(td->td_proc);
-  mtx_scoped_lock(&td->td_proc->p_lock);
+  SCOPED_MTX_LOCK(&td->td_proc->p_lock);
 
   if (sig >= NSIG)
     return -EINVAL;
@@ -72,19 +72,19 @@ int sig_send(proc_t *proc, signo_t sig) {
      below for each thread in proc. */
   thread_t *target = TAILQ_FIRST(&proc->p_threads);
 
-  mtx_scoped_lock(&target->td_lock);
+  SCOPED_MTX_LOCK(&target->td_lock);
 
   /* If the thread is already dead, don't post a signal. */
   if (target->td_state == TDS_INACTIVE)
     return -EINVAL;
 
-  mtx_lock(&target->td_proc->p_lock);
-  /* If the signal is ignored, don't even bother posting it. */
-  sighandler_t *handler = target->td_proc->p_sigactions[sig].sa_handler;
-  if (handler == SIG_IGN ||
-      (sig_default(sig) == SA_IGNORE && handler == SIG_DFL))
-    return 0;
-  mtx_unlock(&target->td_proc->p_lock);
+  WITH_MTX_LOCK(&target->td_proc->p_lock) {
+    /* If the signal is ignored, don't even bother posting it. */
+    sighandler_t *handler = target->td_proc->p_sigactions[sig].sa_handler;
+    if (handler == SIG_IGN ||
+        (sig_default(sig) == SA_IGNORE && handler == SIG_DFL))
+      return 0;
+  }
 
   bit_set(target->td_sigpend, sig);
 
@@ -115,7 +115,7 @@ int sig_check(thread_t *td) {
 
     bit_clear(td->td_sigpend, sig);
 
-    mtx_scoped_lock(&td->td_proc->p_lock);
+    SCOPED_MTX_LOCK(&td->td_proc->p_lock);
     sighandler_t *handler = td->td_proc->p_sigactions[sig].sa_handler;
 
     if (handler == SIG_IGN ||
@@ -143,7 +143,7 @@ term:
 void sig_deliver(signo_t sig) {
   thread_t *td = thread_self();
   assert(td->td_proc);
-  mtx_scoped_lock(&td->td_proc->p_lock);
+  SCOPED_MTX_LOCK(&td->td_proc->p_lock);
   sigaction_t *sa = td->td_proc->p_sigactions + sig;
 
   assert(sa->sa_handler != SIG_IGN && sa->sa_handler != SIG_DFL);

--- a/sys/sync.c
+++ b/sys/sync.c
@@ -3,11 +3,14 @@
 #include <sync.h>
 #include <thread.h>
 
-void critical_enter() {
+unsigned _critical_enter() {
   thread_t *td = thread_self();
   if (td->td_csnest++ == 0)
     intr_disable();
+  return td->td_csnest;
 }
+
+void critical_enter() __alias(_critical_enter);
 
 void critical_leave() {
   thread_t *td = thread_self();

--- a/sys/sync.c
+++ b/sys/sync.c
@@ -3,14 +3,11 @@
 #include <sync.h>
 #include <thread.h>
 
-unsigned _critical_enter() {
+void critical_enter() {
   thread_t *td = thread_self();
   if (td->td_csnest++ == 0)
     intr_disable();
-  return td->td_csnest;
 }
-
-void critical_enter() __alias(_critical_enter);
 
 void critical_leave() {
   thread_t *td = thread_self();

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -44,10 +44,12 @@ void thread_reap() {
   if (TAILQ_EMPTY(&zombie_threads))
     return;
 
-  mtx_lock(&zombie_threads_mtx);
-  thread_list_t thq = zombie_threads;
-  TAILQ_INIT(&zombie_threads);
-  mtx_unlock(&zombie_threads_mtx);
+  thread_list_t thq;
+
+  WITH_MTX_LOCK (&zombie_threads_mtx) {
+    thq = zombie_threads;
+    TAILQ_INIT(&zombie_threads);
+  }
 
   thread_t *td;
   TAILQ_FOREACH (td, &thq, td_zombieq) {
@@ -131,9 +133,8 @@ noreturn void thread_exit(int exitcode) {
       critical_leave();
   }
 
-  mtx_lock(&zombie_threads_mtx);
-  TAILQ_INSERT_TAIL(&zombie_threads, td, td_zombieq);
-  mtx_unlock(&zombie_threads_mtx);
+  WITH_MTX_LOCK (&zombie_threads_mtx)
+    TAILQ_INSERT_TAIL(&zombie_threads, td, td_zombieq);
 
   critical_enter();
   {
@@ -156,10 +157,10 @@ void thread_join(thread_t *p) {
   thread_t *otd = p;
   klog("Joining '%s' {%p} with '%s' {%p}", td->td_name, td, otd->td_name, otd);
 
-  mtx_lock(&otd->td_lock);
-  while (otd->td_state != TDS_INACTIVE)
-    cv_wait(&otd->td_waitcv, &otd->td_lock);
-  mtx_unlock(&otd->td_lock);
+  WITH_MTX_LOCK (&otd->td_lock) {
+    while (otd->td_state != TDS_INACTIVE)
+      cv_wait(&otd->td_waitcv, &otd->td_lock);
+  }
 }
 
 /* It would be better to have a hash-map from tid_t to thread_t,

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -136,14 +136,12 @@ noreturn void thread_exit(int exitcode) {
   WITH_MTX_LOCK (&zombie_threads_mtx)
     TAILQ_INSERT_TAIL(&zombie_threads, td, td_zombieq);
 
-  critical_enter();
-  {
+  IN_CRITICAL_SECTION () {
     td->td_exitcode = exitcode;
     td->td_state = TDS_INACTIVE;
     cv_broadcast(&td->td_waitcv);
     mtx_unlock(&td->td_lock);
   }
-  critical_leave();
 
   sched_yield();
 

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -166,10 +166,11 @@ void thread_join(thread_t *p) {
  * but using a list is sufficient for now. */
 thread_t *thread_get_by_tid(tid_t id) {
   thread_t *td = NULL;
-  mtx_scoped_lock(&all_threads_mtx);
-  TAILQ_FOREACH (td, &all_threads, td_all) {
-    if (td->td_tid == id)
-      break;
+  WITH_MTX_LOCK (&all_threads_mtx) {
+    TAILQ_FOREACH (td, &all_threads, td_all) {
+      if (td->td_tid == id)
+        break;
+    }
   }
   return td;
 }

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -69,9 +69,8 @@ static int vfs_register(vfsconf_t *vfc) {
   if (vfs_get_by_name(vfc->vfc_name))
     return -EEXIST;
 
-  mtx_lock(&vfsconf_list_mtx);
-  TAILQ_INSERT_TAIL(&vfsconf_list, vfc, vfc_list);
-  mtx_unlock(&vfsconf_list_mtx);
+  WITH_MTX_LOCK (&vfsconf_list_mtx)
+    TAILQ_INSERT_TAIL(&vfsconf_list, vfc, vfc_list);
 
   vfc->vfc_mountcnt = 0;
 
@@ -146,9 +145,8 @@ int vfs_domount(vfsconf_t *vfc, vnode_t *v) {
 
   v->v_mountedhere = m;
 
-  mtx_lock(&mount_list_mtx);
-  TAILQ_INSERT_TAIL(&mount_list, m, mnt_list);
-  mtx_unlock(&mount_list_mtx);
+  WITH_MTX_LOCK (&mount_list_mtx)
+    TAILQ_INSERT_TAIL(&mount_list, m, mnt_list);
 
   /* Note that we do not need to ask the new mount for the root vnode! That
      V_DIR vnode which is at the mount point stays in place. The root vnode is

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -54,12 +54,12 @@ void vfs_init() {
 }
 
 vfsconf_t *vfs_get_by_name(const char *name) {
+  SCOPED_MTX_LOCK(&vfsconf_list_mtx);
+
   vfsconf_t *vfc;
-  WITH_MTX_LOCK (&vfsconf_list_mtx) {
-    TAILQ_FOREACH (vfc, &vfsconf_list, vfc_list)
-      if (!strcmp(name, vfc->vfc_name))
-        return vfc;
-  }
+  TAILQ_FOREACH (vfc, &vfsconf_list, vfc_list)
+    if (!strcmp(name, vfc->vfc_name))
+      return vfc;
   return NULL;
 }
 

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -55,10 +55,11 @@ void vfs_init() {
 
 vfsconf_t *vfs_get_by_name(const char *name) {
   vfsconf_t *vfc;
-  mtx_scoped_lock(&vfsconf_list_mtx);
-  TAILQ_FOREACH (vfc, &vfsconf_list, vfc_list)
-    if (!strcmp(name, vfc->vfc_name))
-      return vfc;
+  WITH_MTX_LOCK (&vfsconf_list_mtx) {
+    TAILQ_FOREACH (vfc, &vfsconf_list, vfc_list)
+      if (!strcmp(name, vfc->vfc_name))
+        return vfc;
+  }
   return NULL;
 }
 

--- a/sys/vfs_vnode.c
+++ b/sys/vfs_vnode.c
@@ -66,6 +66,7 @@ static int vnode_generic_close(file_t *f, thread_t *td) {
   vnode_unref(f->f_vnode);
   return 0;
 }
+
 static int vnode_generic_getattr(file_t *f, thread_t *td, vattr_t *vattr) {
   vnode_t *v = f->f_vnode;
   return v->v_ops->v_getattr(v, vattr);

--- a/sys/vm_map.c
+++ b/sys/vm_map.c
@@ -19,10 +19,10 @@ static MALLOC_DEFINE(M_VMMAP, "vm-map", 1, 2);
 static vm_map_t kspace;
 
 void vm_map_activate(vm_map_t *map) {
-  critical_enter();
-  PCPU_SET(uspace, map);
-  pmap_activate(map ? map->pmap : NULL);
-  critical_leave();
+  IN_CRITICAL_SECTION () {
+    PCPU_SET(uspace, map);
+    pmap_activate(map ? map->pmap : NULL);
+  }
 }
 
 vm_map_t *get_user_vm_map() {
@@ -90,10 +90,11 @@ static bool vm_map_insert_entry(vm_map_t *vm_map, vm_map_entry_t *entry) {
 
 vm_map_entry_t *vm_map_find_entry(vm_map_t *vm_map, vm_addr_t vaddr) {
   vm_map_entry_t *etr_it;
-  rw_scoped_enter(&vm_map->rwlock, RW_READER);
-  TAILQ_FOREACH (etr_it, &vm_map->list, map_list)
-    if (etr_it->start <= vaddr && vaddr < etr_it->end)
-      return etr_it;
+  WITH_RW_LOCK (&vm_map->rwlock, RW_READER) {
+    TAILQ_FOREACH (etr_it, &vm_map->list, map_list)
+      if (etr_it->start <= vaddr && vaddr < etr_it->end)
+        return etr_it;
+  }
   return NULL;
 }
 
@@ -106,11 +107,10 @@ static void vm_map_remove_entry(vm_map_t *vm_map, vm_map_entry_t *entry) {
 }
 
 void vm_map_delete(vm_map_t *map) {
-  rw_enter(&map->rwlock, RW_WRITER);
-  while (map->nentries > 0)
-    vm_map_remove_entry(map, TAILQ_FIRST(&map->list));
-  rw_leave(&map->rwlock);
-
+  WITH_RW_LOCK (&map->rwlock, RW_WRITER) {
+    while (map->nentries > 0)
+      vm_map_remove_entry(map, TAILQ_FIRST(&map->list));
+  }
   kfree(M_VMMAP, map);
 }
 
@@ -121,7 +121,6 @@ vm_map_entry_t *vm_map_add_entry(vm_map_t *map, vm_addr_t start, vm_addr_t end,
   assert(is_aligned(start, PAGESIZE));
   assert(is_aligned(end, PAGESIZE));
 
-  rw_scoped_enter(&map->rwlock, RW_WRITER);
 #if 0
   assert(vm_map_find_entry(map, start) == NULL);
   assert(vm_map_find_entry(map, end) == NULL);
@@ -133,7 +132,8 @@ vm_map_entry_t *vm_map_add_entry(vm_map_t *map, vm_addr_t start, vm_addr_t end,
   entry->end = end;
   entry->prot = prot;
 
-  vm_map_insert_entry(map, entry);
+  WITH_RW_LOCK (&map->rwlock, RW_WRITER)
+    vm_map_insert_entry(map, entry);
 
   return entry;
 }
@@ -223,15 +223,15 @@ int vm_map_resize(vm_map_t *map, vm_map_entry_t *entry, vm_addr_t new_end) {
 
 void vm_map_dump(vm_map_t *map) {
   vm_map_entry_t *it;
-  kprintf("[vm_map] Virtual memory map (%08lx - %08lx):\n", map->pmap->start,
-          map->pmap->end);
-  rw_scoped_enter(&map->rwlock, RW_READER);
-  TAILQ_FOREACH (it, &map->list, map_list) {
-    kprintf("[vm_map] * %08lx - %08lx [%c%c%c]\n", it->start, it->end,
-            (it->prot & VM_PROT_READ) ? 'r' : '-',
-            (it->prot & VM_PROT_WRITE) ? 'w' : '-',
-            (it->prot & VM_PROT_EXEC) ? 'x' : '-');
-    vm_map_object_dump(it->object);
+  klog("Virtual memory map (%08lx - %08lx):", map->pmap->start, map->pmap->end);
+  WITH_RW_LOCK (&map->rwlock, RW_READER) {
+    TAILQ_FOREACH (it, &map->list, map_list) {
+      klog(" * %08lx - %08lx [%c%c%c]", it->start, it->end,
+           (it->prot & VM_PROT_READ) ? 'r' : '-',
+           (it->prot & VM_PROT_WRITE) ? 'w' : '-',
+           (it->prot & VM_PROT_EXEC) ? 'x' : '-');
+      vm_map_object_dump(it->object);
+    }
   }
 }
 
@@ -245,21 +245,21 @@ vm_map_t *vm_map_clone(vm_map_t *map) {
   vm_map_t *orig_current_map = get_user_vm_map();
   vm_map_t *newmap = vm_map_new();
 
-  rw_scoped_enter(&map->rwlock, RW_READER);
+  WITH_RW_LOCK (&map->rwlock, RW_READER) {
+    /* Temporarily switch to the new map, so that we may write contents. */
+    td->td_proc->p_uspace = newmap;
+    vm_map_activate(newmap);
 
-  /* Temporarily switch to the new map, so that we may write contents. */
-  td->td_proc->p_uspace = newmap;
-  vm_map_activate(newmap);
-
-  vm_map_entry_t *it;
-  TAILQ_FOREACH (it, &map->list, map_list) {
-    vm_map_entry_t *entry =
-      vm_map_add_entry(newmap, it->start, it->end, it->prot);
-    entry->object = default_pager->pgr_alloc();
-    vm_page_t *page;
-    TAILQ_FOREACH (page, &it->object->list, obj.list) {
-      memcpy((char *)it->start + page->vm_offset,
-             (char *)MIPS_PHYS_TO_KSEG0(page->paddr), page->size * PAGESIZE);
+    vm_map_entry_t *it;
+    TAILQ_FOREACH (it, &map->list, map_list) {
+      vm_map_entry_t *entry =
+        vm_map_add_entry(newmap, it->start, it->end, it->prot);
+      entry->object = default_pager->pgr_alloc();
+      vm_page_t *page;
+      TAILQ_FOREACH (page, &it->object->list, obj.list) {
+        memcpy((char *)it->start + page->vm_offset,
+               (char *)MIPS_PHYS_TO_KSEG0(page->paddr), page->size * PAGESIZE);
+      }
     }
   }
 
@@ -271,10 +271,12 @@ vm_map_t *vm_map_clone(vm_map_t *map) {
 }
 
 int vm_page_fault(vm_map_t *map, vm_addr_t fault_addr, vm_prot_t fault_type) {
-  vm_map_entry_t *entry;
-  rw_scoped_enter(&map->rwlock, RW_READER);
+  vm_map_entry_t *entry = NULL;
 
-  if (!(entry = vm_map_find_entry(map, fault_addr))) {
+  WITH_RW_LOCK (&map->rwlock, RW_READER)
+    entry = vm_map_find_entry(map, fault_addr);
+
+  if (!entry) {
     klog("Tried to access unmapped memory region: 0x%08lx!", fault_addr);
     return -EFAULT;
   }

--- a/tests/producer_consumer.c
+++ b/tests/producer_consumer.c
@@ -24,7 +24,7 @@ static void producer(void *ptr) {
   unsigned produced = 0;
   klog("%s started", thread_self()->td_name);
   while (working) {
-    mtx_scoped_lock(&buf.lock);
+    SCOPED_MTX_LOCK(&buf.lock);
     do {
       working = (buf.all_produced < ITEMS);
       if (!working)
@@ -49,7 +49,7 @@ static void consumer(void *ptr) {
   unsigned consumed = 0;
   klog("%s started", thread_self()->td_name);
   while (working) {
-    mtx_scoped_lock(&buf.lock);
+    SCOPED_MTX_LOCK(&buf.lock);
     do {
       working = (buf.all_consumed < ITEMS);
       if (!working)


### PR DESCRIPTION
During code reviews I have noticed that `mtx_scoped_lock` blends visually with the surrounding code too much. More important issue is that it does not force a programmer to think how long a mutex is really needed to be acquired, so the mutex may be held for code that does not require such assumption. To address the problem we could write following code with `mtx_scoped_lock`:

```c
{
  mtx_scoped_lock(a_lock);
  ...
}
```

... or use `WITH_MTX_LOCK`:

```c
WITH_MTX_LOCK (a_lock) {
  ...
}
```

Please give me your feedback on usefulness of this construct.