### PR TITLE
added flag PF_ZERO

### DIFF
--- a/include/pool.h
+++ b/include/pool.h
@@ -8,6 +8,8 @@ typedef struct pool *pool_t;
 typedef void (*pool_ctor_t)(void *);
 typedef void (*pool_dtor_t)(void *);
 
+#define PF_ZERO 0x1 /* fill allocated space with zeros */
+
 void pool_bootstrap(void);
 
 pool_t pool_create(const char *desc, size_t size, pool_ctor_t ctor,

--- a/sys/pool.c
+++ b/sys/pool.c
@@ -154,8 +154,7 @@ static void destroy_slab_list(pool_t pool, pool_slabs_t *slabs) {
   }
 }
 
-/* TODO: find some use for flags */
-void *pool_alloc(pool_t pool, __unused unsigned flags) {
+void *pool_alloc(pool_t pool, unsigned flags) {
   debug("pool_alloc: pool=%p", pool);
 
   SCOPED_MTX_LOCK(&pool->pp_mtx);
@@ -181,6 +180,11 @@ void *pool_alloc(pool_t pool, __unused unsigned flags) {
                           ? &pool->pp_part_slabs
                           : &pool->pp_full_slabs;
   LIST_INSERT_HEAD(slabs, slab, ph_slablist);
+
+  if (flags & PF_ZERO) {
+    memset(p, 0, pool->pp_itemsize);
+  }
+
   return p;
 }
 


### PR DESCRIPTION
Having flag which tells pool allocator to returned memory with zeros, is simpler and more elegant way, than clearing data structure fields one by one in constructor. 