### PR TITLE
Allow for multiple tests to be specified on the command line + non-default repeat for user-specified tests

### DIFF
--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -2,6 +2,8 @@
 #include <stdc.h>
 #include <time.h>
 
+SET_DECLARE(tests, test_entry_t);
+
 /* Borrowed from mips/malta.c */
 char *kenv_get(const char *key);
 
@@ -145,7 +147,6 @@ static void run_all_tests(void) {
 
   /* Count the number of tests that may be run in an arbitrary order. */
   unsigned int n = 0;
-  SET_DECLARE(tests, test_entry_t);
   test_entry_t **ptr;
   SET_FOREACH(ptr, tests) {
     if (test_is_autorunnable(*ptr))

--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -62,15 +62,19 @@ void ktest_failure(void) {
   panic("Halting kernel on failed test.\n");
 }
 
-static test_entry_t *find_test_by_name(const char *test) {
-  SET_DECLARE(tests, test_entry_t);
+static test_entry_t *find_test_by_name_with_len(const char *test, size_t len) {
   test_entry_t **ptr;
   SET_FOREACH(ptr, tests) {
-    if (strcmp((*ptr)->test_name, test) == 0) {
+    if (strlen((*ptr)->test_name) == len &&
+        strncmp((*ptr)->test_name, test, len) == 0) {
       return *ptr;
     }
   }
   return NULL;
+}
+
+static test_entry_t *find_test_by_name(const char *test) {
+  return find_test_by_name_with_len(test, strlen(test));
 }
 
 typedef int (*test_func_t)(unsigned);

--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -8,6 +8,11 @@ SET_DECLARE(tests, test_entry_t);
 char *kenv_get(const char *key);
 
 #define KTEST_MAX_NO 1024
+#define KTEST_FAIL(args...)                                                    \
+  do {                                                                         \
+    kprintf(args);                                                             \
+    ktest_atomically_print_failure();                                          \
+  } while (0)
 
 /* Stores currently running test data. */
 static test_entry_t *current_test = NULL;
@@ -159,10 +164,9 @@ static void run_all_tests(void) {
 
   int total_tests = n * ktest_repeat;
   if (total_tests > KTEST_MAX_NO + 1) {
-    kprintf("Warning: There are more kernel tests registered than there is "
-            "memory available for ktest framework. Please increase "
-            "KTEST_MAX_NO.\n");
-    ktest_atomically_print_failure();
+    KTEST_FAIL("Warning: There are more kernel tests registered than there is "
+               "memory available for ktest framework. Please increase "
+               "KTEST_MAX_NO.\n");
     return;
   }
 

--- a/sys/ktest.c
+++ b/sys/ktest.c
@@ -2,8 +2,6 @@
 #include <stdc.h>
 #include <time.h>
 
-SET_DECLARE(tests, test_entry_t);
-
 /* Borrowed from mips/malta.c */
 char *kenv_get(const char *key);
 
@@ -14,6 +12,8 @@ char *kenv_get(const char *key);
     ktest_atomically_print_failure();                                          \
   } while (0)
 
+/* Linker set that stores all kernel tests. */
+SET_DECLARE(tests, test_entry_t);
 /* Stores currently running test data. */
 static test_entry_t *current_test = NULL;
 /* A null-terminated array of pointers to the tested test list. */
@@ -21,8 +21,8 @@ static test_entry_t *autorun_tests[KTEST_MAX_NO] = {NULL};
 
 int ktest_test_running_flag = 0;
 
-static uint32_t ktest_seed =
-  0; /* The initial seed, as set from command-line. */
+/* The initial seed, as set from command-line. */
+static uint32_t ktest_seed = 0;
 static uint32_t ktest_repeat = 1; /* Number of repetitions of each test. */
 static unsigned seed = 0;         /* Current seed */
 
@@ -217,7 +217,7 @@ static void run_specified_tests(const char *test) {
   while (1) {
     size_t len = strcspn(cur, ","); /* Find first comma or end of string. */
     test_entry_t *t = find_test_by_name_with_len(cur, len);
-    int is_last = *(cur + len) == '\0';
+    int is_last = cur[len] == '\0';
     if (t) {
       if (test_is_autorunnable(t)) {
         for (unsigned r = 0; r < ktest_repeat; r++)
@@ -237,9 +237,8 @@ static void run_specified_tests(const char *test) {
       return;
     }
     if (is_last)
-      break; /* This was the last test name. */
-    else
-      cur += len + 1; /* Skip comma. */
+      break;        /* This was the last test name. */
+    cur += len + 1; /* Skip comma. */
   }
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,12 +19,17 @@ listed below:
 * `test=TEST` - Requests the kernel to run the specified test.
   `test=user_{name}` to run single user test, `test={name}` to run single kernel
   test.
+  You can specify multiple tests by separating their names with commas (without spaces),
+  e.g. `test=test1,test2,test3`
 * `test=all` - Runs a number of tests one after another, and reports success
   only when all of them passed.
 * `seed=UINT` - Sets the RNG seed for shuffling the list of test when using
   `test=all`.
 * `repeat=UINT` - Specifies the number of (shuffled) repetitions of each test
   when using `test=all`.
+  When running user-specified tests (i.e. when `test` is not equal to `all`),
+  `repeat` specifies the number of times each test will be run. For example,
+  `test=test1,test2 repeat=4` will run `test1` 4 times and then run `test2` 4 times.
 
 ### Programming tests
 


### PR DESCRIPTION
The user can now specify multiple specific tests to be run, e.g. `test=findspace,user_pmap`.
It is now also possible to specify a repeat count for tests other than `all`, so for example `test=findspace,user_pmap repeat=2` will first run `findspace` 2 times, and then run `user_pmap` 2 times.

