### PR TITLE
Disable pmap in klog mask by default

### DIFF
--- a/include/klog.h
+++ b/include/klog.h
@@ -32,6 +32,8 @@ typedef enum {
 #define KL_MASK(l) (1 << (l))
 #define KL_ALL 0xffffffff /* log everything */
 
+#define KL_DEFAULT_MASK (KL_ALL & (~KL_MASK(KL_PMAP)))
+
 /* Mask for subsystem using klog. If not specified using default subsystem. */
 #ifndef KL_LOG
 #define KL_LOG KL_UNDEF

--- a/sys/klog.c
+++ b/sys/klog.c
@@ -20,7 +20,7 @@ char *kenv_get(char *key);
 
 void klog_init() {
   const char *mask = kenv_get("klog-mask");
-  klog.mask = mask ? (unsigned)strtol(mask, NULL, 16) : KL_ALL;
+  klog.mask = mask ? (unsigned)strtol(mask, NULL, 16) : KL_DEFAULT_MASK;
   klog.verbose = kenv_get("klog-quiet") ? 0 : 1;
   klog.first = 0;
   klog.last = 0;


### PR DESCRIPTION
NOTE: I know I can set any mask I want on my own, but this is about changing the ***deafult experience***.

At this point `pmap` logs are extremely verbose, and they render the output completely unreadable and unattractive. When running `test_fork`, pmap logs take 75% of the output! Just see for yourself how much of a difference it makes: [completely useless output](https://pastebin.com/PQxCgpUY) versus [clean description of what the kernel is doing](https://pastebin.com/HQ1kGCpe). Stunning!

Furthermore, disabling `pmap` logs by default should increase the speed of automatic tests a lot.

And it's not like we need to see these messages by default, when was the last time any of us had to debug pmap behavior? We can explicitly re-enable it when working on pmap.