### PR TITLE
Increased timeouts for GDB

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -44,8 +44,8 @@ def gdb_inspect(interactive):
                 '-ex=python sys.path.append(os.getcwd())',
                 '-ex=python import debug',
                 '--nh', '--nx', 'mimiker.elf']
-    gdb = pexpect.spawn(gdb_command, gdb_opts, timeout=1)
-    gdb.expect_exact('(gdb)', timeout=2)
+    gdb = pexpect.spawn(gdb_command, gdb_opts, timeout=3)
+    gdb.expect_exact('(gdb)', timeout=5)
     send_command(gdb, 'klog')
     send_command(gdb, 'info registers')
     send_command(gdb, 'backtrace')


### PR DESCRIPTION
Sometimes `gdb` takes longer to startup and print diagnostic messages. With following patch we give it more time. Hopefully it will resolve an issue where debugger is killed prematurely after a failed test run.