### PR TITLE
Use i8254 PIT for system clock

### DIFF
--- a/include/dev/i8253reg.h
+++ b/include/dev/i8253reg.h
@@ -1,0 +1,95 @@
+/*	$NetBSD: i8253reg.h,v 1.9 2005/12/11 12:21:26 christos Exp $	*/
+
+/*-
+ * Copyright (c) 1993 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Register definitions for the Intel 8253 Programmable Interval Timer.
+ *
+ * This chip has three independent 16-bit down counters that can be
+ * read on the fly.  There are three mode registers and three countdown
+ * registers.  The countdown registers are addressed directly, via the
+ * first three I/O ports.  The three mode registers are accessed via
+ * the fourth I/O port, with two bits in the mode byte indicating the
+ * register.  (Why are hardware interfaces always so braindead?).
+ *
+ * To write a value into the countdown register, the mode register
+ * is first programmed with a command indicating the which byte of
+ * the two byte register is to be modified.  The three possibilities
+ * are load msb (TMR_MR_MSB), load lsb (TMR_MR_LSB), or load lsb then
+ * msb (TMR_MR_BOTH).
+ *
+ * To read the current value ("on the fly") from the countdown register,
+ * you write a "latch" command into the mode register, then read the stable
+ * value from the corresponding I/O port.  For example, you write
+ * TMR_MR_LATCH into the corresponding mode register.  Presumably,
+ * after doing this, a write operation to the I/O port would result
+ * in undefined behavior (but hopefully not fry the chip).
+ * Reading in this manner has no side effects.
+ *
+ * The outputs of the three timers are connected as follows:
+ *
+ *	 timer 0 -> irq 0
+ *	 timer 1 -> DMA chan 0 (for dram refresh)
+ * 	 timer 2 -> speaker (via keyboard controller)
+ *
+ * Timer 0 is used to call hardclock.
+ * Timer 2 is used to generate console beeps.
+ */
+
+/*
+ * Frequency of all three count-down timers; (TIMER_FREQ/freq) is the
+ * appropriate count to generate a frequency of freq Hz.
+ */
+#ifndef TIMER_FREQ
+#define TIMER_FREQ 1193182
+#endif
+#define TIMER_DIV(x) ((TIMER_FREQ + (x) / 2) / (x))
+
+/*
+ * Macros for specifying values to be written into a mode register.
+ */
+#define TIMER_CNTR0 0       /* timer 0 counter port */
+#define TIMER_CNTR1 1       /* timer 1 counter port */
+#define TIMER_CNTR2 2       /* timer 2 counter port */
+#define TIMER_MODE 3        /* timer mode port */
+#define TIMER_SEL0 0x00     /* select counter 0 */
+#define TIMER_SEL1 0x40     /* select counter 1 */
+#define TIMER_SEL2 0x80     /* select counter 2 */
+#define TIMER_INTTC 0x00    /* mode 0, intr on terminal cnt */
+#define TIMER_ONESHOT 0x02  /* mode 1, one shot */
+#define TIMER_RATEGEN 0x04  /* mode 2, rate generator */
+#define TIMER_SQWAVE 0x06   /* mode 3, square wave */
+#define TIMER_SWSTROBE 0x08 /* mode 4, s/w triggered strobe */
+#define TIMER_HWSTROBE 0x0a /* mode 5, h/w triggered strobe */
+#define TIMER_LATCH 0x00    /* latch counter for reading */
+#define TIMER_LSB 0x10      /* r/w counter LSB */
+#define TIMER_MSB 0x20      /* r/w counter MSB */
+#define TIMER_16BIT 0x30    /* r/w counter 16 bits, LSB first */
+#define TIMER_BCD 0x01      /* count in BCD */

--- a/include/klog.h
+++ b/include/klog.h
@@ -17,6 +17,7 @@ typedef enum {
   KL_POOL,    /* pooled allocator */
   KL_LOCK,    /* lock operations tracing */
   KL_SCHED,   /* scheduler tracing */
+  KL_TIME,    /* system clock & timers */
   KL_THREAD,  /* kernel threads management */
   KL_INTR,    /* interrupts management and handling */
   KL_DEV,     /* device management */

--- a/include/mips/timer.h
+++ b/include/mips/timer.h
@@ -1,0 +1,6 @@
+#ifndef _MIPS_TIMER_H_
+#define _MIPS_TIMER_H_
+
+void mips_timer_init(void);
+
+#endif /* !_MIPS_TIMER_H_ */

--- a/include/time.h
+++ b/include/time.h
@@ -29,10 +29,20 @@ typedef struct timespec {
   long tv_nsec;  /* and nanoseconds */
 } timespec_t;
 
+typedef struct bintime {
+  time_t sec;    /* second */
+  uint64_t frac; /* a fraction of second */
+} bintime_t;
+
 #define TIMEVAL(fp)                                                            \
   (timeval_t) {                                                                \
     .tv_sec = (long)((fp)*1000000L) / 1000000L,                                \
     .tv_usec = (long)((fp)*1000000L) % 1000000L                                \
+  }
+
+#define HZ2BT(hz)                                                              \
+  (bintime_t) {                                                                \
+    .sec = 0, .frac = ((1ULL << 63) / (hz)) << 1                               \
   }
 
 static inline timeval_t st2tv(systime_t st) {
@@ -77,5 +87,16 @@ static inline timeval_t timeval_sub(timeval_t *tvp, timeval_t *uvp) {
 }
 
 timeval_t get_uptime(void);
+
+/* Operations on bintime. */
+#define bintime_cmp(a, b, cmp)                                                 \
+  (((a).sec == (b).sec) ? (((a).frac)cmp((b).frac)) : (((a).sec)cmp((b).sec)))
+
+static inline bintime_t bintime_mul(const bintime_t bt, uint32_t x) {
+  uint64_t p1 = (bt.frac & 0xffffffffULL) * x;
+  uint64_t p2 = (bt.frac >> 32) * x + (p1 >> 32);
+  return (bintime_t){.sec = bt.sec * x + (p2 >> 32),
+                     .frac = (p2 << 32) | (p1 & 0xffffffffULL)};
+}
 
 #endif /* !_SYS_TIME_H_ */

--- a/include/timer.h
+++ b/include/timer.h
@@ -10,39 +10,53 @@ typedef TAILQ_HEAD(, timer) timer_list_t;
 typedef bintime_t (*tm_gettime_t)(timer_t *tm);
 typedef int (*tm_start_t)(timer_t *tm, unsigned flags, const bintime_t value);
 typedef int (*tm_stop_t)(timer_t *tm);
+
+/*! \brief Callback function type.
+ *
+ * \warning It will be called in interrupt context! */
 typedef void (*tm_event_cb_t)(timer_t *tm, void *arg);
 
-#define TMF_ONESHOT 0x0001
-#define TMF_PERIODIC 0x0002
-#define TMF_TYPEMASK 0x0003
-#define TMF_ACTIVE 0x1000
-#define TMF_INITIALIZED 0x2000
-#define TMF_ALLOCATED 0x4000
-#define TMF_REGISTERED 0x8000
+#define TMF_ONESHOT 0x0001  /*!< triggers callback once */
+#define TMF_PERIODIC 0x0002 /*!< triggers callback on regular basis */
+#define TMF_TYPEMASK 0x0003 /*!< don't use other bits! */
 
 typedef struct timer {
-  TAILQ_ENTRY(timer) tm_link;
-  const char *tm_name;
-  unsigned tm_flags;
-  bintime_t tm_min_period;
-  bintime_t tm_max_period;
-  tm_gettime_t tm_gettime;
-  tm_start_t tm_start;
-  tm_stop_t tm_stop;
-  tm_event_cb_t tm_event_cb;
-  void *tm_arg;
-  void *tm_priv; /*!< private data (usually pointer to device_t) */
+  TAILQ_ENTRY(timer) tm_link; /*!< entry on list of all timers */
+  const char *tm_name;        /*!< name of the timer */
+  unsigned tm_flags;          /*!< TMF_* flags */
+  bintime_t tm_min_period;    /*!< valid only for TMF_PERIODIC */
+  bintime_t tm_max_period;    /*!< same as above */
+  tm_gettime_t tm_gettime;    /*!< returns current time value */
+  tm_start_t tm_start;        /*!< makes timer operational */
+  tm_stop_t tm_stop;          /*!< ceases timer from generating new events */
+  tm_event_cb_t tm_event_cb;  /*!< callback called when timer triggers */
+  void *tm_arg;               /*!< an argument for callback */
+  void *tm_priv;              /*!< private data (usually device_t *) */
 } timer_t;
 
+/*! \brief Used by a driver to make timer device available to the system. */
 int tm_register(timer_t *tm);
+/*! \brief Called when unloading a timer driver. */
 int tm_deregister(timer_t *tm);
+
+/*! \brief Allocate a timer for exclusive use according to criteria.
+ *
+ * \arg name specifies name of the timer (can be NULL)
+ * \arg flags specifies timer capabilities
+ */
 timer_t *tm_alloc(const char *name, unsigned flags);
-int tm_init(timer_t *tm, tm_event_cb_t event, void *arg);
+/*! \brief Releases a timer if it's not needed anymore. */
 int tm_free(timer_t *tm);
 
+/*! \brief Prepares timer to call event trigger callback. */
+int tm_init(timer_t *tm, tm_event_cb_t event, void *arg);
+/*! \brief Reads current timer value. */
 bintime_t tm_gettime(timer_t *tm);
+/*! \brief Configures timer to trigger callback(s). */
 int tm_start(timer_t *tm, unsigned flags, const bintime_t value);
+/*! \brief Stops timer from triggering a callback. */
 int tm_stop(timer_t *tm);
+/*! \brief Used by interrupt filter routine to trigger a callback. */
 void tm_trigger(timer_t *tm);
 
 #endif /* !_SYS_TIMER_H_ */

--- a/include/timer.h
+++ b/include/timer.h
@@ -15,6 +15,7 @@ typedef int (*tm_stop_t)(timer_t *tm);
  * \warning It will be called in interrupt context! */
 typedef void (*tm_event_cb_t)(timer_t *tm, void *arg);
 
+/* There are some flags used by implementation that are not listed here! */
 #define TMF_ONESHOT 0x0001  /*!< triggers callback once */
 #define TMF_PERIODIC 0x0002 /*!< triggers callback on regular basis */
 #define TMF_TYPEMASK 0x0003 /*!< don't use other bits! */
@@ -38,14 +39,14 @@ int tm_register(timer_t *tm);
 /*! \brief Called when unloading a timer driver. */
 int tm_deregister(timer_t *tm);
 
-/*! \brief Allocate a timer for exclusive use according to criteria.
+/*! \brief Find a timer according to criteria and reserve for exclusive use.
  *
  * \arg name specifies name of the timer (can be NULL)
  * \arg flags specifies timer capabilities
  */
-timer_t *tm_alloc(const char *name, unsigned flags);
+timer_t *tm_reserve(const char *name, unsigned flags);
 /*! \brief Releases a timer if it's not needed anymore. */
-int tm_free(timer_t *tm);
+int tm_release(timer_t *tm);
 
 /*! \brief Prepares timer to call event trigger callback. */
 int tm_init(timer_t *tm, tm_event_cb_t event, void *arg);

--- a/include/timer.h
+++ b/include/timer.h
@@ -4,21 +4,45 @@
 #include <queue.h>
 #include <time.h>
 
-typedef struct timer_event timer_event_t;
-typedef TAILQ_HEAD(, timer_event) timer_event_list_t;
+typedef struct timer timer_t;
+typedef TAILQ_HEAD(, timer) timer_list_t;
 
-struct timer_event {
-  /* entry on list of all time events */
-  TAILQ_ENTRY(timer_event) tev_link;
-  /* absolute time when this event should be handled */
-  timeval_t tev_when;
-  /* callback function called in interrupt context */
-  void (*tev_func)(timer_event_t *self);
-  /* auxiliary data */
-  void *tev_data;
-};
+typedef bintime_t (*tm_gettime_t)(timer_t *tm);
+typedef int (*tm_start_t)(timer_t *tm, unsigned flags, const bintime_t value);
+typedef int (*tm_stop_t)(timer_t *tm);
+typedef void (*tm_event_cb_t)(timer_t *tm, void *arg);
 
-void cpu_timer_add_event(timer_event_t *tev);
-void cpu_timer_remove_event(timer_event_t *tev);
+#define TMF_ONESHOT 0x0001
+#define TMF_PERIODIC 0x0002
+#define TMF_TYPEMASK 0x0003
+#define TMF_ACTIVE 0x1000
+#define TMF_INITIALIZED 0x2000
+#define TMF_ALLOCATED 0x4000
+#define TMF_REGISTERED 0x8000
+
+typedef struct timer {
+  TAILQ_ENTRY(timer) tm_link;
+  const char *tm_name;
+  unsigned tm_flags;
+  bintime_t tm_min_period;
+  bintime_t tm_max_period;
+  tm_gettime_t tm_gettime;
+  tm_start_t tm_start;
+  tm_stop_t tm_stop;
+  tm_event_cb_t tm_event_cb;
+  void *tm_arg;
+  void *tm_priv; /*!< private data (usually pointer to device_t) */
+} timer_t;
+
+int tm_register(timer_t *tm);
+int tm_deregister(timer_t *tm);
+timer_t *tm_alloc(const char *name, unsigned flags);
+int tm_init(timer_t *tm, tm_event_cb_t event, void *arg);
+int tm_free(timer_t *tm);
+
+bintime_t tm_gettime(timer_t *tm);
+int tm_start(timer_t *tm, unsigned flags, const bintime_t value);
+int tm_stop(timer_t *tm);
+void tm_trigger(timer_t *tm);
 
 #endif /* !_SYS_TIMER_H_ */

--- a/include/timer.h
+++ b/include/timer.h
@@ -24,6 +24,7 @@ typedef struct timer {
   TAILQ_ENTRY(timer) tm_link; /*!< entry on list of all timers */
   const char *tm_name;        /*!< name of the timer */
   unsigned tm_flags;          /*!< TMF_* flags */
+  uint32_t tm_frequency;      /*!< base frequency of the timer */
   bintime_t tm_min_period;    /*!< valid only for TMF_PERIODIC */
   bintime_t tm_max_period;    /*!< same as above */
   tm_gettime_t tm_gettime;    /*!< returns current time value */

--- a/include/timer.h
+++ b/include/timer.h
@@ -7,7 +7,6 @@
 typedef struct timer timer_t;
 typedef TAILQ_HEAD(, timer) timer_list_t;
 
-typedef bintime_t (*tm_gettime_t)(timer_t *tm);
 typedef int (*tm_start_t)(timer_t *tm, unsigned flags, const bintime_t value);
 typedef int (*tm_stop_t)(timer_t *tm);
 
@@ -27,7 +26,6 @@ typedef struct timer {
   uint32_t tm_frequency;      /*!< base frequency of the timer */
   bintime_t tm_min_period;    /*!< valid only for TMF_PERIODIC */
   bintime_t tm_max_period;    /*!< same as above */
-  tm_gettime_t tm_gettime;    /*!< returns current time value */
   tm_start_t tm_start;        /*!< makes timer operational */
   tm_stop_t tm_stop;          /*!< ceases timer from generating new events */
   tm_event_cb_t tm_event_cb;  /*!< callback called when timer triggers */
@@ -51,8 +49,6 @@ int tm_free(timer_t *tm);
 
 /*! \brief Prepares timer to call event trigger callback. */
 int tm_init(timer_t *tm, tm_event_cb_t event, void *arg);
-/*! \brief Reads current timer value. */
-bintime_t tm_gettime(timer_t *tm);
 /*! \brief Configures timer to trigger callback(s). */
 int tm_start(timer_t *tm, unsigned flags, const bintime_t value);
 /*! \brief Stops timer from triggering a callback. */

--- a/mips/malta.c
+++ b/mips/malta.c
@@ -4,6 +4,7 @@
 #include <mips/cpuinfo.h>
 #include <mips/malta.h>
 #include <mips/intr.h>
+#include <mips/timer.h>
 #include <mips/tlb.h>
 #include <klog.h>
 #include <kbss.h>
@@ -161,6 +162,7 @@ void platform_init(int argc, char **argv, char **envp, unsigned memsize) {
   pcpu_init();
   cpu_init();
   tlb_init();
+  mips_timer_init();
   mips_intr_init();
   pm_bootstrap(memsize);
   pmap_init();

--- a/mips/timer.c
+++ b/mips/timer.c
@@ -1,89 +1,60 @@
-#include <interrupt.h>
 #include <mips/m32c0.h>
 #include <mips/config.h>
 #include <mips/intr.h>
-#include <spinlock.h>
+#include <interrupt.h>
 #include <time.h>
 
-typedef struct timer_event timer_event_t;
-typedef TAILQ_HEAD(, timer_event) timer_event_list_t;
+/* For now, sole purpose of MIPS CPU timer is to provide accurate timestamps
+ * for various parts of the system.
+ *
+ * TODO Integrate with new timer framework. */
 
-struct timer_event {
-  /* entry on list of all time events */
-  TAILQ_ENTRY(timer_event) tev_link;
-  /* absolute time when this event should be handled */
-  timeval_t tev_when;
-  /* callback function called in interrupt context */
-  void (*tev_func)(timer_event_t *self);
-  /* auxiliary data */
-  void *tev_data;
-};
+typedef union {
+  struct {
+    uint32_t lo;
+    uint32_t hi;
+  };
+  uint64_t val;
+} counter_t;
 
-static timer_event_list_t events = TAILQ_HEAD_INITIALIZER(events);
-static spinlock_t *events_lock = &SPINLOCK_INITIALIZER();
+static counter_t count = {.hi = 0, .lo = 0};
+static counter_t compare = {.hi = 1, .lo = 0};
 
-static inline uint32_t ticks(timer_event_t *tev) {
-  return tev->tev_when.tv_sec * TICKS_PER_SEC +
-         tev->tev_when.tv_usec * TICKS_PER_US;
+static uint64_t read_count(void) {
+  uint64_t now;
+  intr_disable();
+  count.lo = mips32_get_c0(C0_COUNT);
+  now = count.val;
+  intr_enable();
+  return now;
 }
 
-timeval_t get_uptime(void) {
-  /* BUG: C0_COUNT will overflow every 4294 seconds for 100MHz processor! */
-  uint32_t count = mips32_get_c0(C0_COUNT) / TICKS_PER_US;
-  return (timeval_t){.tv_sec = count / 1000000, .tv_usec = count % 1000000};
-}
-
-static intr_filter_t cpu_timer_intr(void *arg);
-
-static intr_handler_t cpu_timer_intr_handler =
-  INTR_HANDLER_INIT(cpu_timer_intr, NULL, NULL, "CPU timer", 0);
-
-static intr_filter_t cpu_timer_intr(void *arg) {
-  uint32_t compare = mips32_get_c0(C0_COMPARE);
-
-  timer_event_t *event, *next;
-  TAILQ_FOREACH_SAFE(event, &events, tev_link, next) {
-    if (ticks(event) > compare)
-      break;
-    TAILQ_REMOVE(&events, event, tev_link);
-    if (TAILQ_EMPTY(&events))
-      mips_intr_teardown(&cpu_timer_intr_handler);
-    assert(event->tev_func != NULL);
-    event->tev_func(event);
-  }
-
-  if (!TAILQ_EMPTY(&events))
-    mips32_set_c0(C0_COMPARE, ticks(TAILQ_FIRST(&events)));
-
+static intr_filter_t mips_timer_intr(void *data) {
+  count.hi++;
+  compare.hi++;
+  /* To mark interrupt as handled we need to write to compare register! */
+  mips32_set_c0(C0_COMPARE, compare.lo);
   return IF_FILTERED;
 }
 
-void cpu_timer_add_event(timer_event_t *tev) {
-  SCOPED_SPINLOCK(events_lock);
+static intr_handler_t mips_timer_intr_handler =
+  INTR_HANDLER_INIT(mips_timer_intr, NULL, NULL, "MIPS CPU timer", 0);
 
-  if (TAILQ_EMPTY(&events))
-    mips_intr_setup(&cpu_timer_intr_handler, MIPS_HWINT5);
-
-  timer_event_t *event;
-  TAILQ_FOREACH (event, &events, tev_link)
-    if (timeval_cmp(&event->tev_when, &tev->tev_when, >))
-      break;
-
-  if (event)
-    TAILQ_INSERT_BEFORE(event, tev, tev_link);
-  else
-    TAILQ_INSERT_TAIL(&events, tev, tev_link);
-
-  mips32_set_c0(C0_COMPARE, ticks(TAILQ_FIRST(&events)));
+static inline timeval_t ticks2tv(uint64_t ticks) {
+  ticks /= (uint64_t)TICKS_PER_US;
+  return (timeval_t){.tv_sec = ticks / 1000000LL, .tv_usec = ticks % 1000000LL};
 }
 
-void cpu_timer_remove_event(timer_event_t *tev) {
-  SCOPED_SPINLOCK(events_lock);
+timeval_t get_uptime(void) {
+  return ticks2tv(read_count());
+}
 
-  TAILQ_REMOVE(&events, tev, tev_link);
+void mips_timer_init(void) {
+  /* Reset cpu timer. */
+  mips32_set_c0(C0_COUNT, 0);
+  mips32_set_c0(C0_COMPARE, 0);
 
-  if (TAILQ_EMPTY(&events))
-    mips_intr_teardown(&cpu_timer_intr_handler);
-  else
-    mips32_set_c0(C0_COMPARE, ticks(TAILQ_FIRST(&events)));
+  /* Let's permanently enable interrupt handler, as we need to generate
+   * interrupt to register counter overflow to correctly maintain time. */
+  mips_intr_setup(&mips_timer_intr_handler, MIPS_HWINT5);
 }

--- a/mips/timer.c
+++ b/mips/timer.c
@@ -1,10 +1,23 @@
-#include <timer.h>
 #include <interrupt.h>
 #include <mips/m32c0.h>
 #include <mips/config.h>
 #include <mips/intr.h>
 #include <spinlock.h>
-#include <stdc.h>
+#include <time.h>
+
+typedef struct timer_event timer_event_t;
+typedef TAILQ_HEAD(, timer_event) timer_event_list_t;
+
+struct timer_event {
+  /* entry on list of all time events */
+  TAILQ_ENTRY(timer_event) tev_link;
+  /* absolute time when this event should be handled */
+  timeval_t tev_when;
+  /* callback function called in interrupt context */
+  void (*tev_func)(timer_event_t *self);
+  /* auxiliary data */
+  void *tev_data;
+};
 
 static timer_event_list_t events = TAILQ_HEAD_INITIALIZER(events);
 static spinlock_t *events_lock = &SPINLOCK_INITIALIZER();

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -14,6 +14,7 @@ SOURCES_C  = \
 	dev_vga.c \
 	devfs.c \
 	drv_atkbdc.c \
+	drv_pit.c \
 	drv_rtc.c \
 	drv_stdvga.c \
 	exception.c \

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -50,6 +50,7 @@ SOURCES_C  = \
 	sysinit.c \
 	taskqueue.c \
 	thread.c \
+	timer.c \
 	uio.c \
 	vfs.c \
 	vfs_readdir.c \

--- a/sys/clock.c
+++ b/sys/clock.c
@@ -1,24 +1,27 @@
+#define KL_LOG KL_TIME
 #include <callout.h>
 #include <sched.h>
+#include <klog.h>
 #include <timer.h>
 #include <sysinit.h>
 
-static timeval_t tick = TIMEVAL(0.001);
+static const bintime_t tick = HZ2BT(1000); /* 1ms */
+static timer_t *clock = NULL;
 
-static void clock(timer_event_t *tev) {
-  systime_t st = tv2st(tev->tev_when);
-  tev->tev_when = timeval_add(&tev->tev_when, &tick);
-  cpu_timer_add_event(tev);
-  callout_process(st);
+static void clock_cb(timer_t *tm, void *arg) {
+  bintime_t now = bintime_mul(tm_gettime(tm), 1000);
+  callout_process(now.sec);
   sched_clock();
 }
 
-static timer_event_t *clock_event = &(timer_event_t){.tev_func = clock};
-
 static void clock_init(void) {
-  timeval_t now = get_uptime();
-  clock_event->tev_when = timeval_add(&now, &tick);
-  cpu_timer_add_event(clock_event);
+  clock = tm_alloc(NULL, TMF_PERIODIC);
+  if (clock == NULL)
+    panic("Missing suitable timer for maintenance of system clock!");
+  tm_init(clock, clock_cb, NULL);
+  if (tm_start(clock, TMF_PERIODIC, tick))
+    panic("Failed to start system clock!");
+  klog("System clock uses \'%s\' hardware timer.", clock->tm_name);
 }
 
-SYSINIT_ADD(clock, clock_init, DEPS("sched", "callout"));
+SYSINIT_ADD(clock, clock_init, DEPS("sched", "callout", "pit"));

--- a/sys/clock.c
+++ b/sys/clock.c
@@ -16,7 +16,7 @@ static void clock_cb(timer_t *tm, void *arg) {
 }
 
 static void clock_init(void) {
-  clock = tm_alloc(NULL, TMF_PERIODIC);
+  clock = tm_reserve(NULL, TMF_PERIODIC);
   if (clock == NULL)
     panic("Missing suitable timer for maintenance of system clock!");
   tm_init(clock, clock_cb, NULL);

--- a/sys/clock.c
+++ b/sys/clock.c
@@ -6,11 +6,12 @@
 #include <sysinit.h>
 
 static const bintime_t tick = HZ2BT(1000); /* 1ms */
+static systime_t ticks = 0;
 static timer_t *clock = NULL;
 
 static void clock_cb(timer_t *tm, void *arg) {
-  bintime_t now = bintime_mul(tm_gettime(tm), 1000);
-  callout_process(now.sec);
+  ticks++;
+  callout_process(ticks);
   sched_clock();
 }
 

--- a/sys/drv_pit.c
+++ b/sys/drv_pit.c
@@ -108,6 +108,7 @@ static int pit_attach(device_t *dev) {
   pit->timer = (timer_t){
     .tm_name = "i8254",
     .tm_flags = TMF_PERIODIC,
+    .tm_frequency = TIMER_FREQ,
     .tm_min_period = HZ2BT(TIMER_FREQ),
     .tm_max_period = bintime_mul(HZ2BT(TIMER_FREQ), 65536),
     .tm_gettime = timer_pit_gettime,

--- a/sys/drv_pit.c
+++ b/sys/drv_pit.c
@@ -4,14 +4,17 @@
 #include <pci.h>
 #include <interrupt.h>
 #include <klog.h>
+#include <timer.h>
 #include <spinlock.h>
 #include <sysinit.h>
 
 typedef struct pit_state {
   resource_t *regs;
   spinlock_t lock;
-  uint32_t counter;
+  uint32_t ticks;
+  uint16_t period;
   intr_handler_t intr_handler;
+  timer_t timer;
 } pit_state_t;
 
 #define inb(addr) bus_space_read_1(pit->regs, IO_TIMER1 + (addr))
@@ -24,9 +27,12 @@ static void pit_set_frequency(pit_state_t *pit, unsigned freq) {
     outb(TIMER_MODE, TIMER_SEL0 | TIMER_16BIT | TIMER_RATEGEN);
     outb(TIMER_CNTR0, period & 0xff);
     outb(TIMER_CNTR0, period >> 8);
+
+    pit->period = period;
   }
 }
 
+#if 0
 static uint16_t pit_get_counter(pit_state_t *pit) {
   uint16_t val = 0;
 
@@ -38,6 +44,7 @@ static uint16_t pit_get_counter(pit_state_t *pit) {
 
   return val;
 }
+#endif
 
 static void pit_set_counter(pit_state_t *pit, uint16_t value) {
   WITH_SPINLOCK(&pit->lock) {
@@ -49,8 +56,42 @@ static void pit_set_counter(pit_state_t *pit, uint16_t value) {
 
 static intr_filter_t pit_intr(void *data) {
   pit_state_t *pit = data;
-  klog("PIT: %d", pit_get_counter(pit));
+  tm_trigger(&pit->timer);
   return IF_FILTERED;
+}
+
+static device_t *device_of(timer_t *tm) {
+  return tm->tm_priv;
+}
+
+static bintime_t timer_pit_gettime(timer_t *tm) {
+  pit_state_t *pit = device_of(tm)->state;
+
+  /* TODO add offset based on current value of PIT counter */
+  return bintime_mul(bintime_mul(HZ2BT(TIMER_FREQ), pit->period), pit->ticks);
+}
+
+static int timer_pit_start(timer_t *tm, unsigned flags, const bintime_t value) {
+  assert(flags & TMF_PERIODIC);
+  assert(!(flags & TMF_ONESHOT));
+
+  device_t *dev = device_of(tm);
+  pit_state_t *pit = dev->state;
+
+  bintime_t period = bintime_mul(value, TIMER_FREQ);
+  pit_set_frequency(pit, period.sec);
+
+  bus_intr_setup(dev, 0, &pit->intr_handler);
+  pit_set_counter(pit, 0);
+  return 0;
+}
+
+static int timer_pit_stop(timer_t *tm) {
+  device_t *dev = device_of(tm);
+  pit_state_t *pit = dev->state;
+
+  bus_intr_teardown(dev, &pit->intr_handler);
+  return 0;
 }
 
 static int pit_attach(device_t *dev) {
@@ -62,24 +103,32 @@ static int pit_attach(device_t *dev) {
   pit->regs = pcib->io_space;
 
   pit->lock = SPINLOCK_INITIALIZER();
-  pit->intr_handler =
-    INTR_HANDLER_INIT(pit_intr, NULL, pit, "programmable interval timer", 0);
-  bus_intr_setup(dev, 0, &pit->intr_handler);
+  pit->intr_handler = INTR_HANDLER_INIT(pit_intr, NULL, pit, "i8254 timer", 0);
+
+  pit->timer = (timer_t){
+    .tm_name = "i8254",
+    .tm_flags = TMF_PERIODIC,
+    .tm_min_period = HZ2BT(TIMER_FREQ),
+    .tm_max_period = bintime_mul(HZ2BT(TIMER_FREQ), 65536),
+    .tm_gettime = timer_pit_gettime,
+    .tm_start = timer_pit_start,
+    .tm_stop = timer_pit_stop,
+    .tm_priv = dev,
+  };
+
+  tm_register(&pit->timer);
 
   return 0;
 }
 
 static driver_t pit_driver = {
-  .desc = "i8253 PIT driver", .size = sizeof(pit_state_t), .attach = pit_attach,
+  .desc = "i8254 PIT driver", .size = sizeof(pit_state_t), .attach = pit_attach,
 };
 
 extern device_t *gt_pci;
 
 static void pit_init(void) {
-  device_t *dev = make_device(gt_pci, &pit_driver);
-  pit_state_t *pit = dev->state;
-  pit_set_counter(pit, 0);
-  pit_set_frequency(pit, 100);
+  (void)make_device(gt_pci, &pit_driver);
 }
 
 SYSINIT_ADD(pit, pit_init, DEPS("rootdev"));

--- a/sys/drv_pit.c
+++ b/sys/drv_pit.c
@@ -70,9 +70,7 @@ static int pit_attach(device_t *dev) {
 }
 
 static driver_t pit_driver = {
-  .desc = "i8253 PIT driver",
-  .size = sizeof(pit_state_t),
-  .attach = pit_attach,
+  .desc = "i8253 PIT driver", .size = sizeof(pit_state_t), .attach = pit_attach,
 };
 
 extern device_t *gt_pci;

--- a/sys/drv_pit.c
+++ b/sys/drv_pit.c
@@ -1,0 +1,87 @@
+#include <common.h>
+#include <dev/i8253reg.h>
+#include <dev/isareg.h>
+#include <pci.h>
+#include <interrupt.h>
+#include <klog.h>
+#include <spinlock.h>
+#include <sysinit.h>
+
+typedef struct pit_state {
+  resource_t *regs;
+  spinlock_t lock;
+  uint32_t counter;
+  intr_handler_t intr_handler;
+} pit_state_t;
+
+#define inb(addr) bus_space_read_1(pit->regs, IO_TIMER1 + (addr))
+#define outb(addr, val) bus_space_write_1(pit->regs, IO_TIMER1 + (addr), (val))
+
+static void pit_set_frequency(pit_state_t *pit, unsigned freq) {
+  uint16_t period = TIMER_DIV(freq);
+
+  WITH_SPINLOCK(&pit->lock) {
+    outb(TIMER_MODE, TIMER_SEL0 | TIMER_16BIT | TIMER_RATEGEN);
+    outb(TIMER_CNTR0, period & 0xff);
+    outb(TIMER_CNTR0, period >> 8);
+  }
+}
+
+static uint16_t pit_get_counter(pit_state_t *pit) {
+  uint16_t val = 0;
+
+  WITH_SPINLOCK(&pit->lock) {
+    outb(TIMER_MODE, TIMER_SEL0 | TIMER_LATCH);
+    val = inb(TIMER_CNTR0);
+    val |= inb(TIMER_CNTR0) << 8;
+  }
+
+  return val;
+}
+
+static void pit_set_counter(pit_state_t *pit, uint16_t value) {
+  WITH_SPINLOCK(&pit->lock) {
+    outb(TIMER_MODE, TIMER_SEL0 | TIMER_LATCH);
+    outb(TIMER_CNTR0, value & 0xff);
+    outb(TIMER_CNTR0, value >> 8);
+  }
+}
+
+static intr_filter_t pit_intr(void *data) {
+  pit_state_t *pit = data;
+  klog("PIT: %d", pit_get_counter(pit));
+  return IF_FILTERED;
+}
+
+static int pit_attach(device_t *dev) {
+  assert(dev->parent->bus == DEV_BUS_PCI);
+
+  pci_bus_state_t *pcib = dev->parent->state;
+  pit_state_t *pit = dev->state;
+
+  pit->regs = pcib->io_space;
+
+  pit->lock = SPINLOCK_INITIALIZER();
+  pit->intr_handler =
+    INTR_HANDLER_INIT(pit_intr, NULL, pit, "programmable interval timer", 0);
+  bus_intr_setup(dev, 0, &pit->intr_handler);
+
+  return 0;
+}
+
+static driver_t pit_driver = {
+  .desc = "i8253 PIT driver",
+  .size = sizeof(pit_state_t),
+  .attach = pit_attach,
+};
+
+extern device_t *gt_pci;
+
+static void pit_init(void) {
+  device_t *dev = make_device(gt_pci, &pit_driver);
+  pit_state_t *pit = dev->state;
+  pit_set_counter(pit, 0);
+  pit_set_frequency(pit, 100);
+}
+
+SYSINIT_ADD(pit, pit_init, DEPS("rootdev"));

--- a/sys/klog.c
+++ b/sys/klog.c
@@ -17,7 +17,7 @@ static const char *subsystems[] =
    [KL_DEV] = "dev",     [KL_VFS] = "vfs",         [KL_VNODE] = "vnode",
    [KL_PROC] = "proc",   [KL_SYSCALL] = "syscall", [KL_USER] = "user",
    [KL_TEST] = "test",   [KL_SIGNAL] = "signal",   [KL_FILESYS] = "filesys",
-   [KL_UNDEF] = "???"};
+   [KL_TIME] = "time",   [KL_UNDEF] = "???"};
 
 /* Borrowed from mips/malta.c */
 char *kenv_get(char *key);

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -74,11 +74,6 @@ int tm_init(timer_t *tm, tm_event_cb_t event, void *arg) {
   return 0;
 }
 
-bintime_t tm_gettime(timer_t *tm) {
-  assert(is_initialized(tm));
-  return tm->tm_gettime(tm);
-}
-
 int tm_start(timer_t *tm, unsigned flags, const bintime_t value) {
   assert(is_initialized(tm));
 

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -91,7 +91,7 @@ int tm_release(timer_t *tm) {
 
   WITH_MTX_LOCK (&timers_mtx) {
     TAILQ_INSERT_TAIL(&timers, tm, tm_link);
-    tm->tm_flags &= ~(TM_INITIALIZED | TM_RESERVED);
+    tm->tm_flags &= ~(TMF_INITIALIZED | TMF_RESERVED);
   }
 
   return 0;

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -29,7 +29,6 @@ int tm_register(timer_t *tm) {
   }
 
   klog("Registered '%s' timer.", tm->tm_name);
-
   return 0;
 }
 
@@ -45,7 +44,6 @@ int tm_deregister(timer_t *tm) {
   }
 
   klog("Unregistered '%s' timer.", tm->tm_name);
-
   return 0;
 }
 
@@ -61,7 +59,6 @@ timer_t *tm_alloc(const char *name, unsigned flags) {
     }
     tm->tm_flags |= TMF_ALLOCATED;
   }
-
   return tm;
 }
 
@@ -87,10 +84,8 @@ int tm_start(timer_t *tm, unsigned flags, const bintime_t value) {
 
   if (is_active(tm))
     return EBUSY;
-
   if (((tm->tm_flags & flags) & TMF_TYPEMASK) == 0)
     return ENODEV;
-
   if (flags & TMF_PERIODIC) {
     if (bintime_cmp(value, tm->tm_min_period, <) ||
         bintime_cmp(value, tm->tm_max_period, >))
@@ -98,10 +93,8 @@ int tm_start(timer_t *tm, unsigned flags, const bintime_t value) {
   }
 
   int retval = tm->tm_start(tm, flags, value);
-
   if (retval == 0)
     tm->tm_flags |= TMF_ACTIVE;
-
   return retval;
 }
 
@@ -112,10 +105,8 @@ int tm_stop(timer_t *tm) {
     return 0;
 
   int retval = tm->tm_stop(tm);
-
   if (retval == 0)
     tm->tm_flags &= ~TMF_ACTIVE;
-
   return retval;
 }
 

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -8,14 +8,35 @@
 static mtx_t timers_mtx = MTX_INITIALIZER(MTX_DEF);
 static timer_list_t timers = TAILQ_HEAD_INITIALIZER(timers);
 
+/* These flags are used internally to encode timer state.
+ * Following state transitions are possible:
+ *
+ * \dot
+ * digraph timer_state {
+ *   a [label="initial", style=bold];
+ *   b [label="registered"];
+ *   c [label="registered ∧ reserved"];
+ *   d [label="registered ∧ reserved ∧ initialized"];
+ *   e [label="registered ∧ reserved ∧ initialized ∧ active"];
+ *   a -> b [label="tm_register"];
+ *   b -> c [label="tm_reserve"];
+ *   c -> d [label="tm_init"];
+ *   d -> e [label="tm_start"];
+ *   e -> d [label="tm_stop"];
+ *   d -> b [label="tm_release"];
+ *   c -> b [label="tm_release"];
+ *   b -> a [label="tm_deregister"];
+ * }
+ * \enddot
+ */
 #define TMF_ACTIVE 0x1000
 #define TMF_INITIALIZED 0x2000
-#define TMF_ALLOCATED 0x4000
+#define TMF_RESERVED 0x4000
 #define TMF_REGISTERED 0x8000
 
 #define is_active(tm) ((tm)->tm_flags & TMF_ACTIVE)
 #define is_initialized(tm) ((tm)->tm_flags & TMF_INITIALIZED)
-#define is_allocated(tm) ((tm)->tm_flags & TMF_ALLOCATED)
+#define is_reserved(tm) ((tm)->tm_flags & TMF_RESERVED)
 #define is_registered(tm) ((tm)->tm_flags & TMF_REGISTERED)
 
 int tm_register(timer_t *tm) {
@@ -35,7 +56,7 @@ int tm_register(timer_t *tm) {
 int tm_deregister(timer_t *tm) {
   assert(is_registered(tm));
 
-  if (is_allocated(tm))
+  if (is_reserved(tm))
     return EBUSY;
 
   WITH_MTX_LOCK (&timers_mtx) {
@@ -47,23 +68,37 @@ int tm_deregister(timer_t *tm) {
   return 0;
 }
 
-timer_t *tm_alloc(const char *name, unsigned flags) {
+timer_t *tm_reserve(const char *name, unsigned flags) {
   timer_t *tm = NULL;
 
   WITH_MTX_LOCK (&timers_mtx) {
     TAILQ_FOREACH (tm, &timers, tm_link) {
-      if (is_allocated(tm))
+      if (is_reserved(tm))
         continue;
       if (tm->tm_flags & flags)
         break;
     }
-    tm->tm_flags |= TMF_ALLOCATED;
+    tm->tm_flags |= TMF_RESERVED;
   }
   return tm;
 }
 
+int tm_release(timer_t *tm) {
+  assert(is_reserved(tm));
+
+  if (is_active(tm))
+    return EBUSY;
+
+  WITH_MTX_LOCK (&timers_mtx) {
+    TAILQ_INSERT_TAIL(&timers, tm, tm_link);
+    tm->tm_flags &= ~(TM_INITIALIZED | TM_RESERVED);
+  }
+
+  return 0;
+}
+
 int tm_init(timer_t *tm, tm_event_cb_t event, void *arg) {
-  assert(is_allocated(tm));
+  assert(is_reserved(tm));
 
   if (is_active(tm))
     return EBUSY;

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -8,6 +8,11 @@
 static mtx_t timers_mtx = MTX_INITIALIZER(MTX_DEF);
 static timer_list_t timers = TAILQ_HEAD_INITIALIZER(timers);
 
+#define TMF_ACTIVE 0x1000
+#define TMF_INITIALIZED 0x2000
+#define TMF_ALLOCATED 0x4000
+#define TMF_REGISTERED 0x8000
+
 #define is_active(tm) ((tm)->tm_flags & TMF_ACTIVE)
 #define is_initialized(tm) ((tm)->tm_flags & TMF_INITIALIZED)
 #define is_allocated(tm) ((tm)->tm_flags & TMF_ALLOCATED)

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -2,6 +2,7 @@
 #include <timer.h>
 #include <mutex.h>
 #include <errno.h>
+#include <stdc.h>
 #include <klog.h>
 #include <interrupt.h>
 
@@ -74,6 +75,8 @@ timer_t *tm_reserve(const char *name, unsigned flags) {
   WITH_MTX_LOCK (&timers_mtx) {
     TAILQ_FOREACH (tm, &timers, tm_link) {
       if (is_reserved(tm))
+        continue;
+      if (name && strcmp(tm->tm_name, name))
         continue;
       if (tm->tm_flags & flags)
         break;

--- a/sys/timer.c
+++ b/sys/timer.c
@@ -1,0 +1,122 @@
+#define KL_LOG KL_TIME
+#include <timer.h>
+#include <mutex.h>
+#include <errno.h>
+#include <klog.h>
+#include <interrupt.h>
+
+static mtx_t timers_mtx = MTX_INITIALIZER(MTX_DEF);
+static timer_list_t timers = TAILQ_HEAD_INITIALIZER(timers);
+
+#define is_active(tm) ((tm)->tm_flags & TMF_ACTIVE)
+#define is_initialized(tm) ((tm)->tm_flags & TMF_INITIALIZED)
+#define is_allocated(tm) ((tm)->tm_flags & TMF_ALLOCATED)
+#define is_registered(tm) ((tm)->tm_flags & TMF_REGISTERED)
+
+int tm_register(timer_t *tm) {
+  if (is_registered(tm))
+    return EBUSY;
+
+  WITH_MTX_LOCK (&timers_mtx) {
+    TAILQ_INSERT_TAIL(&timers, tm, tm_link);
+    tm->tm_flags &= TMF_TYPEMASK;
+    tm->tm_flags |= TMF_REGISTERED;
+  }
+
+  klog("Registered '%s' timer.", tm->tm_name);
+
+  return 0;
+}
+
+int tm_deregister(timer_t *tm) {
+  assert(is_registered(tm));
+
+  if (is_allocated(tm))
+    return EBUSY;
+
+  WITH_MTX_LOCK (&timers_mtx) {
+    TAILQ_REMOVE(&timers, tm, tm_link);
+    tm->tm_flags &= TMF_TYPEMASK;
+  }
+
+  klog("Unregistered '%s' timer.", tm->tm_name);
+
+  return 0;
+}
+
+timer_t *tm_alloc(const char *name, unsigned flags) {
+  timer_t *tm = NULL;
+
+  WITH_MTX_LOCK (&timers_mtx) {
+    TAILQ_FOREACH (tm, &timers, tm_link) {
+      if (is_allocated(tm))
+        continue;
+      if (tm->tm_flags & flags)
+        break;
+    }
+    tm->tm_flags |= TMF_ALLOCATED;
+  }
+
+  return tm;
+}
+
+int tm_init(timer_t *tm, tm_event_cb_t event, void *arg) {
+  assert(is_allocated(tm));
+
+  if (is_active(tm))
+    return EBUSY;
+
+  tm->tm_flags |= TMF_INITIALIZED;
+  tm->tm_event_cb = event;
+  tm->tm_arg = arg;
+  return 0;
+}
+
+bintime_t tm_gettime(timer_t *tm) {
+  assert(is_initialized(tm));
+  return tm->tm_gettime(tm);
+}
+
+int tm_start(timer_t *tm, unsigned flags, const bintime_t value) {
+  assert(is_initialized(tm));
+
+  if (is_active(tm))
+    return EBUSY;
+
+  if (((tm->tm_flags & flags) & TMF_TYPEMASK) == 0)
+    return ENODEV;
+
+  if (flags & TMF_PERIODIC) {
+    if (bintime_cmp(value, tm->tm_min_period, <) ||
+        bintime_cmp(value, tm->tm_max_period, >))
+      return EINVAL;
+  }
+
+  int retval = tm->tm_start(tm, flags, value);
+
+  if (retval == 0)
+    tm->tm_flags |= TMF_ACTIVE;
+
+  return retval;
+}
+
+int tm_stop(timer_t *tm) {
+  assert(is_initialized(tm));
+
+  if (!is_active(tm))
+    return 0;
+
+  int retval = tm->tm_stop(tm);
+
+  if (retval == 0)
+    tm->tm_flags &= ~TMF_ACTIVE;
+
+  return retval;
+}
+
+void tm_trigger(timer_t *tm) {
+  assert(is_initialized(tm));
+  assert(intr_disabled());
+
+  tm->tm_event_cb(tm, tm->tm_arg);
+}


### PR DESCRIPTION
 * Add infrastructure for timers that trigger callbacks either periodically or in one-shot mode.
 * Introduce bintime_t structure for high-fidelity time measurement.
 * Add i8254 PIT driver.
 * Use timer infrastructure to trigger system clock every 1ms.
 * Repurpose MIPS CPU timer for time measurement.