### PR TITLE
Simplify acquiring strategy for process locks

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -17,7 +17,7 @@ GDB_PORT_BASE = 9100
 
 # Tries to decode binary output as ASCII, as hard as it can.
 def safe_decode(data):
-    return data.decode('unicode_escape', errors='replace')
+    return data.decode('unicode_escape', errors='replace').replace('\r', '')
 
 
 # Tries to start gdb in order to investigate kernel state on deadlock.

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -20,7 +20,7 @@ static pid_t last_pid = 0;
 
 proc_t *proc_create(void) {
   proc_t *proc = kmalloc(M_PROC, sizeof(proc_t), M_ZERO);
-  mtx_init(&proc->p_lock, MTX_DEF);
+  mtx_init(&proc->p_lock, MTX_RECURSE);
   TAILQ_INIT(&proc->p_threads);
   proc->p_nthreads = 0;
   proc->p_state = PRS_NORMAL;

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -55,7 +55,6 @@ proc_t *proc_find(pid_t pid) {
   return p;
 }
 
-/* Always call proc_reap with parent process locked. */
 int proc_reap(proc_t *child, int *status) {
   /* Child is now a zombie. Gather its data, cleanup & free. */
   mtx_lock(&child->p_lock);
@@ -66,13 +65,14 @@ int proc_reap(proc_t *child, int *status) {
      free it. I don't think it may ever happen that there would be multiple
      references to a terminated process, but if it does, we would need to
      introduce refcounting for processes. */
-  *status = child->p_exitstatus;
+  if (status)
+    *status = child->p_exitstatus;
 
   int retval = child->p_pid;
 
   if (child->p_parent) {
-    assert(mtx_owned(&child->p_parent->p_lock));
-    TAILQ_REMOVE(&child->p_parent->p_children, child, p_child);
+    WITH_MTX_LOCK (&child->p_parent->p_lock)
+      TAILQ_REMOVE(&child->p_parent->p_children, child, p_child);
   }
 
   WITH_MTX_LOCK (&zombie_proc_list_mtx)
@@ -91,8 +91,9 @@ void proc_exit(int exitstatus) {
   proc_t *p = td->td_proc;
   assert(p);
 
-  WITH_MTX_LOCK (&p->p_lock) {
+  bool reap_now = false;
 
+  WITH_MTX_LOCK (&p->p_lock) {
     assert(p->p_nthreads == 1);
     /* If the process had other threads, we'd need to wake the sleeping ones,
        request all of them except this one to call thread_exit from
@@ -124,6 +125,9 @@ void proc_exit(int exitstatus) {
 
     p->p_state = PRS_ZOMBIE;
 
+    WITH_MTX_LOCK (&zombie_proc_list_mtx)
+      TAILQ_INSERT_TAIL(&zombie_proc_list, p, p_zombie);
+
     /* Notify the parent, in various ways, about state change. */
     if (p->p_parent) {
       WITH_MTX_LOCK (&p->p_parent->p_lock) {
@@ -132,9 +136,7 @@ void proc_exit(int exitstatus) {
 
         /* If the parent explicitly ignores SIGCHLD, reap child immediately. */
         if (p->p_sigactions[SIGCHLD].sa_handler == SIG_IGN) {
-          int ignore_status;
-          proc_reap(p, &ignore_status);
-          /* Can't call [noreturn] thread_exit() from within a WITH scope. */
+          reap_now = true;
           goto exit;
         }
       }
@@ -143,11 +145,12 @@ void proc_exit(int exitstatus) {
     }
   }
 
-  /* Process is ready for disposal, move it to zombie list. */
-  WITH_MTX_LOCK (&zombie_proc_list_mtx)
-    TAILQ_INSERT_TAIL(&zombie_proc_list, p, p_zombie);
-
 exit:
+  /* If process ready for disposal, then reap it immediately. */
+  if (reap_now)
+    proc_reap(p, NULL);
+
+  /* Can't call [noreturn] thread_exit() from within a WITH scope. */
   /* This thread is the last one in the process to exit. */
   thread_exit();
 }
@@ -183,16 +186,16 @@ int do_waitpid(pid_t pid, int *status, int options) {
   proc_t *p = td->td_proc;
   assert(p != NULL);
 
-  proc_t *child = NULL;
+  proc_t *zombie = NULL;
 
   if (pid == -1) {
     for (;;) {
       /* Search for any zombie children. */
-      WITH_MTX_LOCK (&p->p_lock) {
-        child = child_find_by_state(p, PRS_ZOMBIE);
-        if (child)
-          return proc_reap(child, status);
-      }
+      WITH_MTX_LOCK (&p->p_lock)
+        zombie = child_find_by_state(p, PRS_ZOMBIE);
+
+      if (zombie)
+        return proc_reap(zombie, status);
 
       /* No zombie child was found. */
       if (options & WNOHANG)
@@ -202,6 +205,8 @@ int do_waitpid(pid_t pid, int *status, int options) {
       sleepq_wait(&p->p_children, "any child state change");
     }
   } else {
+    proc_t *child = NULL;
+
     /* Wait for a particular child. */
     WITH_MTX_LOCK (&p->p_lock)
       child = child_find_by_pid(p, pid);
@@ -213,7 +218,10 @@ int do_waitpid(pid_t pid, int *status, int options) {
     for (;;) {
       WITH_MTX_LOCK (&child->p_lock)
         if (child->p_state == PRS_ZOMBIE)
-          return proc_reap(child, status);
+          zombie = child;
+
+      if (zombie)
+        return proc_reap(zombie, status);
 
       if (options & WNOHANG)
         return 0;


### PR DESCRIPTION
* Fix proc_reap race condition on non-recursive p_lock
* do_waitpid on a child did not lock parent p_lock