### PR TITLE
Pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ script:
  - |
    set -e
    ./verify-format.sh
+   ./verify-pep8.sh
    make
    ./run_tests.py --thorough

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
  - sudo apt-get -qq update
  - sudo apt-get install -y qemu-system-mips ctags cscope wget python3-pip clang-format-3.8
  - sudo rm /usr/local/clang-3.5.0/bin/clang-format && sudo ln -s /usr/bin/clang-format-3.8 /usr/local/clang-3.5.0/bin/clang-format
- - sudo pip3 install -I pexpect
+ - sudo pip3 install -I pexpect pep8
  - wget http://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.1_amd64.deb
  - sudo dpkg -i mipsel-mimiker-elf_1.1_amd64.deb
  - export PATH="/opt/mipsel-mimiker-elf/bin/:$PATH"

--- a/verify-format.sh
+++ b/verify-format.sh
@@ -26,11 +26,11 @@ rm -rf $TMPDIR
 
 if ! [ $RES -eq 0 ]
 then
-    echo "Formatting incorrect. Please run 'make format' before"  \
-         "committing your changes, or manually apply the changes" \
-         "listed above."
+    echo "Formatting incorrect for C files!"
+    echo "Please run 'make format' before committing your changes,"\
+         "or manually apply the changes listed above."
 else
-    echo "Formatting correct."
+    echo "Formatting correct for C files."
 fi
 
 exit $RES

--- a/verify-pep8.sh
+++ b/verify-pep8.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+find . \( -name 'cache' -prune \) -o \( -name '.*.py' -prune \)\
+  -o \( -name '*.py' -print \) |xargs pep8
+RES=$?
+
+
+if ! [ $RES -eq 0 ]
+then
+    echo "Formatting incorrect. Please manually apply the changes" \
+         "listed above."
+else
+    echo "Formatting correct."
+fi
+
+exit $RES

--- a/verify-pep8.sh
+++ b/verify-pep8.sh
@@ -1,16 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 
-find . \( -name 'cache' -prune \) -o \( -name '.*.py' -prune \)\
-  -o \( -name '*.py' -print \) |xargs pep8
+PYFILES=$(find . \( -name 'cache' -prune \) \
+              -o \( -name '.*.py' -prune \) \
+              -o \( -name '*.py' -printf '%P\n' \))
+PYEXTRA="launch"
+
+pep8 ${PYEXTRA} ${PYFILES}
 RES=$?
-
 
 if ! [ $RES -eq 0 ]
 then
-    echo "Formatting incorrect. Please manually apply the changes" \
-         "listed above."
+    echo "Formatting incorrect for Python files!"
+    echo "Please manually fix the warnings listed above."
 else
-    echo "Formatting correct."
+    echo "Formatting correct for Python files."
 fi
 
 exit $RES


### PR DESCRIPTION
I had to use different approach than `verify-format.sh`. I just locate `*.py` files which aren't hidden (`.ycm_extra_conf.py`) or in cache (newlib/doc) and run pep8 on every one.
Implementation of  #345