### PR TITLE
Little cleanup before turnstile PR

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -18,6 +18,7 @@ typedef unsigned long pm_addr_t;
 
 typedef long off_t;
 typedef long ssize_t;
+typedef uint8_t td_prio_t;
 typedef int32_t pid_t;
 typedef uint16_t dev_t;
 typedef uint32_t time_t;

--- a/include/common.h
+++ b/include/common.h
@@ -18,7 +18,7 @@ typedef unsigned long pm_addr_t;
 
 typedef long off_t;
 typedef long ssize_t;
-typedef uint8_t td_prio_t;
+typedef uint8_t prio_t;
 typedef int32_t pid_t;
 typedef uint16_t dev_t;
 typedef uint32_t time_t;

--- a/include/interrupt.h
+++ b/include/interrupt.h
@@ -43,7 +43,6 @@ typedef void driver_intr_t(void *);
 
 typedef struct intr_chain intr_chain_t;
 typedef struct intr_handler intr_handler_t;
-typedef int prio_t;
 
 struct intr_handler {
   TAILQ_ENTRY(intr_handler) ih_list;

--- a/include/pool.h
+++ b/include/pool.h
@@ -1,6 +1,8 @@
 #ifndef _SYS_POOL_H_
 #define _SYS_POOL_H_
 
+#include <common.h>
+
 typedef struct pool *pool_t;
 
 typedef void (*pool_ctor_t)(void *);

--- a/include/sched.h
+++ b/include/sched.h
@@ -54,7 +54,7 @@ void sched_wakeup(thread_t *td);
  *
  * \note Must be called with \a td_spin acquired!
  */
-void sched_lend_prio(thread_t *td, td_prio_t prio);
+void sched_lend_prio(thread_t *td, prio_t prio);
 
 /*! \brief Remove lent priority while offering a new priority to lend.
  *
@@ -63,7 +63,7 @@ void sched_lend_prio(thread_t *td, td_prio_t prio);
  *
  * \note Must be called with \a td_spin acquired!
  */
-void sched_unlend_prio(thread_t *td, td_prio_t prio);
+void sched_unlend_prio(thread_t *td, prio_t prio);
 
 /*! \brief Takes care of run-time accounting for current thread.
  *

--- a/include/thread.h
+++ b/include/thread.h
@@ -96,8 +96,8 @@ typedef struct thread {
   void *td_wchan;
   const void *td_waitpt; /*!< a point where program waits */
   /* scheduler part */
-  td_prio_t td_base_prio; /*!< base priority */
-  td_prio_t td_prio;      /*!< active priority */
+  prio_t td_base_prio; /*!< base priority */
+  prio_t td_prio;      /*!< active priority */
   int td_slice;
   /* thread statistics */
   timeval_t td_rtime;        /*!< time spent running */

--- a/include/thread.h
+++ b/include/thread.h
@@ -14,7 +14,6 @@
 
 /*! \file thread.h */
 
-typedef uint8_t td_prio_t;
 typedef struct vm_page vm_page_t;
 typedef struct vm_map vm_map_t;
 typedef struct fdtab fdtab_t;

--- a/sys/sched.c
+++ b/sys/sched.c
@@ -54,7 +54,7 @@ void sched_wakeup(thread_t *td) {
  *
  * \note Must be called with td_spin acquired!
  */
-static void sched_set_priority(thread_t *td, td_prio_t prio) {
+static void sched_set_priority(thread_t *td, prio_t prio) {
   assert(spin_owned(td->td_spin));
 
   if (td->td_prio == prio)
@@ -70,7 +70,7 @@ static void sched_set_priority(thread_t *td, td_prio_t prio) {
   }
 }
 
-void sched_lend_prio(thread_t *td, td_prio_t prio) {
+void sched_lend_prio(thread_t *td, prio_t prio) {
   assert(spin_owned(td->td_spin));
   assert(td->td_prio < prio);
 
@@ -78,7 +78,7 @@ void sched_lend_prio(thread_t *td, td_prio_t prio) {
   sched_set_priority(td, prio);
 }
 
-void sched_unlend_prio(thread_t *td, td_prio_t prio) {
+void sched_unlend_prio(thread_t *td, prio_t prio) {
   assert(spin_owned(td->td_spin));
 
   if (prio <= td->td_base_prio) {


### PR DESCRIPTION
- Move `td_prio_t` definition from `include/thread.h` to `include/common.h`
- Rename `td_prio_t` to `prio_t`
- Unify `prio_t` from `include/interrupt.h` with `prio_t` from `include/common.h` (now interrupt priority is `uint8_t` instead if `int`!)
- Add `#include <common.h>` to `include/pool.h`