### PR TITLE
added reserved instruction handler and updated cp unusable handler to send signals

### DIFF
--- a/mips/intr.c
+++ b/mips/intr.c
@@ -171,7 +171,7 @@ static void fpe_handler(exc_frame_t *frame) {
 
 static void cp_unusable_handler(exc_frame_t *frame) {
   if (in_kernel_mode(frame)) {
-    panic("FPU unusable exception in kernel mode.");
+    panic("Coprocessor unusable exception in kernel mode.");
   }
 
   int cp_id = (frame->cause & CR_CEMASK) >> CR_CESHIFT;

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -170,21 +170,22 @@ static void fpe_handler(exc_frame_t *frame) {
 }
 
 static void cp_unusable_handler(exc_frame_t *frame) {
-  int cp_id = (frame->cause & CR_CEMASK) >> CR_CESHIFT;
-  bool kernel_mode = in_kernel_mode(frame);
-
-  if (cp_id != 1) {
-    panic(
-      "Unexpected unusable coprocessor exception, with coprocessor id = %d\n",
-      cp_id);
+  if (in_kernel_mode(frame)) {
+    panic("FPU unusable exception in kernel mode.");
   }
 
-  if (kernel_mode) {
-    panic("FPU unusable exception in kernel mode.");
+  int cp_id = (frame->cause & CR_CEMASK) >> CR_CESHIFT;
+  if (cp_id != 1) {
+    sig_send(thread_self()->td_proc, SIGILL);
   }
 
   /* Enable FPU for interrupted context. */
   frame->sr |= SR_CU1;
+}
+
+static void ri_handler(exc_frame_t *frame) {
+  assert(!in_kernel_mode(frame));
+  sig_send(thread_self()->td_proc, SIGILL);
 }
 
 /*
@@ -201,7 +202,8 @@ static exc_handler_t user_exception_table[32] =
    [EXC_FPE] = fpe_handler,
    [EXC_MSAFPE] = fpe_handler,
    [EXC_OVF] = fpe_handler,
-   [EXC_CPU] = cp_unusable_handler};
+   [EXC_CPU] = cp_unusable_handler,
+   [EXC_RI] = ri_handler};
 
 static exc_handler_t kernel_exception_table[32] =
   {[EXC_MOD] = tlb_exception_handler, [EXC_TLBL] = tlb_exception_handler,

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -177,10 +177,10 @@ static void cp_unusable_handler(exc_frame_t *frame) {
   int cp_id = (frame->cause & CR_CEMASK) >> CR_CESHIFT;
   if (cp_id != 1) {
     sig_send(thread_self()->td_proc, SIGILL);
+  } else {
+    /* Enable FPU for interrupted context. */
+    frame->sr |= SR_CU1;
   }
-
-  /* Enable FPU for interrupted context. */
-  frame->sr |= SR_CU1;
 }
 
 static void ri_handler(exc_frame_t *frame) {

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -98,9 +98,10 @@ UTEST_ADD_SIMPLE(access_basic);
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
-#if 0
-/* TODO Kernel does not handle such cases yet. */
 UTEST_ADD_SIMPLE(exc_cop_unusable);
 UTEST_ADD_SIMPLE(exc_reserved_instruction);
+
+#if 0
+/* TODO Kernel does not handle this case yet. */
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -98,10 +98,9 @@ UTEST_ADD_SIMPLE(access_basic);
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
+#if 0
+/* TODO Kernel does not handle such cases yet. */
 UTEST_ADD_SIMPLE(exc_cop_unusable);
 UTEST_ADD_SIMPLE(exc_reserved_instruction);
-
-#if 0
-/* TODO Kernel does not handle this case yet. */
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif


### PR DESCRIPTION
Now in case of reserved instruction exception or coprocessor unusable exception (other than FPU coprocessor), SIGILL is sent to process, instead of panicking.