### PR TITLE
Testing Floating Point, Unaligned Access exceptions and wrong syscall number behaviour.

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -12,6 +12,7 @@ typedef enum {
   SIGCHLD,
   SIGUSR1,
   SIGUSR2,
+  SIGBUS,
   NSIG = 32
 } signo_t;
 

--- a/mips/intr.c
+++ b/mips/intr.c
@@ -171,7 +171,7 @@ static void fpe_handler(exc_frame_t *frame) {
 
 static void cp_unusable_handler(exc_frame_t *frame) {
   int cp_id = (frame->cause & CR_CEMASK) >> CR_CESHIFT;
-  bool kernel_mode = (frame->sr & SR_KSU_MASK) == 0;
+  bool kernel_mode = in_kernel_mode(frame);
 
   if (cp_id != 1) {
     panic(

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -98,9 +98,12 @@ UTEST_ADD_SIMPLE(access_basic);
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
+// UTEST_ADD_SIMPLE(exc_fpe);
+
 #if 0
 /* TODO Kernel does not handle such cases yet. */
 UTEST_ADD_SIGNAL(exc_cop_unusable, SIGILL);
 UTEST_ADD_SIGNAL(exc_reserved_instruction, SIGILL);
+UTEST_ADD_SIMPLE(exc_unaligned_access);
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -104,6 +104,6 @@ UTEST_ADD_SIMPLE(fstat);
 /* TODO Kernel does not handle such cases yet. */
 UTEST_ADD_SIGNAL(exc_cop_unusable, SIGILL);
 UTEST_ADD_SIGNAL(exc_reserved_instruction, SIGILL);
-UTEST_ADD_SIMPLE(exc_unaligned_access);
+UTEST_ADD_SIGNAL(exc_unaligned_access, SIGBUS);
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -99,7 +99,7 @@ UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
 UTEST_ADD_SIGNAL(exc_fpe, SIGFPE);
-// UTEST_ADD_SIMPLE(exc_sigsys);
+UTEST_ADD_SIMPLE(exc_sigsys);
 
 #if 0
 /* TODO Kernel does not handle such cases yet. */

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -98,7 +98,7 @@ UTEST_ADD_SIMPLE(access_basic);
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
-// UTEST_ADD_SIMPLE(exc_fpe);
+UTEST_ADD_SIGNAL(exc_fpe, SIGFPE);
 // UTEST_ADD_SIMPLE(exc_sigsys);
 
 #if 0

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -99,12 +99,12 @@ UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
 UTEST_ADD_SIGNAL(exc_fpe, SIGFPE);
-UTEST_ADD_SIMPLE(exc_sigsys);
 
 #if 0
 /* TODO Kernel does not handle such cases yet. */
 UTEST_ADD_SIGNAL(exc_cop_unusable, SIGILL);
 UTEST_ADD_SIGNAL(exc_reserved_instruction, SIGILL);
 UTEST_ADD_SIGNAL(exc_unaligned_access, SIGBUS);
+UTEST_ADD_SIMPLE(exc_sigsys);
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -100,10 +100,10 @@ UTEST_ADD_SIMPLE(fstat);
 
 #if 0
 /* TODO Kernel does not handle such cases yet. */
-UTEST_ADD_SIGNAL(exc_fpe, SIGFPE);
 UTEST_ADD_SIGNAL(exc_cop_unusable, SIGILL);
 UTEST_ADD_SIGNAL(exc_reserved_instruction, SIGILL);
 UTEST_ADD_SIGNAL(exc_unaligned_access, SIGBUS);
+UTEST_ADD_SIGNAL(exc_integer_overflow, SIGFPE);
 UTEST_ADD_SIMPLE(exc_sigsys);
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -98,10 +98,9 @@ UTEST_ADD_SIMPLE(access_basic);
 UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
-UTEST_ADD_SIGNAL(exc_fpe, SIGFPE);
-
 #if 0
 /* TODO Kernel does not handle such cases yet. */
+UTEST_ADD_SIGNAL(exc_fpe, SIGFPE);
 UTEST_ADD_SIGNAL(exc_cop_unusable, SIGILL);
 UTEST_ADD_SIGNAL(exc_reserved_instruction, SIGILL);
 UTEST_ADD_SIGNAL(exc_unaligned_access, SIGBUS);

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -100,7 +100,7 @@ UTEST_ADD_SIMPLE(fstat);
 
 #if 0
 /* TODO Kernel does not handle such cases yet. */
-UTEST_ADD_SIMPLE(exc_cop_unusable);
-UTEST_ADD_SIMPLE(exc_reserved_instruction);
+UTEST_ADD_SIGNAL(exc_cop_unusable, SIGILL);
+UTEST_ADD_SIGNAL(exc_reserved_instruction, SIGILL);
 UTEST_ADD_SIMPLE(syscall_in_bds);
 #endif

--- a/tests/utest.c
+++ b/tests/utest.c
@@ -99,6 +99,7 @@ UTEST_ADD_SIMPLE(stat);
 UTEST_ADD_SIMPLE(fstat);
 
 // UTEST_ADD_SIMPLE(exc_fpe);
+// UTEST_ADD_SIMPLE(exc_sigsys);
 
 #if 0
 /* TODO Kernel does not handle such cases yet. */

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -31,9 +31,7 @@ int test_exc_integer_overflow(void) {
 int test_exc_unaligned_access(void) {
   int a[2];
   int val;
-  asm volatile("lw %0, 1(%1)"
-               : "=r"(val)
-               : "r"(a));
+  asm volatile("lw %0, 1(%1)" : "=r"(val) : "r"(a));
 
   return 0;
 }

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -5,6 +5,8 @@
 #include <sys/signal.h>
 #include <stdlib.h>
 
+#include <stdio.h>
+
 int test_exc_cop_unusable(void) {
   int value;
   asm volatile("mfc0 %0, $12, 0" : "=r"(value));
@@ -16,6 +18,28 @@ int test_exc_reserved_instruction(void) {
    * of the Opcode Field" from "MIPS® Architecture For Programmers Volume II-A:
    * The MIPS32® Instruction Set" */
   asm volatile(".long 0x00000039"); /* objdump fails to disassemble it */
+  return 0;
+}
+
+int test_exc_fpe(void){
+  // #pragma GCC diagnostic push
+  // #pragma GCC diagnostic ignored "-Wdiv-by-zero"
+  float a = 0.0;
+  float b = 1.0;
+  float c = b / a;
+  (void)c;
+  // #pragma GCC diagnostic pop
+  return 0;
+}
+
+int test_exc_unaligned_access(void){
+  int a[2];
+  asm volatile ("addiu $a0, %0, 1;"
+                "lw $a1, 0($a0)" 
+                : 
+                : "r"(a)
+                : "a0", "a1");
+
   return 0;
 }
 

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -21,7 +21,7 @@ int test_exc_reserved_instruction(void) {
   return 0;
 }
 
-int test_exc_fpe(void) {
+int test_exc_integer_overflow(void) {
   int d = __INT_MAX__;
   asm volatile("addi %0, %0, 1" : : "r"(d));
 
@@ -30,11 +30,10 @@ int test_exc_fpe(void) {
 
 int test_exc_unaligned_access(void) {
   int a[2];
-  asm volatile("addiu $a0, %0, 1;"
-               "lw $a1, 0($a0)"
-               :
-               : "r"(a)
-               : "a0", "a1");
+  int val;
+  asm volatile("lw %0, 1(%1)"
+               : "=r"(val)
+               : "r"(a));
 
   return 0;
 }

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -21,20 +21,20 @@ int test_exc_reserved_instruction(void) {
   return 0;
 }
 
-int test_exc_fpe(void){
+int test_exc_fpe(void) {
   int d = __INT_MAX__;
-  asm volatile ("addi %0, %0, 1" : : "r"(d));
+  asm volatile("addi %0, %0, 1" : : "r"(d));
 
   return 0;
 }
 
-int test_exc_unaligned_access(void){
+int test_exc_unaligned_access(void) {
   int a[2];
-  asm volatile ("addiu $a0, %0, 1;"
-                "lw $a1, 0($a0)" 
-                : 
-                : "r"(a)
-                : "a0", "a1");
+  asm volatile("addiu $a0, %0, 1;"
+               "lw $a1, 0($a0)"
+               :
+               : "r"(a)
+               : "a0", "a1");
 
   return 0;
 }

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -21,6 +21,7 @@ int test_exc_reserved_instruction(void) {
   return 0;
 }
 
+// TODO not working
 int test_exc_fpe(void){
   // #pragma GCC diagnostic push
   // #pragma GCC diagnostic ignored "-Wdiv-by-zero"

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -21,15 +21,10 @@ int test_exc_reserved_instruction(void) {
   return 0;
 }
 
-// TODO not working
 int test_exc_fpe(void){
-  // #pragma GCC diagnostic push
-  // #pragma GCC diagnostic ignored "-Wdiv-by-zero"
-  float a = 0.0;
-  float b = 1.0;
-  float c = b / a;
-  (void)c;
-  // #pragma GCC diagnostic pop
+  int d = __INT_MAX__;
+  asm volatile ("addi %0, %0, 1" : : "r"(d));
+
   return 0;
 }
 

--- a/user/utest/exceptions.c
+++ b/user/utest/exceptions.c
@@ -5,46 +5,18 @@
 #include <sys/signal.h>
 #include <stdlib.h>
 
-static int spawn_process(void (*proc_handler)(void)) {
-  int pid;
-  switch ((pid = fork())) {
-    case -1:
-      exit(EXIT_FAILURE);
-    case 0:
-      proc_handler();
-      exit(EXIT_SUCCESS);
-    default:
-      return pid;
-  }
-}
-
-static int check_exception(void (*code)(void), int signum) {
-  spawn_process(code);
-  int status;
-  wait(&status);
-  assert(WIFSIGNALED(status));
-  assert(signum == WTERMSIG(status));
+int test_exc_cop_unusable(void) {
+  int value;
+  asm volatile("mfc0 %0, $12, 0" : "=r"(value));
   return 0;
 }
 
-static inline void exec_cp0_instr(void) {
-  int value;
-  asm volatile("mfc0 %0, $12, 0" : "=r"(value));
-}
-
-static inline void exec_reserved_instr(void) {
+int test_exc_reserved_instruction(void) {
   /* The choice of reserved opcode was done based on "Table A.2 MIPS32 Encoding
    * of the Opcode Field" from "MIPS® Architecture For Programmers Volume II-A:
    * The MIPS32® Instruction Set" */
   asm volatile(".long 0x00000039"); /* objdump fails to disassemble it */
-}
-
-int test_exc_cop_unusable(void) {
-  return check_exception(exec_cp0_instr, SIGILL);
-}
-
-int test_exc_reserved_instruction(void) {
-  return check_exception(exec_reserved_instr, SIGILL);
+  return 0;
 }
 
 int test_syscall_in_bds(void) {

--- a/user/utest/main.c
+++ b/user/utest/main.c
@@ -44,6 +44,8 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(exc_cop_unusable);
   CHECKRUN_TEST(exc_reserved_instruction);
   CHECKRUN_TEST(syscall_in_bds);
+  CHECKRUN_TEST(exc_fpe);
+  CHECKRUN_TEST(exc_unaligned_access);
 
   printf("No user test \"%s\" available.\n", test_name);
   return 1;

--- a/user/utest/main.c
+++ b/user/utest/main.c
@@ -46,6 +46,7 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(syscall_in_bds);
   CHECKRUN_TEST(exc_fpe);
   CHECKRUN_TEST(exc_unaligned_access);
+  CHECKRUN_TEST(exc_sigsys);
 
   printf("No user test \"%s\" available.\n", test_name);
   return 1;

--- a/user/utest/main.c
+++ b/user/utest/main.c
@@ -43,10 +43,10 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(fstat);
   CHECKRUN_TEST(exc_cop_unusable);
   CHECKRUN_TEST(exc_reserved_instruction);
-  CHECKRUN_TEST(syscall_in_bds);
-  CHECKRUN_TEST(exc_fpe);
+  CHECKRUN_TEST(exc_integer_overflow);
   CHECKRUN_TEST(exc_unaligned_access);
   CHECKRUN_TEST(exc_sigsys);
+  CHECKRUN_TEST(syscall_in_bds);
 
   printf("No user test \"%s\" available.\n", test_name);
   return 1;

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -25,8 +25,7 @@ int test_misbehave() {
   return 0;
 }
 
-/* Should return -1 and set errno to ENOSYS == 38 (as in Linux) */
-int test_exc_sigsys(void){
+int test_exc_sigsys(void) {
   int retval = 0;
   asm volatile("li $v0, 250;"
                "syscall;"
@@ -34,7 +33,7 @@ int test_exc_sigsys(void){
                : "=m"(retval)
                :
                : "memory", "v0");
-               
+
   assert(retval == -1);
   assert(errno == ENOSYS);
   return 0;

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -27,11 +27,12 @@ int test_misbehave() {
 
 int test_exc_sigsys(void) {
   int retval = 0;
-  asm volatile("li $v0, 250;"
+  int sysnum = 9999; /* large enough to be never implemented */
+  asm volatile("li $v0, %1;"
                "syscall;"
                "sw $v0, %0"
                : "=m"(retval)
-               :
+               : "i"(sysnum)
                : "memory", "v0");
 
   assert(retval == -1);

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -24,3 +24,10 @@ int test_misbehave() {
 
   return 0;
 }
+
+// TODO not working
+int test_exc_sigsys(void){
+  asm volatile("li $v0, 13;"
+               "syscall");
+  return 0;
+}

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -25,6 +25,7 @@ int test_misbehave() {
   return 0;
 }
 
+/* Should return -1 and set errno to ENOSYS == 38 (as in Linux) */
 int test_exc_sigsys(void){
   int retval = 0;
   asm volatile("li $v0, 250;"

--- a/user/utest/misbehave.c
+++ b/user/utest/misbehave.c
@@ -25,9 +25,16 @@ int test_misbehave() {
   return 0;
 }
 
-// TODO not working
 int test_exc_sigsys(void){
-  asm volatile("li $v0, 13;"
-               "syscall");
+  int retval = 0;
+  asm volatile("li $v0, 250;"
+               "syscall;"
+               "sw $v0, %0"
+               : "=m"(retval)
+               :
+               : "memory", "v0");
+               
+  assert(retval == -1);
+  assert(errno == ENOSYS);
   return 0;
 }

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -34,7 +34,7 @@ int test_fstat(void);
 
 int test_exc_cop_unusable(void);
 int test_exc_reserved_instruction(void);
-int test_exc_fpe(void);
+int test_exc_integer_overflow(void);
 int test_exc_sigsys(void);
 int test_exc_unaligned_access(void);
 int test_syscall_in_bds(void);

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -34,6 +34,9 @@ int test_fstat(void);
 
 int test_exc_cop_unusable(void);
 int test_exc_reserved_instruction(void);
+int test_exc_fpe(void);
+int test_exc_unaligned_access(void);
 int test_syscall_in_bds(void);
+
 
 #endif /* __UTEST_H__ */

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -35,7 +35,7 @@ int test_fstat(void);
 int test_exc_cop_unusable(void);
 int test_exc_reserved_instruction(void);
 int test_exc_fpe(void);
-int test_exc_sigsys(void)
+int test_exc_sigsys(void);
 int test_exc_unaligned_access(void);
 int test_syscall_in_bds(void);
 

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -39,5 +39,4 @@ int test_exc_sigsys(void);
 int test_exc_unaligned_access(void);
 int test_syscall_in_bds(void);
 
-
 #endif /* __UTEST_H__ */

--- a/user/utest/utest.h
+++ b/user/utest/utest.h
@@ -35,6 +35,7 @@ int test_fstat(void);
 int test_exc_cop_unusable(void);
 int test_exc_reserved_instruction(void);
 int test_exc_fpe(void);
+int test_exc_sigsys(void)
 int test_exc_unaligned_access(void);
 int test_syscall_in_bds(void);
 


### PR DESCRIPTION
* refactored   `test_exc_cop_unusable()`, `test_exc_reserved_instruction()`, `test_syscall_in_bds()`
* implemented tests: floating point exception, unaligned access, ENOSYS