### PR TITLE
Fix waitpid return value

### DIFF
--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -265,9 +265,9 @@ static int sys_waitpid(thread_t *td, syscall_args_t *args) {
   int res = do_waitpid(pid, &status, options);
   if (res < 0)
     return res;
-  if (status_p != NULL){
+  if (status_p != NULL) {
     int error = copyout_s(status, status_p);
-    if(error)
+    if (error)
       return error;
   }
   return res;

--- a/sys/sysent.c
+++ b/sys/sysent.c
@@ -265,8 +265,11 @@ static int sys_waitpid(thread_t *td, syscall_args_t *args) {
   int res = do_waitpid(pid, &status, options);
   if (res < 0)
     return res;
-  if (status_p != NULL)
-    res = copyout_s(status, status_p);
+  if (status_p != NULL){
+    int error = copyout_s(status, status_p);
+    if(error)
+      return error;
+  }
   return res;
 }
 


### PR DESCRIPTION
This bug was introduced with #335 (Simplify copying data between user-space and kernel-space). `copyout_s` would overwrite the value returned by `do_waitpid`, which is the PID of the process we've waited for.

We don't have tests in place that would detect such issue, which is why I find #328 (Implemented utest user program) important.