### PR TITLE
`preempt_enable` should switch to another thread if indirectly requested

### DIFF
--- a/sys/sched.c
+++ b/sys/sched.c
@@ -189,10 +189,13 @@ void preempt_disable(void) {
 void preempt_enable(void) {
   thread_t *td = thread_self();
   assert(td->td_pdnest > 0);
-  td->td_pdnest--;
 
-  if (td->td_pdnest == 0 && td->td_flags & TDF_NEEDSWITCH) {
-    WITH_SPINLOCK(td->td_spin) {
+  td->td_pdnest--;
+  if (td->td_pdnest > 0)
+    return;
+
+  WITH_SPINLOCK(td->td_spin) {
+    if (td->td_flags & TDF_NEEDSWITCH) {
       td->td_state = TDS_READY;
       sched_switch();
     }

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -190,6 +190,13 @@ void preempt_enable(void) {
   thread_t *td = thread_self();
   assert(td->td_pdnest > 0);
   td->td_pdnest--;
+
+  if (td->td_pdnest == 0 && td->td_flags & TDF_NEEDSWITCH) {
+    WITH_SPINLOCK(td->td_spin) {
+      td->td_state = TDS_READY;
+      sched_switch();
+    }
+  }
 }
 
 SYSINIT_ADD(sched, sched_init, DEPS("callout"));


### PR DESCRIPTION
In Mimiker we set `TDF_NEEDSWITCH` when thread's time slice is exhausted or when some another thread with higher priority is added to run queue.
To solve issue #241 I add code to `preempt_enable` which preempts current thread if `TDF_NEEDSWITCH` is set.
Note that `critical_exit` in FreeBSD is counterpart of our `preempt_enable`.