### PR TITLE
Revert a major regression in vnode_open_generic

### DIFF
--- a/sys/vfs_vnode.c
+++ b/sys/vfs_vnode.c
@@ -179,7 +179,7 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
   fp->f_ops = &default_vnode_fileops;
   fp->f_type = FT_VNODE;
   fp->f_vnode = v;
-  switch (mode & O_RDWR) {
+  switch (mode) {
     case O_RDONLY:
       fp->f_flags = FF_READ;
       break;


### PR DESCRIPTION
I suggest to revert this change which was introduced as a part of this [major patch](https://github.com/cahirwpz/mimiker/commit/0bb05a098b27936df30fbbcadc38f9387174dc49). I see no point of it, and because of this change **usermode programs are no longer able to write to stdout**. Note that:
```
O_RDONLY = 0
O_WRONLY = 1
O_RDWR = 2
```
These are numbers, not bitmasks. Thus masking mode with `O_RDWR` causes files that are requested in `O_WRONLY` mode (like stdout) to be opened in `FF_READ` mode, which is incorrect.

I also urge you, again, to **manually test some user programs**, especially during such extensive changes as the one that introduced this problem, as it would immediately detect this issue and save us both time! Although... I think I shouldn't care anymore.