### PR TITLE
Tests for preserving FPU context across processes using FPU.

### DIFF
--- a/tests/utest.c
+++ b/tests/utest.c
@@ -97,3 +97,8 @@ UTEST_ADD_SIMPLE(access_basic);
 
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
+
+UTEST_ADD_SIMPLE(fpu_fcsr);
+UTEST_ADD_SIMPLE(fpu_gpr_preservation);
+UTEST_ADD_SIMPLE(fpu_cpy_ctx_on_fork);
+UTEST_ADD_SIMPLE(fpu_ctx_signals);

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -102,3 +102,5 @@ UTEST_ADD_SIMPLE(fpu_fcsr);
 UTEST_ADD_SIMPLE(fpu_gpr_preservation);
 UTEST_ADD_SIMPLE(fpu_cpy_ctx_on_fork);
 UTEST_ADD_SIMPLE(fpu_ctx_signals);
+
+UTEST_ADD_SIMPLE(call_cp0_from_userspace);

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -102,5 +102,3 @@ UTEST_ADD_SIMPLE(fpu_fcsr);
 UTEST_ADD_SIMPLE(fpu_gpr_preservation);
 UTEST_ADD_SIMPLE(fpu_cpy_ctx_on_fork);
 UTEST_ADD_SIMPLE(fpu_ctx_signals);
-
-UTEST_ADD_SIMPLE(call_cp0_from_userspace);

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -98,7 +98,9 @@ UTEST_ADD_SIMPLE(access_basic);
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
+#if 0
 UTEST_ADD_SIMPLE(fpu_fcsr);
 UTEST_ADD_SIMPLE(fpu_gpr_preservation);
 UTEST_ADD_SIMPLE(fpu_cpy_ctx_on_fork);
 UTEST_ADD_SIMPLE(fpu_ctx_signals);
+#endif

--- a/user/utest/Makefile
+++ b/user/utest/Makefile
@@ -7,6 +7,7 @@ SOURCES_C = \
 	exceptions.c \
 	fd.c \
 	fork.c \
+	fpu_ctx.c \
 	lseek.c \
 	main.c \
 	misbehave.c \
@@ -14,6 +15,6 @@ SOURCES_C = \
 	sbrk.c \
 	signal.c \
 	stat.c \
-	fpu_ctx.c
+	utest.c
 
 include $(TOPDIR)/build/build.prog.mk

--- a/user/utest/Makefile
+++ b/user/utest/Makefile
@@ -12,6 +12,7 @@ SOURCES_C = \
 	mmap.c \
 	sbrk.c \
 	signal.c \
-	stat.c
+	stat.c \
+	fpu_ctx.c
 
 include $(TOPDIR)/build/build.prog.mk

--- a/user/utest/fpu_ctx.c
+++ b/user/utest/fpu_ctx.c
@@ -4,6 +4,7 @@
  * - test_fpu_fcsr                  - needs context switch. sleep(0)?
  * - test_fpu_gpr_preservation      - needs context switch. sleep(0)?
  * - test_fpu_cpy_ctx_on_fork       - needs another process using FPU
+ *                                    with a little bit of synchronization
  * - test_fpu_ctx_signals
  *
  * Checking 32 FPU FPR's and FPU FCSR register.

--- a/user/utest/fpu_ctx.c
+++ b/user/utest/fpu_ctx.c
@@ -1,0 +1,200 @@
+/*----------------------------------------------------------------------------
+ *
+ * Floating Point Unit context preservation tests:
+ * - test_fpu_fcsr
+ * - test_fpu_gpr_preservation
+ * - test_fpu_cpy_ctx_on_fork
+ * - test_fpu_ctx_signals
+ *
+ * Checking 32 FPU FPR's and FPU FCSR register.
+ * FCCR, FEXR, FENR need not to be saved, because they are only better
+ * structured views of FCSR.
+ *
+ *----------------------------------------------------------------------------
+ */
+
+#include "utest.h"
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/wait.h>
+#include <sys/signal.h>
+
+#define TEST_TIME 10
+#define PROCESSES 2
+
+#define MTC1(var, freg) asm volatile("mtc1 %0, " #freg : : "r"(var))
+#define MFC1(var, freg) asm volatile("mfc1 %0, " #freg : "=r"(var))
+
+#define MFC1_ASSERT_CMP(var, freg, cmp)                                        \
+  do {                                                                         \
+    MFC1(var, freg);                                                           \
+    assert(var == cmp);                                                        \
+    assert(1 == 0);                                                            \
+  } while (0)
+
+static inline void check_fpu_all_gpr(int expected_value) {
+  int current_value;
+
+  MFC1_ASSERT_CMP(current_value, $f0, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f1, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f2, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f3, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f4, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f5, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f6, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f7, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f8, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f9, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f10, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f11, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f12, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f13, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f14, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f15, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f16, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f17, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f18, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f19, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f20, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f21, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f22, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f23, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f24, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f25, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f26, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f27, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f28, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f29, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f30, expected_value);
+  MFC1_ASSERT_CMP(current_value, $f31, expected_value);
+}
+
+static inline void MTC1_all_gpr(int value) {
+  MTC1(value, $f0);
+  MTC1(value, $f1);
+  MTC1(value, $f2);
+  MTC1(value, $f3);
+  MTC1(value, $f4);
+  MTC1(value, $f5);
+  MTC1(value, $f6);
+  MTC1(value, $f7);
+  MTC1(value, $f8);
+  MTC1(value, $f9);
+  MTC1(value, $f10);
+  MTC1(value, $f11);
+  MTC1(value, $f12);
+  MTC1(value, $f13);
+  MTC1(value, $f14);
+  MTC1(value, $f15);
+  MTC1(value, $f16);
+  MTC1(value, $f17);
+  MTC1(value, $f18);
+  MTC1(value, $f19);
+  MTC1(value, $f20);
+  MTC1(value, $f21);
+  MTC1(value, $f22);
+  MTC1(value, $f23);
+  MTC1(value, $f24);
+  MTC1(value, $f25);
+  MTC1(value, $f26);
+  MTC1(value, $f27);
+  MTC1(value, $f28);
+  MTC1(value, $f29);
+  MTC1(value, $f30);
+  MTC1(value, $f31);
+}
+
+static void spawn_process(int pproc, void (*proc_handler)(int)) {
+  switch (fork()) {
+    case -1:
+      exit(EXIT_FAILURE);
+    case 0:
+      proc_handler(pproc);
+      exit(EXIT_SUCCESS);
+    default:
+      return;
+  }
+}
+
+static void check_fpu_ctx(int value) {
+  MTC1_all_gpr(value);
+  for (int i = 0; i < TEST_TIME; i++) {
+    check_fpu_all_gpr(value);
+  }
+}
+
+int test_fpu_gpr_preservation() {
+  int seed = 0xbeefface;
+  for (int i = 0; i < PROCESSES; i++) {
+    spawn_process(seed + i, check_fpu_ctx);
+  }
+
+  int status;
+  for (int i = 0; i < PROCESSES; i++) {
+    wait(&status);
+    assert(WIFEXITED(status));
+    assert(EXIT_SUCCESS == WEXITSTATUS(status));
+  }
+
+  return 0;
+}
+
+int test_fpu_cpy_ctx_on_fork() {
+  int value = 0xbeefface;
+  MTC1_all_gpr(value);
+  spawn_process(value, check_fpu_all_gpr);
+  int status;
+  wait(&status);
+  assert(WIFEXITED(status));
+  assert(EXIT_SUCCESS == WEXITSTATUS(status));
+
+  return 0;
+}
+
+static void signal_handler_usr2(int signo) {
+  MTC1_all_gpr(42);
+}
+
+static void signal_handler_usr1(int signo) {
+  MTC1_all_gpr(1337);
+
+  signal(SIGUSR2, signal_handler_usr2);
+  raise(SIGUSR2);
+
+  check_fpu_all_gpr(1337);
+}
+
+int test_fpu_ctx_signals() {
+  MTC1_all_gpr(0xc0de);
+
+  signal(SIGUSR1, signal_handler_usr1);
+  raise(SIGUSR1);
+
+  check_fpu_all_gpr(0xc0de);
+
+  return 0;
+}
+
+static void check_fcsr(int expected_value) {
+  MTC1(expected_value, $25);
+  for (int i = 0; i < TEST_TIME; i++) {
+    int current_value;
+    MFC1_ASSERT_CMP(current_value, $25, expected_value);
+  }
+}
+
+int test_fpu_fcsr() {
+  for (int i = 0; i < PROCESSES; i++) {
+    spawn_process(i, check_fcsr);
+  }
+
+  int status;
+  for (int i = 0; i < PROCESSES; i++) {
+    wait(&status);
+    assert(WIFEXITED(status));
+    assert(EXIT_SUCCESS == WEXITSTATUS(status));
+  }
+
+  return 0;
+}

--- a/user/utest/fpu_ctx.c
+++ b/user/utest/fpu_ctx.c
@@ -1,5 +1,4 @@
-/*----------------------------------------------------------------------------
- *
+/*
  * Floating Point Unit context preservation tests:
  * - test_fpu_fcsr                  - needs context switch. sleep(0)?
  * - test_fpu_gpr_preservation      - needs context switch. sleep(0)?
@@ -10,8 +9,6 @@
  * Checking 32 FPU FPR's and FPU FCSR register.
  * FCCR, FEXR, FENR need not to be saved, because they are only better
  * structured views of FCSR.
- *
- *----------------------------------------------------------------------------
  */
 
 #include "utest.h"
@@ -30,47 +27,46 @@
 #define MTC1(var, freg) asm volatile("mtc1 %0, " #freg : : "r"(var))
 #define MFC1(var, freg) asm volatile("mfc1 %0, " #freg : "=r"(var))
 
-#define MFC1_ASSERT_CMP(var, freg, cmp)                                        \
+#define MFC1_ASSERT_CMP(freg)                                                  \
   do {                                                                         \
-    MFC1(var, freg);                                                           \
-    assert(var == cmp);                                                        \
+    int value;                                                                 \
+    MFC1(value, freg);                                                         \
+    assert(value == expected);                                                 \
   } while (0)
 
-static inline void check_fpu_all_gpr(int expected_value) {
-  int current_value;
-
-  MFC1_ASSERT_CMP(current_value, $f0, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f1, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f2, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f3, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f4, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f5, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f6, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f7, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f8, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f9, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f10, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f11, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f12, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f13, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f14, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f15, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f16, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f17, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f18, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f19, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f20, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f21, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f22, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f23, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f24, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f25, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f26, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f27, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f28, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f29, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f30, expected_value);
-  MFC1_ASSERT_CMP(current_value, $f31, expected_value);
+static inline void check_fpu_all_gpr(int expected) {
+  MFC1_ASSERT_CMP($f0);
+  MFC1_ASSERT_CMP($f1);
+  MFC1_ASSERT_CMP($f2);
+  MFC1_ASSERT_CMP($f3);
+  MFC1_ASSERT_CMP($f4);
+  MFC1_ASSERT_CMP($f5);
+  MFC1_ASSERT_CMP($f6);
+  MFC1_ASSERT_CMP($f7);
+  MFC1_ASSERT_CMP($f8);
+  MFC1_ASSERT_CMP($f9);
+  MFC1_ASSERT_CMP($f10);
+  MFC1_ASSERT_CMP($f11);
+  MFC1_ASSERT_CMP($f12);
+  MFC1_ASSERT_CMP($f13);
+  MFC1_ASSERT_CMP($f14);
+  MFC1_ASSERT_CMP($f15);
+  MFC1_ASSERT_CMP($f16);
+  MFC1_ASSERT_CMP($f17);
+  MFC1_ASSERT_CMP($f18);
+  MFC1_ASSERT_CMP($f19);
+  MFC1_ASSERT_CMP($f20);
+  MFC1_ASSERT_CMP($f21);
+  MFC1_ASSERT_CMP($f22);
+  MFC1_ASSERT_CMP($f23);
+  MFC1_ASSERT_CMP($f24);
+  MFC1_ASSERT_CMP($f25);
+  MFC1_ASSERT_CMP($f26);
+  MFC1_ASSERT_CMP($f27);
+  MFC1_ASSERT_CMP($f28);
+  MFC1_ASSERT_CMP($f29);
+  MFC1_ASSERT_CMP($f30);
+  MFC1_ASSERT_CMP($f31);
 }
 
 static inline void MTC1_all_gpr(int value) {
@@ -123,16 +119,16 @@ static int spawn_process(int pproc, void (*proc_handler)(int)) {
 
 static void check_fpu_ctx(int value) {
   MTC1_all_gpr(value);
-  for (int i = 0; i < P_TEST_TIME; i++) {
+
+  for (int i = 0; i < P_TEST_TIME; i++)
     check_fpu_all_gpr(value);
-  }
 }
 
 int test_fpu_gpr_preservation() {
   int seed = 0xbeefface;
-  for (int i = 0; i < P_PROCESSES; i++) {
+
+  for (int i = 0; i < P_PROCESSES; i++)
     spawn_process(seed + i, check_fpu_ctx);
-  }
 
   int status;
   for (int i = 0; i < PROCESSES; i++) {
@@ -146,6 +142,7 @@ int test_fpu_gpr_preservation() {
 
 int test_fpu_cpy_ctx_on_fork() {
   int value = 0xbeefface;
+
   MTC1_all_gpr(value);
   spawn_process(0xc0de, MTC1_all_gpr);
   spawn_process(value, check_fpu_all_gpr);
@@ -160,18 +157,15 @@ int test_fpu_cpy_ctx_on_fork() {
   return 0;
 }
 
-static void check_fcsr(int expected_value) {
-  MTC1(expected_value, $25);
-  for (int i = 0; i < TEST_TIME; i++) {
-    int current_value;
-    MFC1_ASSERT_CMP(current_value, $25, expected_value);
-  }
+static void check_fcsr(int expected) {
+  MTC1(expected, $25);
+  for (int i = 0; i < TEST_TIME; i++)
+    MFC1_ASSERT_CMP($25);
 }
 
 int test_fpu_fcsr() {
-  for (int i = 0; i < PROCESSES; i++) {
+  for (int i = 0; i < PROCESSES; i++)
     spawn_process(i, check_fcsr);
-  }
 
   int status;
   for (int i = 0; i < PROCESSES; i++) {
@@ -179,6 +173,7 @@ int test_fpu_fcsr() {
     assert(WIFEXITED(status));
     assert(EXIT_SUCCESS == WEXITSTATUS(status));
   }
+
   return 0;
 }
 

--- a/user/utest/fpu_ctx.c
+++ b/user/utest/fpu_ctx.c
@@ -30,7 +30,6 @@
   do {                                                                         \
     MFC1(var, freg);                                                           \
     assert(var == cmp);                                                        \
-    assert(1 == 0);                                                            \
   } while (0)
 
 static inline void check_fpu_all_gpr(int expected_value) {

--- a/user/utest/main.c
+++ b/user/utest/main.c
@@ -47,6 +47,8 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(fpu_cpy_ctx_on_fork);
   CHECKRUN_TEST(fpu_ctx_signals);
 
+  CHECKRUN_TEST(call_cp0_from_userspace);
+
   printf("No user test \"%s\" available.\n", test_name);
   return 1;
 }

--- a/user/utest/main.c
+++ b/user/utest/main.c
@@ -47,8 +47,6 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(fpu_cpy_ctx_on_fork);
   CHECKRUN_TEST(fpu_ctx_signals);
 
-  CHECKRUN_TEST(call_cp0_from_userspace);
-
   printf("No user test \"%s\" available.\n", test_name);
   return 1;
 }

--- a/user/utest/main.c
+++ b/user/utest/main.c
@@ -42,6 +42,11 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(stat);
   CHECKRUN_TEST(fstat);
 
+  CHECKRUN_TEST(fpu_fcsr);
+  CHECKRUN_TEST(fpu_gpr_preservation);
+  CHECKRUN_TEST(fpu_cpy_ctx_on_fork);
+  CHECKRUN_TEST(fpu_ctx_signals);
+
   printf("No user test \"%s\" available.\n", test_name);
   return 1;
 }

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -4,12 +4,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <unistd.h>
-#include <assert.h>
-#include <sys/wait.h>
-#include <sys/signal.h>
-#include <stdlib.h>
-
-#define MFC0(var, reg, sel) asm volatile("mfc0 %0," #reg "," #sel : "=r"(var))
 
 int test_misbehave() {
   const char str[] = "Hello world from a user program!\n";
@@ -28,30 +22,5 @@ int test_misbehave() {
   assert(write(STDOUT_FILENO, (char *)0x1EE7C0DE, 100) == -1);
   assert(errno == EFAULT);
 
-  return 0;
-}
-
-static int spawn_sprocess_calling_cp0(void) {
-  int pid;
-  // int value;
-  switch((pid = fork())) {
-    case -1:
-      exit(EXIT_FAILURE);
-    case 0:
-      // MFC0(value, $12, 0);
-      // asm volatile("mfc0 %0,$12,0" : "=r"(value));
-      // raise(SIGILL);
-      exit(EXIT_FAILURE);
-    default : 
-      return pid;
-  }
-}
-
-int test_call_cp0_from_userspace() {
-  spawn_sprocess_calling_cp0();
-  int status;
-  wait(&status);
-  assert(WIFSIGNALED(status));
-  assert(SIGILL == WTERMSIG(status));
   return 0;
 }

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -36,12 +36,12 @@ static int spawn_sprocess_calling_cp0(void) {
   // int value;
   switch((pid = fork())) {
     case -1:
-      exit(1);
+      exit(EXIT_FAILURE);
     case 0:
       // MFC0(value, $12, 0);
       // asm volatile("mfc0 %0,$12,0" : "=r"(value));
-      raise(SIGILL);
-      exit(1);
+      // raise(SIGILL);
+      exit(EXIT_FAILURE);
     default : 
       return pid;
   }

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -4,6 +4,12 @@
 #include <assert.h>
 #include <errno.h>
 #include <unistd.h>
+#include <assert.h>
+#include <sys/wait.h>
+#include <sys/signal.h>
+#include <stdlib.h>
+
+#define MFC0(var, reg, sel) asm volatile("mfc0 %0," #reg "," #sel : "=r"(var))
 
 int test_misbehave() {
   const char str[] = "Hello world from a user program!\n";
@@ -22,5 +28,30 @@ int test_misbehave() {
   assert(write(STDOUT_FILENO, (char *)0x1EE7C0DE, 100) == -1);
   assert(errno == EFAULT);
 
+  return 0;
+}
+
+static int spawn_sprocess_calling_cp0(void) {
+  int pid;
+  // int value;
+  switch((pid = fork())) {
+    case -1:
+      exit(1);
+    case 0:
+      // MFC0(value, $12, 0);
+      // asm volatile("mfc0 %0,$12,0" : "=r"(value));
+      raise(SIGILL);
+      exit(1);
+    default : 
+      return pid;
+  }
+}
+
+int test_call_cp0_from_userspace() {
+  spawn_sprocess_calling_cp0();
+  int status;
+  wait(&status);
+  assert(WIFSIGNALED(status));
+  assert(SIGILL == WTERMSIG(status));
   return 0;
 }

--- a/user/utest/utest.c
+++ b/user/utest/utest.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "utest.h"
+
+int utest_spawn(proc_func_t func, void *arg) {
+  int pid;
+  switch ((pid = fork())) {
+    case -1:
+      exit(EXIT_FAILURE);
+    case 0:
+      exit(func(arg));
+    default:
+      return pid;
+  }
+}
+
+void utest_child_exited(int exitcode) {
+  int status;
+  wait(&status);
+  assert(WIFEXITED(status));
+  assert(WEXITSTATUS(status) == exitcode);
+}

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -1,6 +1,12 @@
 #ifndef __UTEST_H__
 #define __UTEST_H__
 
+typedef int (*proc_func_t)(void *);
+
+int utest_spawn(proc_func_t func, void *arg);
+void utest_child_exited(int exitcode);
+
+/* List of available tests. */
 int test_mmap(void);
 int test_sbrk(void);
 int test_misbehave(void);

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -37,4 +37,6 @@ int test_fpu_gpr_preservation(void);
 int test_fpu_cpy_ctx_on_fork(void);
 int test_fpu_ctx_signals(void);
 
+int test_call_cp0_from_userspace(void);
+
 #endif /* __UTEST_H__ */

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -37,7 +37,6 @@ int test_fpu_gpr_preservation(void);
 int test_fpu_cpy_ctx_on_fork(void);
 int test_fpu_ctx_signals(void);
 
-int test_call_cp0_from_userspace(void);
 int test_exc_cop_unusable(void);
 int test_exc_reserved_instruction(void);
 int test_exc_integer_overflow(void);

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -32,4 +32,9 @@ int test_access_basic(void);
 int test_stat(void);
 int test_fstat(void);
 
+int test_fpu_fcsr(void);
+int test_fpu_gpr_preservation(void);
+int test_fpu_cpy_ctx_on_fork(void);
+int test_fpu_ctx_signals(void);
+
 #endif /* __UTEST_H__ */


### PR DESCRIPTION
Tests for #409 :
* test_fpu_fcsr - checks FPU FCSR register preservation. 
* test_fpu_gpr_preservation - checks 32 FPU FPR's.
* test_fpu_cpy_ctx_on_fork - checks whether child inherited parent's FPU context.
* test_fpu_ctx_signals - checks appropiate FPU context preservation across nested signal handlers which use FPU.

First 2 tests need at least one context switch to happen. nanosleep() from #366  would shorten them significantly. 
Third test depends on a scheduler.