### PR TITLE
Add missing `#include <mips/mips.h>` in `mips/malta.c`

### DIFF
--- a/mips/malta.c
+++ b/mips/malta.c
@@ -1,6 +1,7 @@
 #define KLOG KL_INIT
 #include <interrupt.h>
 #include <malloc.h>
+#include <mips/mips.h>
 #include <mips/cpuinfo.h>
 #include <mips/malta.h>
 #include <mips/intr.h>


### PR DESCRIPTION
The `MIPS_KSEG0_TO_PHYS` macro defined in `include/mips/mips.h`
is used in `mips/malta.c`, but the necessary header is not included.