### PR TITLE
Circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,9 @@
-version: 2
-
 defaults: &defaults
   working_directory: ~/mimiker
   docker:
     - image: rafalcieslak/mimiker-build-base:1.1
 
+version: 2
 jobs:
   verify-formatting:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,15 +42,3 @@ jobs:
       - attach_workspace:
           at: ~/mimiker
       - run: './run_tests.py --thorough'
-
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - verify-formatting
-      - verify-pep8
-      - compile
-      - kernel-tests:
-        requires:
-          - compile
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,44 +1,24 @@
+defaults: &defaults
+  working_directory: ~/mimiker
+  docker:
+    - image: rafalcieslak/mimiker-build-base:1.1
+
 version: 2
 jobs:
-  build:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
-    steps:
-      - run:
-          name: 'Trigger basic jobs'
-          command: |
-            # One day this function will become a CircleCI built-in.
-            function trigger_job() {
-              curl --user ${CIRCLE_API_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=$1 \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-            }          
-            trigger_job verify-formatting
-            trigger_job verify-pep8
-            trigger_job compile
-
   verify-formatting:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - run: './verify-format.sh'
 
   verify-pep8:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - run: './verify-pep8.sh'
 
   compile:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - run: 'make'
@@ -53,24 +33,24 @@ jobs:
           paths:
             - mimiker.elf
             - initrd.cpio
-      - run:
-          name: 'Trigger kernel tests'
-          command: |
-            # One day this function will become a CircleCI built-in.
-            function trigger_job() {
-              curl --user ${CIRCLE_API_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=$1 \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-            }          
-            trigger_job kernel_tests
 
-  kernel_tests:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+  kernel-tests:
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
           key: mimiker-{{ .Branch }}-{{ .Revision }}
       - run: './run_tests.py --thorough'
+
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - verify-formatting
+      - verify-pep8
+      - compile
+      - kernel-tests:
+        requires:
+          - compile
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ defaults: &defaults
     - image: rafalcieslak/mimiker-build-base:1.1
 
 jobs:
-  verify-formatting:
+  verify_formatting:
     <<: *defaults
     steps:
       - checkout
       - run: './verify-format.sh'
 
-  verify-pep8:
+  verify_pep8:
     <<: *defaults
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
             - mimiker.elf
             - initrd.cpio
 
-  kernel-tests:
+  kernel_tests:
     <<: *defaults
     steps:
       - checkout
@@ -48,4 +48,6 @@ workflows:
   build_and_test:
     jobs:
       - compile
+      - verify_formatting
+      - verify_pep8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: './verify-pep8.sh'
 
-  build:
+  compile:
     <<: *defaults
     steps:
       - checkout
@@ -42,3 +42,10 @@ jobs:
       - attach_workspace:
           at: ~/mimiker
       - run: './run_tests.py --thorough'
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - compile
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           path: initrd.cpio
           prefix: ramdisk
       - persist_to_workspace:
-          root: ~/mimiker
+          root: .
           paths:
             - mimiker.elf
             - initrd.cpio

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
       - store_artifacts:
           path: initrd.cpio
           prefix: ramdisk
-      - persist_to_workspace:
-          root: .
+      - save_cache:
+          key: mimiker-{{ .Branch }}-{{ .Revision }}
           paths:
             - mimiker.elf
             - initrd.cpio
@@ -39,8 +39,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/mimiker
+      - restore_cache:
+          key: mimiker-{{ .Branch }}-{{ .Revision }}
       - run: './run_tests.py --thorough'
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - compile
       - verify_formatting
       - verify_pep8
-
+      - compile
+      - kernel_tests:
+          requires:
+            - compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,10 @@
+version: 2
+
 defaults: &defaults
   working_directory: ~/mimiker
   docker:
     - image: rafalcieslak/mimiker-build-base:1.1
 
-version: 2
 jobs:
   verify-formatting:
     <<: *defaults
@@ -17,7 +18,7 @@ jobs:
       - checkout
       - run: './verify-pep8.sh'
 
-  compile:
+  build:
     <<: *defaults
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,44 @@
-defaults: &defaults
-  working_directory: ~/mimiker
-  docker:
-    - image: rafalcieslak/mimiker-build-base:1.1
-
 version: 2
 jobs:
+  build:
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
+    steps:
+      - run:
+          name: 'Trigger basic jobs'
+          command: |
+            # One day this function will become a CircleCI built-in.
+            function trigger_job() {
+              curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=$1 \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            }          
+            trigger_job verify-formatting
+            trigger_job verify-pep8
+            trigger_job compile
+
   verify-formatting:
-    <<: *defaults
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
       - checkout
       - run: './verify-format.sh'
 
   verify-pep8:
-    <<: *defaults
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
       - checkout
       - run: './verify-pep8.sh'
 
   compile:
-    <<: *defaults
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
       - checkout
       - run: 'make'
@@ -33,24 +53,24 @@ jobs:
           paths:
             - mimiker.elf
             - initrd.cpio
+      - run:
+          name: 'Trigger kernel tests'
+          command: |
+            # One day this function will become a CircleCI built-in.
+            function trigger_job() {
+              curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=$1 \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            }          
+            trigger_job kernel_tests
 
-  kernel-tests:
-    <<: *defaults
+  kernel_tests:
+    working_directory: ~/mimiker
+    docker:
+      - image: rafalcieslak/mimiker-build-base:1.1
     steps:
       - checkout
       - restore_cache:
           key: mimiker-{{ .Branch }}-{{ .Revision }}
       - run: './run_tests.py --thorough'
-
-
-workflows:
-  version: 2
-  build-and-test:
-    jobs:
-      - verify-formatting
-      - verify-pep8
-      - compile
-      - kernel-tests:
-        requires:
-          - compile
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
       - store_artifacts:
           path: initrd.cpio
           prefix: ramdisk
-      - save_cache:
-          key: mimiker-{{ .Branch }}-{{ .Revision }}
+      - persist_to_workspace:
+          root: ~/mimiker
           paths:
             - mimiker.elf
             - initrd.cpio
@@ -38,14 +38,13 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: mimiker-{{ .Branch }}-{{ .Revision }}
+      - attach_workspace:
+          at: ~/mimiker
       - run: './run_tests.py --thorough'
-
 
 workflows:
   version: 2
-  build-and-test:
+  build_and_test:
     jobs:
       - verify-formatting
       - verify-pep8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,4 @@ workflows:
       - kernel-tests:
         requires:
           - compile
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,25 @@
 version: 2
+
+defaults: &defaults
+  working_directory: ~/mimiker
+  docker:
+    - image: rafalcieslak/mimiker-build-base:1.1
+
 jobs:
   verify-formatting:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - run: './verify-format.sh'
 
   verify-pep8:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - run: './verify-pep8.sh'
 
   compile:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - run: 'make'
@@ -36,9 +36,7 @@ jobs:
             - initrd.cpio
 
   kernel-tests:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,5 @@
 version: 2
 jobs:
-  build:
-    working_directory: ~/mimiker
-    docker:
-      - image: rafalcieslak/mimiker-build-base:1.1
-    steps:
-      - run:
-          name: 'Trigger basic jobs'
-          command: |
-            # One day this function will become a CircleCI built-in.
-            function trigger_job() {
-              curl --user ${CIRCLE_API_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=$1 \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-            }          
-            trigger_job verify-formatting
-            trigger_job verify-pep8
-            trigger_job compile
-
   verify-formatting:
     working_directory: ~/mimiker
     docker:
@@ -53,19 +34,8 @@ jobs:
           paths:
             - mimiker.elf
             - initrd.cpio
-      - run:
-          name: 'Trigger kernel tests'
-          command: |
-            # One day this function will become a CircleCI built-in.
-            function trigger_job() {
-              curl --user ${CIRCLE_API_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=$1 \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-            }          
-            trigger_job kernel_tests
 
-  kernel_tests:
+  kernel-tests:
     working_directory: ~/mimiker
     docker:
       - image: rafalcieslak/mimiker-build-base:1.1
@@ -74,3 +44,15 @@ jobs:
       - restore_cache:
           key: mimiker-{{ .Branch }}-{{ .Revision }}
       - run: './run_tests.py --thorough'
+
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - verify-formatting
+      - verify-pep8
+      - compile
+      - kernel-tests:
+        requires:
+          - compile


### PR DESCRIPTION
Today early morning we were accepted into private beta of CircleCI workflows feature. Today evening workflows left beta, and are now available to all CircleCI 2.0 users.

This branch is barely a cleanup for CircleCI config I promised to do, and it shouldn't change general behavior. Job triggers are removed and `workflow` block describes dependencies between jobs, also `defaults` are used to share parts of configuration between jobs.