### PR TITLE
Simplified mutex and tailq initialization

### DIFF
--- a/include/interrupt.h
+++ b/include/interrupt.h
@@ -41,9 +41,6 @@ typedef struct intr_chain {
   unsigned ic_irq;                 /* physical interrupt request line number */
 } intr_chain_t;
 
-/* Initializes and enables interrupts. */
-void intr_init();
-
 void intr_chain_init(intr_chain_t *ic, unsigned irq, char *name);
 void intr_chain_add_handler(intr_chain_t *ic, intr_handler_t *ih);
 void intr_chain_remove_handler(intr_handler_t *ih);

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -15,6 +15,8 @@ typedef struct mtx {
   unsigned m_type;            /* Normal or recursive mutex */
 } mtx_t;
 
+#define MUTEX_INITIALIZER(type) (mtx_t){.m_owner = NULL, .m_count = 0, .m_type = type}
+
 /* Initializes mutex. Note that EVERY mutex has to be initialized
  * before it is used. */
 void mtx_init(mtx_t *m, unsigned type);

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -15,7 +15,10 @@ typedef struct mtx {
   unsigned m_type;            /* Normal or recursive mutex */
 } mtx_t;
 
-#define MUTEX_INITIALIZER(type) (mtx_t){.m_owner = NULL, .m_count = 0, .m_type = type}
+#define MUTEX_INITIALIZER(type)                                                \
+  (mtx_t) {                                                                    \
+    .m_owner = NULL, .m_count = 0, .m_type = type                              \
+  }
 
 /* Initializes mutex. Note that EVERY mutex has to be initialized
  * before it is used. */

--- a/include/thread.h
+++ b/include/thread.h
@@ -60,8 +60,6 @@ typedef struct thread {
   /* TODO: Signal mask, sigsuspend. */
 } thread_t;
 
-void thread_init();
-
 thread_t *thread_self();
 thread_t *thread_create(const char *name, void (*fn)(void *), void *arg);
 void thread_delete(thread_t *td);

--- a/mips/malta.c
+++ b/mips/malta.c
@@ -155,8 +155,6 @@ static void pm_bootstrap(unsigned memsize) {
 }
 
 static void thread_bootstrap() {
-  thread_init();
-
   /* Create main kernel thread */
   thread_t *td = thread_create("kernel-main", (void *)kernel_init, NULL);
 
@@ -178,7 +176,6 @@ void platform_init(int argc, char **argv, char **envp, unsigned memsize) {
   pcpu_init();
   cpu_init();
   tlb_init();
-  intr_init();
   mips_intr_init();
   pm_bootstrap(memsize);
   kmem_bootstrap();

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -25,7 +25,7 @@ typedef struct devfs_device {
 typedef TAILQ_HEAD(, devfs_device) devfs_device_list_t;
 static devfs_device_list_t devfs_device_list =
   TAILQ_HEAD_INITIALIZER(devfs_device_list);
-static mtx_t devfs_device_list_mtx;
+static mtx_t devfs_device_list_mtx = MUTEX_INITIALIZER(MTX_DEF);
 
 static devfs_device_t *devfs_get_by_name(const char *name) {
   SCOPED_MTX_LOCK(&devfs_device_list_mtx);
@@ -105,8 +105,6 @@ static int devfs_root(mount_t *m, vnode_t **v) {
 }
 
 static int devfs_init(vfsconf_t *vfc) {
-  mtx_init(&devfs_device_list_mtx, MTX_DEF);
-
   /* Prepare some initial devices */
   typedef void devfs_init_func_t();
   SET_DECLARE(devfs_init, devfs_init_func_t);

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -44,7 +44,7 @@ typedef struct cpio_node {
 
 typedef TAILQ_HEAD(, cpio_node) cpio_list_t;
 
-static cpio_list_t initrd_head;
+static cpio_list_t initrd_head = TAILQ_HEAD_INITIALIZER(initrd_head);
 static cpio_node_t *root_node;
 static vnodeops_t initrd_ops = {.v_lookup = vnode_op_notsup,
                                 .v_readdir = vnode_op_notsup,
@@ -249,7 +249,6 @@ static int initrd_init(vfsconf_t *vfc) {
   if (!rd_size)
     return ENXIO;
 
-  TAILQ_INIT(&initrd_head);
   initrd_ops.v_lookup = initrd_vnode_lookup;
   initrd_ops.v_read = initrd_vnode_read;
   initrd_ops.v_open = vnode_open_generic;

--- a/sys/interrupt.c
+++ b/sys/interrupt.c
@@ -1,6 +1,7 @@
 #include <interrupt.h>
 
-static TAILQ_HEAD(, intr_chain) intr_chain_list = TAILQ_HEAD_INITIALIZER(intr_chain_list);
+static TAILQ_HEAD(, intr_chain)
+  intr_chain_list = TAILQ_HEAD_INITIALIZER(intr_chain_list);
 
 void intr_chain_init(intr_chain_t *ic, unsigned irq, char *name) {
   ic->ic_irq = irq;

--- a/sys/interrupt.c
+++ b/sys/interrupt.c
@@ -1,10 +1,6 @@
 #include <interrupt.h>
 
-static TAILQ_HEAD(, intr_chain) intr_chain_list;
-
-void intr_init() {
-  TAILQ_INIT(&intr_chain_list);
-}
+static TAILQ_HEAD(, intr_chain) intr_chain_list = TAILQ_HEAD_INITIALIZER(intr_chain_list);
 
 void intr_chain_init(intr_chain_t *ic, unsigned irq, char *name) {
   ic->ic_irq = irq;

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -5,18 +5,11 @@
 
 static MALLOC_DEFINE(M_PROC, "proc", 1, 2);
 
-static mtx_t all_proc_list_mtx;
-static proc_list_t all_proc_list;
+static mtx_t all_proc_list_mtx = MUTEX_INITIALIZER(MTX_DEF);
+static proc_list_t all_proc_list = TAILQ_HEAD_INITIALIZER(all_proc_list);
 
-static mtx_t last_pid_mtx;
-static pid_t last_pid;
-
-static void proc_init() {
-  mtx_init(&all_proc_list_mtx, MTX_DEF);
-  TAILQ_INIT(&all_proc_list);
-  mtx_init(&last_pid_mtx, MTX_DEF);
-  last_pid = 0;
-}
+static mtx_t last_pid_mtx = MUTEX_INITIALIZER(MTX_DEF);
+static pid_t last_pid = 0;
 
 proc_t *proc_create() {
   proc_t *proc = kmalloc(M_PROC, sizeof(proc_t), M_ZERO);
@@ -52,5 +45,3 @@ proc_t *proc_find(pid_t pid) {
   }
   return p;
 }
-
-SYSINIT_ADD(proc, proc_init, NODEPS);

--- a/sys/thread.c
+++ b/sys/thread.c
@@ -14,20 +14,11 @@ static MALLOC_DEFINE(M_THREAD, "thread", 1, 2);
 
 typedef TAILQ_HEAD(, thread) thread_list_t;
 
-static mtx_t all_threads_mtx;
-static thread_list_t all_threads;
+static mtx_t all_threads_mtx = MUTEX_INITIALIZER(MTX_DEF);
+static thread_list_t all_threads = TAILQ_HEAD_INITIALIZER(all_threads);
 
-static mtx_t zombie_threads_mtx;
-static thread_list_t zombie_threads;
-
-void thread_init() {
-  klog("Threads initialization");
-  mtx_init(&all_threads_mtx, MTX_DEF);
-  TAILQ_INIT(&all_threads);
-
-  mtx_init(&zombie_threads_mtx, MTX_DEF);
-  TAILQ_INIT(&zombie_threads);
-}
+static mtx_t zombie_threads_mtx = MUTEX_INITIALIZER(MTX_DEF);
+static thread_list_t zombie_threads = TAILQ_HEAD_INITIALIZER(zombie_threads);
 
 /* FTTB such a primitive method of creating new TIDs will do. */
 static tid_t make_tid() {

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -14,12 +14,12 @@ MALLOC_DEFINE(M_VFS, "vfs", 1, 4);
 
 /* The list of all installed filesystem types */
 vfsconf_list_t vfsconf_list = TAILQ_HEAD_INITIALIZER(vfsconf_list);
-mtx_t vfsconf_list_mtx;
+mtx_t vfsconf_list_mtx = MUTEX_INITIALIZER(MTX_DEF);
 
 /* The list of all mounts mounted */
 typedef TAILQ_HEAD(, mount) mount_list_t;
 static mount_list_t mount_list = TAILQ_HEAD_INITIALIZER(mount_list);
-static mtx_t mount_list_mtx;
+static mtx_t mount_list_mtx = MUTEX_INITIALIZER(MTX_DEF);
 
 /* Default vfs operations */
 static vfs_root_t vfs_default_root;
@@ -41,9 +41,6 @@ static vnodeops_t vfs_root_ops = {
 static int vfs_register(vfsconf_t *vfc);
 
 static void vfs_init() {
-  mtx_init(&vfsconf_list_mtx, MTX_DEF);
-  mtx_init(&mount_list_mtx, MTX_DEF);
-
   vfs_root_vnode = vnode_new(V_DIR, &vfs_root_ops);
 
   /* Initialize available filesystem types. */


### PR DESCRIPTION
I was in a mood for cleanup today. I've always wondered why:

1. We rarely use `TAILQ_HEAD_INITIALIZER` macro
2. We have not implemented a `MUTEX_INITIALIZER` macro

These are very useful for initializing static/global variables. I've applied them consistently where applicable, and that rendered as much as three `init_` functions useless (!), so I've removed them entirely.