### PR TITLE
New devfs API

### DIFF
--- a/include/devfs.h
+++ b/include/devfs.h
@@ -1,11 +1,10 @@
 #ifndef _SYS_DEVFS_H_
 #define _SYS_DEVFS_H_
 
-#include <vnode.h>
-
 #define DEVFS_NAME_MAX 64
 
 typedef struct devfs_node devfs_node_t;
+typedef struct vnodeops vnodeops_t;
 
 /* If parent is NULL new device will be attached to root devfs directory. */
 int devfs_makedev(devfs_node_t *parent, const char *name, vnodeops_t *vops,

--- a/include/devfs.h
+++ b/include/devfs.h
@@ -1,11 +1,12 @@
 #ifndef _SYS_DEVFS_H_
 #define _SYS_DEVFS_H_
 
+#include <vnode.h>
+
 #define DEVFS_NAME_MAX 64
 
-typedef struct vnode vnode_t;
-
 /* Installs a new device into the devfs */
-int devfs_install(const char *name, vnode_t *device);
+int devfs_install(const char *name, vnodetype_t type, vnodeops_t *vops,
+                  void *data);
 
 #endif /* !_SYS_DEVFS_H_ */

--- a/include/devfs.h
+++ b/include/devfs.h
@@ -5,8 +5,11 @@
 
 #define DEVFS_NAME_MAX 64
 
-/* Installs a new device into the devfs */
-int devfs_install(const char *name, vnodetype_t type, vnodeops_t *vops,
+typedef struct devfs_node devfs_node_t;
+
+/* If parent is NULL new device will be attached to root devfs directory. */
+int devfs_makedev(devfs_node_t *parent, const char *name, vnodeops_t *vops,
                   void *data);
+int devfs_makedir(devfs_node_t *parent, const char *name, devfs_node_t **dir_p);
 
 #endif /* !_SYS_DEVFS_H_ */

--- a/include/file.h
+++ b/include/file.h
@@ -40,6 +40,7 @@ typedef enum {
 #define O_RDONLY 0
 #define O_WRONLY 1
 #define O_RDWR 2
+#define O_RDWR_MASK 3
 
 typedef struct file {
   void *f_data; /* File specific data */

--- a/include/vnode.h
+++ b/include/vnode.h
@@ -136,7 +136,7 @@ static inline int VOP_RMDIR(vnode_t *dv, const char *name) {
 }
 
 /* Allocates and initializes a new vnode */
-vnode_t *vnode_new(vnodetype_t type, vnodeops_t *ops);
+vnode_t *vnode_new(vnodetype_t type, vnodeops_t *ops, void *data);
 
 /* Lock and unlock vnode's mutex.
  * Call vnode_lock whenever you're about to use vnode's contents. */

--- a/sys/dev_cons.c
+++ b/sys/dev_cons.c
@@ -40,7 +40,7 @@ static vnodeops_t dev_cons_vnodeops = {.v_open = vnode_open_generic,
 
 static void init_dev_cons(void) {
   vnodeops_init(&dev_cons_vnodeops);
-  devfs_install("cons", V_DEV, &dev_cons_vnodeops, NULL);
+  devfs_makedev(NULL, "cons", &dev_cons_vnodeops, NULL);
 }
 
 SET_ENTRY(devfs_init, init_dev_cons);

--- a/sys/dev_cons.c
+++ b/sys/dev_cons.c
@@ -6,8 +6,6 @@
 #include <console.h>
 #include <linker_set.h>
 
-static vnode_t *dev_cons_device;
-
 #define UART_BUF_MAX 100
 
 static int dev_cons_write(vnode_t *t, uio_t *uio) {
@@ -42,8 +40,7 @@ static vnodeops_t dev_cons_vnodeops = {.v_open = vnode_open_generic,
 
 static void init_dev_cons(void) {
   vnodeops_init(&dev_cons_vnodeops);
-  dev_cons_device = vnode_new(V_DEV, &dev_cons_vnodeops);
-  devfs_install("cons", dev_cons_device);
+  devfs_install("cons", V_DEV, &dev_cons_vnodeops, NULL);
 }
 
 SET_ENTRY(devfs_init, init_dev_cons);

--- a/sys/dev_null.c
+++ b/sys/dev_null.c
@@ -5,20 +5,18 @@
 #include <vnode.h>
 #include <linker_set.h>
 
-static vnode_t *dev_null_device;
-static vnode_t *dev_zero_device;
 static vm_page_t *zero_page, *junk_page;
 
-static int dev_null_write(vnode_t *t, uio_t *uio) {
+static int dev_null_write(vnode_t *v, uio_t *uio) {
   uio->uio_resid = 0;
   return 0;
 }
 
-static int dev_null_read(vnode_t *t, uio_t *uio) {
+static int dev_null_read(vnode_t *v, uio_t *uio) {
   return 0;
 }
 
-static int dev_zero_write(vnode_t *t, uio_t *uio) {
+static int dev_zero_write(vnode_t *v, uio_t *uio) {
   /* We might just discard the data, but to demonstrate using uiomove for
    * writing, store the data into a junkyard page. */
   int error = 0;
@@ -31,7 +29,7 @@ static int dev_zero_write(vnode_t *t, uio_t *uio) {
   return error;
 }
 
-static int dev_zero_read(vnode_t *t, uio_t *uio) {
+static int dev_zero_read(vnode_t *v, uio_t *uio) {
   int error = 0;
   while (uio->uio_resid && !error) {
     size_t len = uio->uio_resid;
@@ -55,12 +53,10 @@ static void init_dev_null(void) {
   junk_page = pm_alloc(1);
 
   vnodeops_init(&dev_null_vnodeops);
-  dev_null_device = vnode_new(V_DEV, &dev_null_vnodeops);
-  devfs_install("null", dev_null_device);
+  devfs_install("null", V_DEV, &dev_null_vnodeops, NULL);
 
   vnodeops_init(&dev_zero_vnodeops);
-  dev_zero_device = vnode_new(V_DEV, &dev_zero_vnodeops);
-  devfs_install("zero", dev_zero_device);
+  devfs_install("zero", V_DEV, &dev_zero_vnodeops, NULL);
 }
 
 SET_ENTRY(devfs_init, init_dev_null);

--- a/sys/dev_null.c
+++ b/sys/dev_null.c
@@ -53,10 +53,10 @@ static void init_dev_null(void) {
   junk_page = pm_alloc(1);
 
   vnodeops_init(&dev_null_vnodeops);
-  devfs_install("null", V_DEV, &dev_null_vnodeops, NULL);
+  devfs_makedev(NULL, "null", &dev_null_vnodeops, NULL);
 
   vnodeops_init(&dev_zero_vnodeops);
-  devfs_install("zero", V_DEV, &dev_zero_vnodeops, NULL);
+  devfs_makedev(NULL, "zero", &dev_zero_vnodeops, NULL);
 }
 
 SET_ENTRY(devfs_init, init_dev_null);

--- a/sys/dev_vga.c
+++ b/sys/dev_vga.c
@@ -98,7 +98,5 @@ void dev_vga_install(vga_device_t *vga) {
   vnodeops_init(&dev_vga_videomode_vnodeops);
   vnodeops_init(&dev_vga_vnodeops);
 
-  vnode_t *dev_vga_device = vnode_new(V_DIR, &dev_vga_vnodeops);
-  dev_vga_device->v_data = vga;
-  devfs_install("vga", dev_vga_device);
+  devfs_install("vga", V_DIR, &dev_vga_vnodeops, vga);
 }

--- a/sys/dev_vga.c
+++ b/sys/dev_vga.c
@@ -11,14 +11,14 @@ static int framebuffer_write(vnode_t *v, uio_t *uio) {
 }
 
 static vnodeops_t framebuffer_vnodeops = {.v_open = vnode_open_generic,
-                                      .v_write = framebuffer_write};
+                                          .v_write = framebuffer_write};
 
 static int palette_write(vnode_t *v, uio_t *uio) {
   return vga_palette_write((vga_device_t *)v->v_data, uio);
 }
 
 static vnodeops_t palette_vnodeops = {.v_open = vnode_open_generic,
-                                  .v_write = palette_write};
+                                      .v_write = palette_write};
 
 #define RES_CTRL_BUFFER_SIZE 16
 
@@ -61,10 +61,9 @@ static int videomode_read(vnode_t *v, uio_t *uio) {
   return 0;
 }
 
-static vnodeops_t videomode_vnodeops = {
-  .v_open = vnode_open_generic,
-  .v_read = videomode_read,
-  .v_write = videomode_write};
+static vnodeops_t videomode_vnodeops = {.v_open = vnode_open_generic,
+                                        .v_read = videomode_read,
+                                        .v_write = videomode_write};
 
 void dev_vga_install(vga_device_t *vga) {
   devfs_node_t *vga_root;

--- a/sys/dev_vga.c
+++ b/sys/dev_vga.c
@@ -6,17 +6,23 @@
 #include <stdc.h>
 #include <vga.h>
 
-static int dev_vga_framebuffer_write(vnode_t *v, uio_t *uio) {
+static int framebuffer_write(vnode_t *v, uio_t *uio) {
   return vga_fb_write((vga_device_t *)v->v_data, uio);
 }
 
-static int dev_vga_palette_write(vnode_t *v, uio_t *uio) {
+static vnodeops_t framebuffer_vnodeops = {.v_open = vnode_open_generic,
+                                      .v_write = framebuffer_write};
+
+static int palette_write(vnode_t *v, uio_t *uio) {
   return vga_palette_write((vga_device_t *)v->v_data, uio);
 }
 
+static vnodeops_t palette_vnodeops = {.v_open = vnode_open_generic,
+                                  .v_write = palette_write};
+
 #define RES_CTRL_BUFFER_SIZE 16
 
-static int dev_vga_videomode_write(vnode_t *v, uio_t *uio) {
+static int videomode_write(vnode_t *v, uio_t *uio) {
   vga_device_t *vga = (vga_device_t *)v->v_data;
   uio->uio_offset = 0; /* This file does not support offsets. */
   unsigned xres, yres, bpp;
@@ -37,7 +43,7 @@ static int dev_vga_videomode_write(vnode_t *v, uio_t *uio) {
   return 0;
 }
 
-static int dev_vga_videomode_read(vnode_t *v, uio_t *uio) {
+static int videomode_read(vnode_t *v, uio_t *uio) {
   vga_device_t *vga = (vga_device_t *)v->v_data;
   unsigned xres, yres, bpp;
   int error = vga_get_videomode(vga, &xres, &yres, &bpp);
@@ -55,48 +61,22 @@ static int dev_vga_videomode_read(vnode_t *v, uio_t *uio) {
   return 0;
 }
 
-static vnodeops_t dev_vga_framebuffer_vnodeops = {
-  .v_open = vnode_open_generic, .v_write = dev_vga_framebuffer_write};
-
-static vnodeops_t dev_vga_palette_vnodeops = {.v_open = vnode_open_generic,
-                                              .v_write = dev_vga_palette_write};
-
-static vnodeops_t dev_vga_videomode_vnodeops = {
+static vnodeops_t videomode_vnodeops = {
   .v_open = vnode_open_generic,
-  .v_read = dev_vga_videomode_read,
-  .v_write = dev_vga_videomode_write};
-
-static int dev_vga_lookup(vnode_t *v, const char *name, vnode_t **res) {
-  vga_device_t *vga = (vga_device_t *)v->v_data;
-  if (strncmp(name, "fb", 2) == 0) {
-    *res = vnode_new(V_DEV, &dev_vga_framebuffer_vnodeops);
-    (*res)->v_data = vga;
-    return 0;
-  }
-  if (strncmp(name, "palette", 7) == 0) {
-    *res = vnode_new(V_DEV, &dev_vga_palette_vnodeops);
-    (*res)->v_data = vga;
-    return 0;
-  }
-  if (strncmp(name, "videomode", 7) == 0) {
-    *res = vnode_new(V_DEV, &dev_vga_videomode_vnodeops);
-    (*res)->v_data = vga;
-    return 0;
-  }
-  return ENOENT;
-}
-
-static vnodeops_t dev_vga_vnodeops = {.v_lookup = dev_vga_lookup};
+  .v_read = videomode_read,
+  .v_write = videomode_write};
 
 void dev_vga_install(vga_device_t *vga) {
-  static int installed = 0;
-  if (installed++) /* Only a single vga device may be installed at /dev/vga. */
+  devfs_node_t *vga_root;
+
+  /* Only a single vga device may be installed at /dev/vga. */
+  if (devfs_makedir(NULL, "vga", &vga_root))
     return;
 
-  vnodeops_init(&dev_vga_framebuffer_vnodeops);
-  vnodeops_init(&dev_vga_palette_vnodeops);
-  vnodeops_init(&dev_vga_videomode_vnodeops);
-  vnodeops_init(&dev_vga_vnodeops);
-
-  devfs_install("vga", V_DIR, &dev_vga_vnodeops, vga);
+  vnodeops_init(&framebuffer_vnodeops);
+  devfs_makedev(vga_root, "fb", &framebuffer_vnodeops, vga);
+  vnodeops_init(&palette_vnodeops);
+  devfs_makedev(vga_root, "palette", &palette_vnodeops, vga);
+  vnodeops_init(&videomode_vnodeops);
+  devfs_makedev(vga_root, "videomode", &videomode_vnodeops, vga);
 }

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -6,6 +6,7 @@
 #include <mutex.h>
 #include <malloc.h>
 #include <linker_set.h>
+#include <dirent.h>
 
 typedef struct devfs_node devfs_node_t;
 typedef TAILQ_HEAD(, devfs_node) devfs_node_list_t;
@@ -13,20 +14,27 @@ typedef TAILQ_HEAD(, devfs_node) devfs_node_list_t;
 struct devfs_node {
   TAILQ_ENTRY(devfs_node) dn_link;
   char *dn_name;
+  ino_t dn_ino;
   vnode_t *dn_vnode;
+  devfs_node_t *dn_parent;
   devfs_node_list_t dn_children;
 };
 
 /* device filesystem state structure */
 typedef struct devfs_mount {
   mtx_t lock;
+  ino_t next_ino;
   devfs_node_t root;
 } devfs_mount_t;
 
 static devfs_mount_t devfs = {.lock = MUTEX_INITIALIZER(MTX_RECURSE),
+                              .next_ino = 2,
                               .root = {}};
 static vnode_lookup_t devfs_vop_lookup;
-static vnodeops_t devfs_vnodeops = {.v_lookup = devfs_vop_lookup};
+static vnode_readdir_t devfs_vop_readdir;
+static vnodeops_t devfs_vnodeops = {.v_lookup = devfs_vop_lookup,
+                                    .v_readdir = devfs_vop_readdir,
+                                    .v_open = vnode_open_generic};
 
 static devfs_node_t *devfs_find_child(devfs_node_t *parent, const char *name) {
   SCOPED_MTX_LOCK(&devfs.lock);
@@ -54,6 +62,7 @@ int devfs_makedev(devfs_node_t *parent, const char *name, vnodeops_t *vops,
   dn->dn_vnode = vnode_new(V_DEV, vops, data);
 
   WITH_MTX_LOCK (&devfs.lock) {
+    dn->dn_ino = ++devfs.next_ino;
     if (devfs_find_child(parent, name))
       return -EEXIST;
     TAILQ_INSERT_TAIL(&parent->dn_children, dn, dn_link);
@@ -73,9 +82,11 @@ int devfs_makedir(devfs_node_t *parent, const char *name,
   devfs_node_t *dn = kmalloc(M_VFS, sizeof(devfs_node_t), M_ZERO);
   dn->dn_name = kstrndup(M_VFS, name, DEVFS_NAME_MAX);
   dn->dn_vnode = vnode_new(V_DIR, &devfs_vnodeops, dn);
+  dn->dn_parent = parent;
   TAILQ_INIT(&dn->dn_children);
 
   WITH_MTX_LOCK (&devfs.lock) {
+    dn->dn_ino = ++devfs.next_ino;
     if (devfs_find_child(parent, name))
       return -EEXIST;
     TAILQ_INSERT_TAIL(&parent->dn_children, dn, dn_link);
@@ -107,6 +118,57 @@ static int devfs_vop_lookup(vnode_t *dv, const char *name, vnode_t **vp) {
   return 0;
 }
 
+static inline devfs_node_t *vn2dn(vnode_t *v) {
+  return (devfs_node_t *)v->v_data;
+}
+
+static void *devfs_dirent_next(vnode_t *v, void *it) {
+  assert(it != NULL);
+  if (it == DIRENT_DOT)
+    return DIRENT_DOTDOT;
+  if (it == DIRENT_DOTDOT)
+    return TAILQ_FIRST(&vn2dn(v)->dn_children);
+  return TAILQ_NEXT((devfs_node_t *)it, dn_link);
+}
+
+static size_t devfs_dirent_namlen(vnode_t *v, void *it) {
+  assert(it != NULL);
+  if (it == DIRENT_DOT)
+    return 1;
+  if (it == DIRENT_DOTDOT)
+    return 2;
+  return strlen(((devfs_node_t *)it)->dn_name);
+}
+
+static void devfs_to_dirent(vnode_t *v, void *it, dirent_t *dir) {
+  assert(it != NULL);
+  devfs_node_t *node;
+  const char *name;
+  if (it == DIRENT_DOT) {
+    node = vn2dn(v);
+    name = ".";
+  } else if (it == DIRENT_DOTDOT) {
+    node = vn2dn(v)->dn_parent;
+    name = "..";
+  } else {
+    node = (devfs_node_t *)it;
+    name = node->dn_name;
+  }
+  dir->d_fileno = node->dn_ino;
+  dir->d_type = (node->dn_vnode->v_type == V_DIR) ? DT_DIR : DT_BLK;
+  memcpy(dir->d_name, name, dir->d_namlen + 1);
+}
+
+static readdir_ops_t devfs_readdir_ops = {
+  .next = devfs_dirent_next,
+  .namlen_of = devfs_dirent_namlen,
+  .convert = devfs_to_dirent,
+};
+
+static int devfs_vop_readdir(vnode_t *v, uio_t *uio, void *state) {
+  return readdir_generic(v, uio, &devfs_readdir_ops);
+}
+
 static int devfs_root(mount_t *m, vnode_t **vp) {
   *vp = devfs.root.dn_vnode;
   vnode_ref(*vp);
@@ -117,8 +179,10 @@ static int devfs_init(vfsconf_t *vfc) {
   vnodeops_init(&devfs_vnodeops);
 
   devfs_node_t *dn = &devfs.root;
-  dn->dn_vnode = vnode_new(V_DIR, &devfs_vnodeops, NULL);
+  dn->dn_vnode = vnode_new(V_DIR, &devfs_vnodeops, dn);
   dn->dn_name = "";
+  dn->dn_parent = dn;
+  dn->dn_ino = devfs.next_ino;
   TAILQ_INIT(&dn->dn_children);
 
   /* Prepare some initial devices */

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -27,9 +27,8 @@ typedef struct devfs_mount {
   devfs_node_t root;
 } devfs_mount_t;
 
-static devfs_mount_t devfs = {.lock = MUTEX_INITIALIZER(MTX_RECURSE),
-                              .next_ino = 2,
-                              .root = {}};
+static devfs_mount_t devfs = {
+  .lock = MUTEX_INITIALIZER(MTX_RECURSE), .next_ino = 2, .root = {}};
 static vnode_lookup_t devfs_vop_lookup;
 static vnode_readdir_t devfs_vop_readdir;
 static vnodeops_t devfs_vnodeops = {.v_lookup = devfs_vop_lookup,

--- a/sys/devfs.c
+++ b/sys/devfs.c
@@ -37,8 +37,10 @@ static devfs_device_t *devfs_get_by_name(const char *name) {
   return NULL;
 }
 
-int devfs_install(const char *name, vnode_t *device) {
+int devfs_install(const char *name, vnodetype_t type, vnodeops_t *vops,
+                  void *data) {
   size_t n = strlen(name);
+
   if (n >= DEVFS_NAME_MAX)
     return -ENAMETOOLONG;
 
@@ -47,7 +49,8 @@ int devfs_install(const char *name, vnode_t *device) {
 
   devfs_device_t *idev = kmalloc(M_VFS, sizeof(devfs_device_t), M_ZERO);
   strlcpy(idev->name, name, DEVFS_NAME_MAX);
-  idev->dev = device;
+  idev->dev = vnode_new(type, vops);
+  idev->dev->v_data = data;
 
   WITH_MTX_LOCK (&devfs_device_list_mtx)
     TAILQ_INSERT_TAIL(&devfs_device_list, idev, list);

--- a/sys/drv_atkbdc.c
+++ b/sys/drv_atkbdc.c
@@ -162,9 +162,7 @@ static int atkbdc_attach(device_t *dev) {
   write_data(atkbdc->regs, KBD_ENABLE_KBD_INT);
 
   /* Prepare /dev/scancode interface. */
-  vnode_t *scancode_device = vnode_new(V_DEV, &dev_scancode_ops);
-  scancode_device->v_data = atkbdc;
-  devfs_install("scancode", scancode_device);
+  devfs_install("scancode", V_DEV, &dev_scancode_ops, atkbdc);
 
   return 0;
 }

--- a/sys/drv_atkbdc.c
+++ b/sys/drv_atkbdc.c
@@ -76,7 +76,7 @@ static int scancode_read(vnode_t *v, uio_t *uio) {
   return 0;
 }
 
-static vnodeops_t dev_scancode_ops = {
+static vnodeops_t scancode_vnodeops = {
   .v_open = vnode_open_generic, .v_read = scancode_read,
 };
 
@@ -162,7 +162,7 @@ static int atkbdc_attach(device_t *dev) {
   write_data(atkbdc->regs, KBD_ENABLE_KBD_INT);
 
   /* Prepare /dev/scancode interface. */
-  devfs_install("scancode", V_DEV, &dev_scancode_ops, atkbdc);
+  devfs_makedev(NULL, "scancode", &scancode_vnodeops, atkbdc);
 
   return 0;
 }
@@ -177,7 +177,7 @@ static driver_t atkbdc_driver = {
 extern device_t *gt_pci;
 
 static void atkbdc_init(void) {
-  vnodeops_init(&dev_scancode_ops);
+  vnodeops_init(&scancode_vnodeops);
   (void)make_device(gt_pci, &atkbdc_driver);
 }
 

--- a/sys/initrd.c
+++ b/sys/initrd.c
@@ -204,8 +204,7 @@ static int initrd_vnode_lookup(vnode_t *vdir, const char *name, vnode_t **res) {
         vnodetype_t type = V_REG;
         if (CMTOFT(it->c_mode) == C_DIR)
           type = V_DIR;
-        *res = vnode_new(type, &initrd_vops);
-        (*res)->v_data = (void *)it;
+        *res = vnode_new(type, &initrd_vops, it);
 
         /* TODO: Only store a token (weak pointer) that allows looking up the
            vnode, otherwise the vnode will never get freed. */
@@ -304,8 +303,7 @@ static int initrd_root(mount_t *m, vnode_t **v) {
 }
 
 static int initrd_mount(mount_t *m) {
-  vnode_t *root = vnode_new(V_DIR, &initrd_vops);
-  root->v_data = (void *)root_node;
+  vnode_t *root = vnode_new(V_DIR, &initrd_vops, root_node);
   root->v_mount = m;
   m->mnt_data = root;
   return 0;

--- a/sys/vfs.c
+++ b/sys/vfs.c
@@ -38,7 +38,7 @@ static int vfs_register(vfsconf_t *vfc);
 static void vfs_init(void) {
   vnodeops_init(&vfs_root_ops);
 
-  vfs_root_vnode = vnode_new(V_DIR, &vfs_root_ops);
+  vfs_root_vnode = vnode_new(V_DIR, &vfs_root_ops, NULL);
 
   /* Initialize available filesystem types. */
   SET_DECLARE(vfsconf, vfsconf_t);

--- a/sys/vfs_vnode.c
+++ b/sys/vfs_vnode.c
@@ -17,10 +17,10 @@ static MALLOC_DEFINE(M_VNODE, "vnode", 2, 16);
 static void vnode_init(void) {
 }
 
-vnode_t *vnode_new(vnodetype_t type, vnodeops_t *ops) {
+vnode_t *vnode_new(vnodetype_t type, vnodeops_t *ops, void *data) {
   vnode_t *v = kmalloc(M_VNODE, sizeof(vnode_t), M_ZERO);
   v->v_type = type;
-  v->v_data = NULL;
+  v->v_data = data;
   v->v_ops = ops;
   v->v_usecnt = 1;
   mtx_init(&v->v_mtx, MTX_DEF);

--- a/sys/vfs_vnode.c
+++ b/sys/vfs_vnode.c
@@ -179,7 +179,7 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
   fp->f_ops = &default_vnode_fileops;
   fp->f_type = FT_VNODE;
   fp->f_vnode = v;
-  switch (mode & O_RDWR) {
+  switch (mode & O_RDWR_MASK) {
     case O_RDONLY:
       fp->f_flags = FF_READ;
       break;


### PR DESCRIPTION
This change introduces API for registering device subtrees in device filesystem. The most apparent improvement is visible on `sys/dev_vga.c` file. Same functionality is expressed with ~20 lines less, but with addition of directory listing (tested with `/bin/ls_rec`).

Registering device files (`fb`, `palette` and `videomode`) in a subdirectory (`vga`) boils down to:
```c
devfs_makedir(NULL, "vga", &vga_root);
devfs_makedev(vga_root, "fb", &framebuffer_vnodeops, vga); /* /dev/vga/fb */
devfs_makedev(vga_root, "palette", &palette_vnodeops, vga); /* /dev/vga/palette */
devfs_makedev(vga_root, "videomode", &videomode_vnodeops, vga); /* /dev/vga/videomode */
```