### PR TITLE
Even cooler CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,22 @@ jobs:
     docker:
       - image: rafalcieslak/mimiker-build-base:1.0
     steps:
+      - run: apt-get install curl
+      - run:
+          name: 'Trigger other jobs'
+          command: |
+            # One day this function will become a CircleCI built-in.
+            echo $CIRCLE_API_TOKEN
+            function trigger_job() {
+              job_name=$1
+              curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=$job_name \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            }          
+            trigger_job verify-formatting
+            trigger_job verify-pep8
       - checkout
-      - run:
-          name: 'Verify formatting'
-          command: './verify-format.sh'
-      - run:
-          name: 'Verify PEP8'
-          command: './verify-pep8.sh'
       - run:
           name: 'Make'
           command: 'make'
@@ -24,3 +33,19 @@ jobs:
       - run:
           name: 'Run kernel tests'
           command: './run_tests.py --thorough'
+
+  verify-formatting:
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.0
+    steps:
+      - checkout
+      - run: './verify-format.sh'
+
+  verify-pep8:
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.0
+    steps:
+      - checkout
+      - run: './verify-pep8.sh'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,26 +3,9 @@ jobs:
   build:
     working_directory: ~/mimiker
     docker:
-      - image: ubuntu:xenial
-        environment:
-          PATH: /opt/mipsel-mimiker-elf/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - image: rafalcieslak/mimiker-build-base:1.0
     steps:
-      - run:
-          name: 'Install system deps'
-          command: 'apt-get -q update && apt-get install -y git make wget cpio socat qemu-system-mips ctags cscope python3-pip clang-format-3.8 rsync'
       - checkout
-      - run:
-          name: 'Install python deps'
-          command: 'pip3 install -I pexpect pep8'
-      - run:
-          name: 'Fetch toolchain package'
-          command: 'wget http://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.1_amd64.deb'
-      - run:
-          name: 'Install toolchain package'
-          command: 'dpkg -i mipsel-mimiker-elf_1.1_amd64.deb'
-      - run:
-          name: 'Select clang-format version to use'
-          command: 'ln -s /usr/bin/clang-format-3.8 /usr/local/bin/clang-format'
       - run:
           name: 'Verify formatting'
           command: './verify-format.sh'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,41 +3,26 @@ jobs:
   build:
     working_directory: ~/mimiker
     docker:
-      - image: rafalcieslak/mimiker-build-base:1.0
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
-      - run: apt-get install curl
       - run:
-          name: 'Trigger other jobs'
+          name: 'Trigger basic jobs'
           command: |
             # One day this function will become a CircleCI built-in.
-            echo $CIRCLE_API_TOKEN
             function trigger_job() {
-              job_name=$1
               curl --user ${CIRCLE_API_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=$job_name \
+                --data build_parameters[CIRCLE_JOB]=$1 \
                 --data revision=$CIRCLE_SHA1 \
                 https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
             }          
             trigger_job verify-formatting
             trigger_job verify-pep8
-      - checkout
-      - run:
-          name: 'Make'
-          command: 'make'
-      - store_artifacts:
-          path: mimiker.elf
-          prefix: kernel_image
-      - store_artifacts:
-          path: initrd.cpio
-          prefix: ramdisk
-      - run:
-          name: 'Run kernel tests'
-          command: './run_tests.py --thorough'
+            trigger_job compile
 
   verify-formatting:
     working_directory: ~/mimiker
     docker:
-      - image: rafalcieslak/mimiker-build-base:1.0
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
       - checkout
       - run: './verify-format.sh'
@@ -45,7 +30,47 @@ jobs:
   verify-pep8:
     working_directory: ~/mimiker
     docker:
-      - image: rafalcieslak/mimiker-build-base:1.0
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
       - checkout
       - run: './verify-pep8.sh'
+
+  compile:
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
+    steps:
+      - checkout
+      - run: 'make'
+      - store_artifacts:
+          path: mimiker.elf
+          prefix: kernel_image
+      - store_artifacts:
+          path: initrd.cpio
+          prefix: ramdisk
+      - save_cache:
+          key: mimiker-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - mimiker.elf
+            - initrd.cpio
+      - run:
+          name: 'Trigger kernel tests'
+          command: |
+            # One day this function will become a CircleCI built-in.
+            function trigger_job() {
+              curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=$1 \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            }          
+            trigger_job kernel_tests
+
+  kernel_tests:
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
+    steps:
+      - checkout
+      - restore_cache:
+          key: mimiker-{{ .Branch }}-{{ .Revision }}
+      - run: './run_tests.py --thorough'

--- a/.circleci/image/Dockerfile
+++ b/.circleci/image/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ENV PATH="/opt/mipsel-mimiker-elf/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-RUN apt-get -q update && apt-get install -y git make wget cpio socat qemu-system-mips ctags cscope python3-pip clang-format-3.8 rsync
+RUN apt-get -q update && apt-get install -y git make wget cpio socat qemu-system-mips ctags cscope python3-pip clang-format-3.8 rsync curl
 RUN pip3 install -I pexpect pep8
 RUN wget http://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.1_amd64.deb
 RUN dpkg -i mipsel-mimiker-elf_1.1_amd64.deb

--- a/.circleci/image/Dockerfile
+++ b/.circleci/image/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+ENV PATH="/opt/mipsel-mimiker-elf/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+RUN apt-get -q update && apt-get install -y git make wget cpio socat qemu-system-mips ctags cscope python3-pip clang-format-3.8 rsync
+RUN pip3 install -I pexpect pep8
+RUN wget http://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.1_amd64.deb
+RUN dpkg -i mipsel-mimiker-elf_1.1_amd64.deb
+RUN ln -s /usr/bin/clang-format-3.8 /usr/local/bin/clang-format


### PR DESCRIPTION
Now that we're using CircleCI, I went a step further and prepared some advanced features.

- Our config no longer uses the stock `ubuntu:16.04` image, but a custom one, build with `.circleci/image/Dockerfile` - it comes with all tools we need pre-installed. That means the build environment no longer has to `apt-get` all the stuff we need, which speeds up the build process.
  - I've measured time between `git push` to receiving an email warning about incorrect source code formatting - **less than 20 seconds**, this is absolutely crazy!
  - You may want to copy the docker image from my repository on dockerhub (`rafalcieslak/mimiker-build-base`) to a repository created by you, although pulling it from from mine won't cause any inconvenience until you wish to publish an updated version.
- I've split the test stages into separate CircleCI jobs. That means:
  - we get 4 test results visible on GitHub, each indicating different kind of success/failure.
  - the jobs run independently in parallel, which means `./verify-*` doesn't wait form `make` to publish it's results to GitHub.

At the moment CircleCI allows defining multiple jobs, but will only start the one named `build`, and there is no elegant command to trigger other jobs. Instead, I use CircleCI web API to request a job to be started. Because of that there's an ugly `trigger_job` function in the config script¹. For security reasons, `CIRCLE_API_TOKEN` is not present in config file and is instead provided as an environmental variable via CircleCI project config. The main job only starts others: `verify-formatting`, `verify-pep8` and `compile`. Each of them may fail or succeed and has a corresponding checkmark on GitHub. The first two are straight-forward, the other runs `make`, saves result as artifacts for convenient download, and also stores the result into cache, so that the final job, `kernel_tests` (triggered when `compile` is done), may restore the cache and run tests using files compiled by previous job.

So that's a very simple yet lighting-fast and quite convenient setup. And, as a side effect, we have a docker image that contains entire setup required to run Mimiker.

¹) This is the [currently recommended](https://discuss.circleci.com/t/how-to-test-multiple-versions-by-triggering-jobs-with-a-shell-function/11305) way of triggering jobs, before they release proper support for it. By request they enable beta-access to a better solution, I've dropped them an e-mail. Should they agree, I hope to clean up the config.

EDIT: Hint - click on `Show all checks` below to see separate jobs/tests.