### PR TITLE
RTC driver mockup

### DIFF
--- a/include/mips/malta.h
+++ b/include/mips/malta.h
@@ -75,9 +75,6 @@ void platform_init(int argc, char **argv, char **envp, unsigned memsize);
 
 #define MALTA_PCI0_ADDR(x) (MALTA_PCI0_IO_BASE + (x))
 
-/* Intel 82371EB: RTC (MC146818) */
-#define MALTA_RTC_ADDR MALTA_PCI0_ADDR(0x70)
-#define MALTA_RTC_DATA MALTA_PCI0_ADDR(0x71)
 /* FDC37M817: UART (NS16550) */
 #define MALTA_SMSC_UART0 MALTA_PCI0_ADDR(0x3f8)
 #define MALTA_SMSC_UART1 MALTA_PCI0_ADDR(0x2f8)

--- a/mips/gt64120.c
+++ b/mips/gt64120.c
@@ -202,11 +202,13 @@ static void gt_pci_unmask_irq(gt_pci_state_t *gtpci, unsigned irq) {
   gt_pci_set_icus(gtpci);
 }
 
+pci_bus_driver_t gt_pci_bus;
+
 static void gt_pci_intr_setup(device_t *pcib, unsigned irq,
                               intr_handler_t *handler) {
-  klog("gt_pci_intr_setup(%p, %d, %p)", pcib, irq, handler);
+  assert(pcib->parent->driver == &gt_pci_bus.driver);
 
-  gt_pci_state_t *gtpci = pcib->state;
+  gt_pci_state_t *gtpci = pcib->parent->state;
   intr_chain_t *chain = &gtpci->intr_chain[irq];
   CRITICAL_SECTION {
     intr_chain_add_handler(chain, handler);
@@ -216,9 +218,9 @@ static void gt_pci_intr_setup(device_t *pcib, unsigned irq,
 }
 
 static void gt_pci_intr_teardown(device_t *pcib, intr_handler_t *handler) {
-  klog("gt_pci_intr_teardown(%p, %p)", pcib, handler);
+  assert(pcib->parent->driver == &gt_pci_bus.driver);
 
-  gt_pci_state_t *gtpci = pcib->state;
+  gt_pci_state_t *gtpci = pcib->parent->state;
   intr_chain_t *chain = handler->ih_chain;
   CRITICAL_SECTION {
     if (chain->ic_count == 1)
@@ -295,6 +297,9 @@ static inline void gt_pci_intr_chain_init(gt_pci_state_t *gtpci, unsigned irq,
 
 static int gt_pci_attach(device_t *pcib) {
   gt_pci_state_t *gtpci = pcib->state;
+
+  pcib->bus = DEV_BUS_PCI;
+
   gtpci->pci_bus.mem_space = &gt_pci_memory;
   gtpci->pci_bus.io_space = &gt_pci_ioports;
   gtpci->corectrl = &gt_pci_corectrl;

--- a/tests/rtc.c
+++ b/tests/rtc.c
@@ -1,7 +1,11 @@
+#include <ktest.h>
 #include <common.h>
 #include <mips/malta.h>
 #include <dev/mc146818reg.h>
-#include <ktest.h>
+#include <pci.h>
+#include <interrupt.h>
+#include <klog.h>
+#include <sleepq.h>
 #include <time.h>
 
 #define RTC_ADDR_R *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(MALTA_RTC_ADDR))
@@ -31,27 +35,40 @@ static void rtc_gettime(tm_t *t) {
   t->tm_year = rtc_read(MC_YEAR) + 2000;
 }
 
-static void tv_delay(timeval_t delay) {
-  timeval_t now = get_uptime();
-  timeval_t end = timeval_add(&now, &delay);
-  while (timeval_cmp(&now, &end, <))
-    now = get_uptime();
+static intr_filter_t rtc_intr(void *arg) {
+  uint8_t regc = rtc_read(MC_REGC);
+  if (regc & MC_REGC_PF) {
+    sleepq_signal(rtc_intr);
+    return IF_FILTERED;
+  }
+  return IF_STRAY;
 }
 
+static INTR_HANDLER_DEFINE(rtc_intr_handler, rtc_intr, NULL, NULL, "RTC timer",
+                           0);
+
+extern device_t *gt_pci;
+
 static int test_rtc() {
-  rtc_setb(MC_REGB, MC_REGB_BINARY | MC_REGB_24HR | MC_REGB_PIE);
+  pci_bus_driver_t *gt_pci_drv = (pci_bus_driver_t *)gt_pci->driver;
+  gt_pci_drv->bus.intr_setup(gt_pci, 8, rtc_intr_handler);
+
+  /* Configure how the time is presented through registers. */
+  rtc_setb(MC_REGB, MC_REGB_BINARY | MC_REGB_24HR);
+
+  /* Set RTC timer so that it triggers interrupt 2 times per second. */
+  rtc_write(MC_REGA, MC_RATE_2_Hz);
+  rtc_setb(MC_REGB, MC_REGB_PIE);
 
   while (1) {
     tm_t t;
     rtc_gettime(&t);
 
-    uint8_t regc = rtc_read(MC_REGC);
+    klog("Time is %02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec);
 
-    kprintf("Time is %02d:%02d:%02d, C(%02x)\n", t.tm_hour, t.tm_min, t.tm_sec,
-            regc);
-
-    tv_delay(TIMEVAL(1.0));
+    sleepq_wait(rtc_intr, "RTC 2Hz interrupt");
   }
+
   return KTEST_FAILURE;
 }
 

--- a/tests/rtc.c
+++ b/tests/rtc.c
@@ -1,46 +1,47 @@
 #include <ktest.h>
 #include <common.h>
-#include <mips/malta.h>
 #include <dev/mc146818reg.h>
+#include <dev/isareg.h>
 #include <pci.h>
 #include <interrupt.h>
 #include <klog.h>
 #include <sleepq.h>
 #include <time.h>
 
-#define RTC_ADDR_R *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(MALTA_RTC_ADDR))
-#define RTC_DATA_R *(volatile uint8_t *)(MIPS_PHYS_TO_KSEG1(MALTA_RTC_DATA))
+#define RTC_ADDR (IO_RTC + 0)
+#define RTC_DATA (IO_RTC + 1)
 
 typedef struct rtc_state {
   resource_t *regs;
 } rtc_state_t;
 
-static inline uint8_t rtc_read(unsigned reg) {
-  RTC_ADDR_R = reg;
-  return RTC_DATA_R;
+static inline uint8_t rtc_read(resource_t *regs, unsigned addr) {
+  bus_space_write_1(regs, RTC_ADDR, addr);
+  return bus_space_read_1(regs, RTC_DATA);
 }
 
-static inline void rtc_write(unsigned reg, uint8_t value) {
-  RTC_ADDR_R = reg;
-  RTC_DATA_R = value;
+static inline void rtc_write(resource_t *regs, unsigned addr, uint8_t value) {
+  bus_space_write_1(regs, RTC_ADDR, addr);
+  bus_space_write_1(regs, RTC_DATA, value);
 }
 
-static inline void rtc_setb(unsigned reg, uint8_t mask) {
-  rtc_write(reg, rtc_read(reg) | mask);
+static inline void rtc_setb(resource_t *regs, unsigned addr, uint8_t mask) {
+  rtc_write(regs, addr, rtc_read(regs, addr) | mask);
 }
 
-static void rtc_gettime(tm_t *t) {
-  t->tm_sec = rtc_read(MC_SEC);
-  t->tm_min = rtc_read(MC_MIN);
-  t->tm_hour = rtc_read(MC_HOUR);
-  t->tm_wday = rtc_read(MC_DOW);
-  t->tm_mday = rtc_read(MC_DOM);
-  t->tm_mon = rtc_read(MC_MONTH);
-  t->tm_year = rtc_read(MC_YEAR) + 2000;
+static void rtc_gettime(resource_t *regs, tm_t *t) {
+  t->tm_sec = rtc_read(regs, MC_SEC);
+  t->tm_min = rtc_read(regs, MC_MIN);
+  t->tm_hour = rtc_read(regs, MC_HOUR);
+  t->tm_wday = rtc_read(regs, MC_DOW);
+  t->tm_mday = rtc_read(regs, MC_DOM);
+  t->tm_mon = rtc_read(regs, MC_MONTH);
+  t->tm_year = rtc_read(regs, MC_YEAR) + 2000;
 }
 
-static intr_filter_t rtc_intr(void *arg) {
-  uint8_t regc = rtc_read(MC_REGC);
+static intr_filter_t rtc_intr(void *data) {
+  rtc_state_t *rtc = data;
+  uint8_t regc = rtc_read(rtc->regs, MC_REGC);
   if (regc & MC_REGC_PF) {
     sleepq_signal(rtc_intr);
     return IF_FILTERED;
@@ -59,14 +60,15 @@ static int rtc_attach(device_t *dev) {
 
   rtc->regs = pcib->io_space;
 
+  rtc_intr_handler->ih_argument = rtc;
   bus_intr_setup(dev, 8, rtc_intr_handler);
 
   /* Configure how the time is presented through registers. */
-  rtc_setb(MC_REGB, MC_REGB_BINARY | MC_REGB_24HR);
+  rtc_setb(rtc->regs, MC_REGB, MC_REGB_BINARY | MC_REGB_24HR);
 
   /* Set RTC timer so that it triggers interrupt 2 times per second. */
-  rtc_write(MC_REGA, MC_RATE_2_Hz);
-  rtc_setb(MC_REGB, MC_REGB_PIE);
+  rtc_write(rtc->regs, MC_REGA, MC_RATE_2_Hz);
+  rtc_setb(rtc->regs, MC_REGB, MC_REGB_PIE);
 
   return 0;
 }
@@ -88,11 +90,12 @@ static device_t *make_device(device_t *parent, driver_t *driver) {
 extern device_t *gt_pci;
 
 static int test_rtc() {
-  (void)make_device(gt_pci, &rtc_driver);
+  device_t *rtcdev = make_device(gt_pci, &rtc_driver);
+  rtc_state_t *rtc = rtcdev->state;
 
   while (1) {
     tm_t t;
-    rtc_gettime(&t);
+    rtc_gettime(rtc->regs, &t);
 
     klog("Time is %02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec);
 

--- a/tests/rtc.c
+++ b/tests/rtc.c
@@ -11,9 +11,7 @@
 #define RTC_ADDR (IO_RTC + 0)
 #define RTC_DATA (IO_RTC + 1)
 
-typedef struct rtc_state {
-  resource_t *regs;
-} rtc_state_t;
+typedef struct rtc_state { resource_t *regs; } rtc_state_t;
 
 static inline uint8_t rtc_read(resource_t *regs, unsigned addr) {
   bus_space_write_1(regs, RTC_ADDR, addr);


### PR DESCRIPTION
This change shows that interrupts are correctly routed from ISA devices to the CPU.

2Hz periodic interrupt is used to wake up main thread in order to print a message.