### PR TITLE
Add PT access procedures & simplify tlb_refill

### DIFF
--- a/mips/ebase.S
+++ b/mips/ebase.S
@@ -38,15 +38,6 @@ _ebase:
 # the consumer, not just after the producer.
 
 tlb_refill:
-        # Consider special case when an access to page table region was from
-        # the kernel (namely pmap module). As UPD & KPD are not mapped within
-        # page table we have to deal with it separately :(
-
-        mfc0    k0, C0_BADVADDR
-        srl     k1, k0, PT_SIZE_BITS
-        addi    k1, k1, -(PT_BASE >> PT_SIZE_BITS)
-        beqz    k1, pt_access
-        nop
 
         mfc0    k0, C0_CONTEXT
         sra     k0, 1
@@ -115,27 +106,6 @@ irq:
         la      k1, mips_intr_handler
         j       exc_enter
         mfc0    k0, C0_STATUS           # (delay slot) load status register
-
-pt_access:
-        # If we're accessing the user part of the PT, take PDE from UPD.
-        # Otherwise lookup in KPD. Preconditions: k0 == BadVAddr.
-
-        lui     k1, %hi(PT_BASE)
-        subu    k1, k0, k1              # k1 = offset into PT (22 bits)
-        srl     k0, k1, 21              # k0 = if <accessing user part> then 0 else 1
-        sll     k0, PTE_SHIFT           # k0 = if <accessing user part> then 0 else PAGESIZE
-        srl     k1, PTE_SHIFT + 1       # k1 = index of even PDE in pair / 2
-        sll     k1, 3                   # k1 = offset into PD
-        addu    k0, k1, k0
-        lui     k1, %hi(PD_BASE)
-        addu    k0, k1, k0
-        lw      k1, 0(k0)               # Load even PDE.
-        mtc0    k1, C0_ENTRYLO0
-        lw      k1, 4(k0)               # Load odd PDE.
-        mtc0    k1, C0_ENTRYLO1
-        ehb
-        tlbwr
-        eret
 
 miss:
         # Find PDE mapping the Page Table Fragment we want to access.

--- a/mips/pmap.c
+++ b/mips/pmap.c
@@ -199,7 +199,7 @@ bool pmap_is_mapped(pmap_t *pmap, vm_addr_t vaddr) {
   assert(is_aligned(vaddr, PAGESIZE));
   SCOPED_MTX_LOCK(&pmap->mtx);
   if (is_valid(PDE_OF(pmap, vaddr)))
-    if (is_valid(PTE_OF(pmap, vaddr)))
+    if (is_valid(pmap_pte_read(pmap, vaddr)))
       return true;
   return false;
 }
@@ -214,7 +214,7 @@ static bool _pmap_is_range_mapped(pmap_t *pmap, vm_addr_t start,
       return false;
 
   for (addr = start; addr < end; addr += PTF_ENTRIES * PAGESIZE)
-    if (!is_valid(PTE_OF(pmap, addr)))
+    if (!is_valid(pmap_pte_read(pmap, addr)))
       return false;
 
   return true;
@@ -239,9 +239,20 @@ static void pmap_add_pde(pmap_t *pmap, vm_addr_t vaddr) {
 
   PDE_OF(pmap, vaddr) = PTE_PFN(pg->paddr) | PTE_KERNEL;
 
-  pte_t *pte = (pte_t *)PTF_ADDR_OF(vaddr);
-  for (int i = 0; i < PTF_ENTRIES; i++)
-    pte[i] = PTE_GLOBAL;
+  vm_addr_t addr = vaddr & ~((1 << PDE_SHIFT) - 1);
+  vm_addr_t end = addr + (1 << PDE_SHIFT);
+
+  /*
+   * We don't want to call pmap_pte_write with a PD address,
+   * as a call to tlb_invalidate would overwrite wired TLB entries!
+   */
+  if (addr == PD_BASE)
+    addr = PD_BASE + 2 * PD_SIZE;
+
+  while (addr < end) {
+    pmap_pte_write(pmap, addr, PTE_GLOBAL);
+    addr += PAGESIZE;
+  }
 }
 
 /* TODO: implement */
@@ -275,38 +286,27 @@ static pte_t vm_prot_map[] = {
 /* TODO: what about caches? */
 static void pmap_set_pte(pmap_t *pmap, vm_addr_t vaddr, pm_addr_t paddr,
                          vm_prot_t prot) {
-  if (!is_valid(PDE_OF(pmap, vaddr)))
-    pmap_add_pde(pmap, vaddr);
-
-  PTE_OF(pmap, vaddr) = PTE_PFN(paddr) | vm_prot_map[prot] |
-                        (in_kernel_space(vaddr) ? PTE_GLOBAL : 0);
+  pmap_pte_write(pmap, vaddr, PTE_PFN(paddr) | vm_prot_map[prot] |
+                                (in_kernel_space(vaddr) ? PTE_GLOBAL : 0));
   klog("Add mapping for page %08lx (PTE at %08lx)", (vaddr & PTE_MASK),
        (vm_addr_t)&PTE_OF(pmap, vaddr));
-
-  /* invalidate corresponding entry in tlb */
-  tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
 }
 
 /* TODO: what about caches? */
 static void pmap_clear_pte(pmap_t *pmap, vm_addr_t vaddr) {
-  PTE_OF(pmap, vaddr) = 0;
+  pmap_pte_write(pmap, vaddr, 0);
   klog("Remove mapping for page %08lx (PTE at %08lx)", (vaddr & PTE_MASK),
        (vm_addr_t)&PTE_OF(pmap, vaddr));
-  /* invalidate corresponding entry in tlb */
-  tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
 
   /* TODO: Deallocate empty page table fragment by calling pmap_remove_pde. */
 }
 
 /* TODO: what about caches? */
 static void pmap_change_pte(pmap_t *pmap, vm_addr_t vaddr, vm_prot_t prot) {
-  PTE_OF(pmap, vaddr) =
-    (PTE_OF(pmap, vaddr) & ~PTE_PROT_MASK) | vm_prot_map[prot];
+  pmap_pte_write(pmap, vaddr, (pmap_pte_read(pmap, vaddr) & ~PTE_PROT_MASK) |
+                                vm_prot_map[prot]);
   klog("Change protection bits for page %08lx (PTE at %08lx)",
        (vaddr & PTE_MASK), (vm_addr_t)&PTE_OF(pmap, vaddr));
-
-  /* invalidate corresponding entry in tlb */
-  tlb_invalidate(PTE_VPN2(vaddr) | PTE_ASID(pmap->asid));
 }
 
 /*
@@ -323,7 +323,7 @@ bool pmap_probe(pmap_t *pmap, vm_addr_t start, vm_addr_t end, vm_prot_t prot) {
   pte_t expected = vm_prot_map[prot];
   SCOPED_MTX_LOCK(&pmap->mtx);
   while (start < end) {
-    pte_t pte = is_valid(PDE_OF(pmap, start)) ? PTE_OF(pmap, start) : 0;
+    pte_t pte = is_valid(PDE_OF(pmap, start)) ? pmap_pte_read(pmap, start) : 0;
     tlbentry_t e = {.hi = PTE_VPN2(start) | PTE_ASID(pmap->asid)};
 
     int i = tlb_probe(&e);


### PR DESCRIPTION
- Add `pmap_pte_read` and `pmap_pte_write` which don't generate TLB misses on PT access.
- Remove code handling PT accesses from `tlb_refill`