### PR TITLE
Swap include order so that `SYSROOT` is defined.

### DIFF
--- a/build/build.prog.mk
+++ b/build/build.prog.mk
@@ -12,8 +12,8 @@ SOURCES_O = $(SOURCES_C:%.c=%.o)
 
 all: $(UELF_NAME).uelf
 
-include $(TOPDIR)/build/flags.user.mk
 include $(TOPDIR)/build/build.mk
+include $(TOPDIR)/build/flags.user.mk
 
 clean:
 	rm -rf $(UELF_NAME).uelf $(SOURCES_C:%.c=.%.D) $(SOURCES_O)


### PR DESCRIPTION
`build/flags.user.mk` adds `--sysroot=$(SYSROOT)` to `CFLAGS`, but
SYSROOT is defined in `build/common.mk`, which is included by
`build/build.mk`. Therefore, `build/build.mk` needs to be included
before `build/flags.user.mk` in order for the flag to be properly
defined.