### PR TITLE
Uiomove - fails if at the end of buffer

### DIFF
--- a/sys/uio.c
+++ b/sys/uio.c
@@ -79,7 +79,7 @@ int uiomove(void *buf, size_t n, uio_t *uio) {
 
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio) {
   size_t offset = uio->uio_offset;
-  assert(offset < buflen);
+  assert(offset <= buflen);
   assert(uio->uio_offset >= 0);
 
   return (uiomove((char *)buf + offset, buflen - offset, uio));


### PR DESCRIPTION
Without this fix user program in #358 which expects `read` to return 0 at the end of file fails due to assert.