### PR TITLE
Simplify copying data between user-space and kernel-space

### DIFF
--- a/include/systm.h
+++ b/include/systm.h
@@ -12,8 +12,7 @@ int copyin(const void *restrict udaddr, void *restrict kaddr, size_t len)
 int copyout(const void *restrict kaddr, void *restrict udaddr, size_t len)
   __nonnull(1) __nonnull(2);
 
-/* fuword32() returns the data fetched or -1 on failure. */
-int32_t fuword32(const void *ptr);
-int suword32(void *ptr, int32_t word);
+#define copyin_s(udaddr, _what) copyin((udaddr), &(_what), sizeof(_what))
+#define copyout_s(_what, udaddr) copyout(&(_what), (udaddr), sizeof(_what))
 
 #endif /* !_SYS_SYSTM_H_ */

--- a/mips/copy.S
+++ b/mips/copy.S
@@ -123,41 +123,4 @@ LEAF(copyerr)
 	li	v0, -EFAULT		# return error
 END(copyerr)
 
-/*
- * int32_t fuword32(const void *ptr)
- * int suword32(void *ptr, int32_t word)
- * 
- * {fu,su}{iword32} fetch / store 32-bit word from / to the user space.
- */
-
-LEAF(fuword32)
-	LA	v0, fswberr
-	blt	a0, zero, fswberr	# make sure address is in user space
-	nop
-	LOAD_PCPU(v1)
-        PTR_L   v1, PCPU_CURTHREAD(v1)
-	PTR_S	v0, TD_ONFAULT(v1)
-	lw	v0, 0(a0)		# fetch word
-	j	ra
-	PTR_S	zero, TD_ONFAULT(v1)
-END(fuword32)
-
-LEAF(suword32)
-	LA	v0, fswberr
-	blt	a0, zero, fswberr	# make sure address is in user space
-	nop
-	LOAD_PCPU(v1)
-        PTR_L   v1, PCPU_CURTHREAD(v1)
-	PTR_S	v0, TD_ONFAULT(v1)
-	sw	a1, 0(a0)		# store short
-	PTR_S	zero, TD_ONFAULT(v1)
-	j	ra
-	move	v0, zero
-END(suword32)
-
-LEAF(fswberr)
-	j	ra
-	li	v0, -1
-END(fswberr)
-
 # vim: sw=8 ts=8 et

--- a/mips/signal.c
+++ b/mips/signal.c
@@ -71,7 +71,7 @@ int platform_sig_return() {
      the following will need to get the scp pointer address from a syscall
      argument. */
   sig_ctx_t *scp = (sig_ctx_t *)((intptr_t *)td->td_uctx.sp + 1);
-  int error = copyin(scp, &ksc, sizeof(sig_ctx_t));
+  int error = copyin_s(scp, ksc);
   if (error)
     return error;
   if (ksc.magic != SIG_CTX_MAGIC)

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -37,8 +37,6 @@ static int sys_sbrk(thread_t *td, syscall_args_t *args) {
   return sbrk_resize(td->td_proc->p_uspace, increment);
 }
 
-/* This is just a stub. A full implementation of this syscall will probably
-   deserve a separate file. */
 static int sys_exit(thread_t *td, syscall_args_t *args) {
   int status = args->args[0];
 
@@ -75,7 +73,7 @@ static int sys_sigaction(thread_t *td, syscall_args_t *args) {
   sigaction_t newact;
   sigaction_t oldact;
   int error;
-  if ((error = copyin(p_newact, &newact, sizeof(sigaction_t))))
+  if ((error = copyin_s(p_newact, newact)))
     return error;
 
   int res = do_sigaction(signo, &newact, &oldact);
@@ -83,7 +81,7 @@ static int sys_sigaction(thread_t *td, syscall_args_t *args) {
     return res;
 
   if (p_oldact != NULL)
-    if ((error = copyout(&oldact, p_oldact, sizeof(sigaction_t))))
+    if ((error = copyout_s(oldact, p_oldact)))
       return error;
 
   return res;
@@ -190,7 +188,7 @@ static int sys_fstat(thread_t *td, syscall_args_t *args) {
   int error = do_fstat(td, fd, &attr_buf);
   if (error)
     return error;
-  error = copyout(&attr_buf, buf, sizeof(vattr_t));
+  error = copyout_s(attr_buf, buf);
   if (error < 0)
     return error;
   return 0;
@@ -229,18 +227,17 @@ static int sys_getdirentries(thread_t *td, syscall_args_t *args) {
   int fd = args->args[0];
   char *ubuf = (char *)args->args[1];
   size_t count = args->args[2];
-  off_t *basep = (off_t *)args->args[3];
+  off_t *base_p = (off_t *)args->args[3];
   off_t base;
 
-  klog("getdirentries(%d, %p, %zu, %p)", fd, ubuf, count, basep);
+  klog("getdirentries(%d, %p, %zu, %p)", fd, ubuf, count, base_p);
 
   uio_t uio = UIO_SINGLE_USER(UIO_READ, 0, ubuf, count);
   int res = do_getdirentries(td, fd, &uio, &base);
   if (res < 0)
     return res;
-  if (basep != NULL)
-    if (suword32(basep, base) == -1)
-      return EFAULT;
+  if (base_p != NULL)
+    res = copyout_s(base, base_p);
   return res;
 }
 
@@ -259,18 +256,17 @@ static int sys_dup2(thread_t *td, syscall_args_t *args) {
 
 static int sys_waitpid(thread_t *td, syscall_args_t *args) {
   pid_t pid = args->args[0];
-  int *user_status = (int *)args->args[1];
+  int *status_p = (int *)args->args[1];
   int options = args->args[2];
+  int status = 0;
 
-  klog("waitpid(%d, %x, %d)", pid, user_status, options);
-  int status = 0, res;
+  klog("waitpid(%d, %x, %d)", pid, status_p, options);
 
-  res = do_waitpid(pid, &status, options);
+  int res = do_waitpid(pid, &status, options);
   if (res < 0)
     return res;
-
-  if (!user_status || suword32(user_status, status) < 0)
-    return EFAULT;
+  if (status_p != NULL)
+    res = copyout_s(status, status_p);
   return res;
 }
 


### PR DESCRIPTION
Mixing `copy{in,out}` with `{su,fu}word32` in syscall implementations started looking awkward, as the latter did not return `EFAULT`. Frankly, I can no longer justify `{fu,su}word32` existence in our code base, so I removed it.

Instead of it I introduced generic `copy{in,out}_s`, which simplified code using regular `copy{in,out}` as well.

