### PR TITLE
Map sleepq interface onto condvar interface

### DIFF
--- a/include/condvar.h
+++ b/include/condvar.h
@@ -16,8 +16,30 @@ void cv_init(condvar_t *cv, const char *name);
 #define cv_destroy(m)
 
 void cv_wait(condvar_t *cv, mtx_t *mtx);
+
+/* \brief Wait interruptibly on a condvar.
+ *
+ * Interruptible sleep may be interrupted by incoming signals.
+ *
+ * \returns 0 if the thread was awoken normally (`sleepq_signal`, `_broadcast`)
+ * \returns EINTR if the thread was interrupted by a signal during the sleep
+ */
 int cv_wait_intr(condvar_t *cv, mtx_t *mtx);
+
+/* \brief Wait on a condvar with timeout.
+ *
+ * Timed sleep is also interruptible. The only guarantee about timeout is that
+ * the thread's sleep will not timeout before the given time passes. It may
+ * happen any time after that point.
+ *
+ * \arg timeout The timeout in system ticks. One tick is 1ms as of writing.
+ *
+ * \returns 0 if the thread was awoken normally (`sleepq_signal`, `_broadcast`)
+ * \returns EINTR if the thread was interrupted by a signal during the sleep
+ * \returns ETIMEDOUT if the sleep timed out.
+ */
 int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout);
+
 void cv_signal(condvar_t *cv);
 void cv_broadcast(condvar_t *cv);
 

--- a/include/condvar.h
+++ b/include/condvar.h
@@ -16,7 +16,7 @@ typedef struct mtx mtx_t;
  *       the string? (in case the string is dynamically allocated but it
  *       doesn't really have a reason to be)
  */
-/* \brief Initialize a condvar.
+/*! \brief Initialize a condvar.
  *
  * Any condvar must be initialized before use.
  *
@@ -32,40 +32,41 @@ void cv_init(condvar_t *cv, const char *name);
  */
 #define cv_destroy(m)
 
+/*! \brief Wait on a conditional variable. */
 void cv_wait(condvar_t *cv, mtx_t *mtx);
 
-/* \brief Wait interruptibly on a condvar.
+/*! \brief Wait on a conditional variable with possiblity of being interrupted.
  *
- * Interruptible sleep may be interrupted by incoming signals.
- *
- * \returns 0 if the thread was awoken normally (`sleepq_signal`, `_broadcast`)
- * \returns EINTR if the thread was interrupted by a signal during the sleep
+ * \returns 0 if the thread was awoken normally (`cv_signal` or `cv_broadcast`)
+ * \returns EINTR if the thread was interrupted during the sleep
  */
-int cv_wait_intr(condvar_t *cv, mtx_t *mtx);
+#define cv_wait_intr(cv, mtx) cv_wait_timed((cv), (mtx), 0)
 
-/* \brief Wait on a condvar with timeout.
+/*! \brief Wait on a conditional variable with timeout.
  *
  * Timed sleep is also interruptible. The only guarantee about timeout is that
  * the thread's sleep will not timeout before the given time passes. It may
  * happen any time after that point.
  *
- * \arg timeout The timeout in system ticks. One tick is 1ms as of writing.
+ * \arg timeout The timeout in system ticks, if 0 waits indefinitely.
  *
- * \returns 0 if the thread was awoken normally (`sleepq_signal`, `_broadcast`)
+ * \returns 0 if the thread was awoken normally (`cv_signal`, `cv_broadcast`)
  * \returns EINTR if the thread was interrupted by a signal during the sleep
  * \returns ETIMEDOUT if the sleep timed out.
  */
 int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout);
 
-/* \brief Wake a single thread waiting on the condvar.
+/*! \brief Wake a single thread waiting on the condvar.
  *
  * If there are multiple waiting threads then the one with the highest priority
- * will be woken up (dependence on `sleepq_signal`).
- */
+ * will be woken up.
+ *
+ * \sa sleepq_signal */
 void cv_signal(condvar_t *cv);
 
-/* \brief Wake all threads waiting on the condvar.
- */
+/*! \brief Wake all threads waiting on a conditional variable.
+ *
+ * \sa sleepq_broadcast */
 void cv_broadcast(condvar_t *cv);
 
 #endif /* !_SYS_CONDVAR_H_ */

--- a/include/condvar.h
+++ b/include/condvar.h
@@ -1,6 +1,10 @@
 #ifndef _SYS_CONDVAR_H_
 #define _SYS_CONDVAR_H_
 
+#include <common.h>
+// TODO we include it just for sq_wakeup_t. Maybe we should define cv_wakeup_t?
+#include <sleepq.h>
+
 typedef struct condvar {
   const char *name;
   int waiters;
@@ -14,6 +18,8 @@ void cv_init(condvar_t *cv, const char *name);
 #define cv_destroy(m)
 
 void cv_wait(condvar_t *cv, mtx_t *mtx);
+sq_wakeup_t cv_wait_intr(condvar_t *cv, mtx_t *mtx);
+sq_wakeup_t cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout_ms);
 void cv_signal(condvar_t *cv);
 void cv_broadcast(condvar_t *cv);
 

--- a/include/condvar.h
+++ b/include/condvar.h
@@ -17,7 +17,7 @@ void cv_init(condvar_t *cv, const char *name);
 
 void cv_wait(condvar_t *cv, mtx_t *mtx);
 int cv_wait_intr(condvar_t *cv, mtx_t *mtx);
-int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout_ms);
+int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout);
 void cv_signal(condvar_t *cv);
 void cv_broadcast(condvar_t *cv);
 

--- a/include/condvar.h
+++ b/include/condvar.h
@@ -3,32 +3,24 @@
 
 #include <common.h>
 
-/* \todo document this? */
 typedef struct condvar {
-  const char *name;
-  int waiters;
+  const char *name;     /*!< name for debugging purpose */
+  volatile int waiters; /*!< # of threads sleeping in associated sleep queue */
 } condvar_t;
 
 typedef struct mtx mtx_t;
 
-/* \todo is the block alignment correct for Doxygen?
- * \todo should we mention that none of the functions here will deallocate
- *       the string? (in case the string is dynamically allocated but it
- *       doesn't really have a reason to be)
- */
-/*! \brief Initialize a condvar.
+/*! \brief Initialize a conditional variable.
  *
  * Any condvar must be initialized before use.
  *
- * \arg name Name of the condvar for debugging purposes. Only the pointer to
- *           the string is stored so don't modify the string after passing it
- *           to a condvar.
- * \arg cv Pointer to the structure that's initialized.
+ * \arg cv Pointer to the structure that's going to be initialized.
+ * \arg name Pointer to statically (!) allocated string.
  */
 void cv_init(condvar_t *cv, const char *name);
 
-/* \brief I don't know what it's supposed to do because it does nothing.
- * \todo Make conditional variable unusable after it has been destroyed.
+/*! \brief Make conditional variable unusable after it has been destroyed.
+ * XXX Do we really need it?
  */
 #define cv_destroy(m)
 
@@ -44,19 +36,15 @@ void cv_wait(condvar_t *cv, mtx_t *mtx);
 
 /*! \brief Wait on a conditional variable with timeout.
  *
- * Timed sleep is also interruptible. The only guarantee about timeout is that
- * the thread's sleep will not timeout before the given time passes. It may
- * happen any time after that point.
- *
  * \arg timeout The timeout in system ticks, if 0 waits indefinitely.
  *
  * \returns 0 if the thread was awoken normally (`cv_signal`, `cv_broadcast`)
- * \returns EINTR if the thread was interrupted by a signal during the sleep
- * \returns ETIMEDOUT if the sleep timed out.
+ * \returns EINTR if the thread was interrupted during the sleep
+ * \returns ETIMEDOUT if the sleep timed out
  */
 int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout);
 
-/*! \brief Wake a single thread waiting on the condvar.
+/*! \brief Wake a single thread waiting on a conditional variable.
  *
  * If there are multiple waiting threads then the one with the highest priority
  * will be woken up.

--- a/include/condvar.h
+++ b/include/condvar.h
@@ -3,6 +3,7 @@
 
 #include <common.h>
 
+/* \todo document this? */
 typedef struct condvar {
   const char *name;
   int waiters;
@@ -10,9 +11,25 @@ typedef struct condvar {
 
 typedef struct mtx mtx_t;
 
+/* \todo is the block alignment correct for Doxygen?
+ * \todo should we mention that none of the functions here will deallocate
+ *       the string? (in case the string is dynamically allocated but it
+ *       doesn't really have a reason to be)
+ */
+/* \brief Initialize a condvar.
+ *
+ * Any condvar must be initialized before use.
+ *
+ * \arg name Name of the condvar for debugging purposes. Only the pointer to
+ *           the string is stored so don't modify the string after passing it
+ *           to a condvar.
+ * \arg cv Pointer to the structure that's initialized.
+ */
 void cv_init(condvar_t *cv, const char *name);
 
-/* TODO: Make conditional variable unusable after it has been destroyed. */
+/* \brief I don't know what it's supposed to do because it does nothing.
+ * \todo Make conditional variable unusable after it has been destroyed.
+ */
 #define cv_destroy(m)
 
 void cv_wait(condvar_t *cv, mtx_t *mtx);
@@ -40,7 +57,15 @@ int cv_wait_intr(condvar_t *cv, mtx_t *mtx);
  */
 int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout);
 
+/* \brief Wake a single thread waiting on the condvar.
+ *
+ * If there are multiple waiting threads then the one with the highest priority
+ * will be woken up (dependence on `sleepq_signal`).
+ */
 void cv_signal(condvar_t *cv);
+
+/* \brief Wake all threads waiting on the condvar.
+ */
 void cv_broadcast(condvar_t *cv);
 
 #endif /* !_SYS_CONDVAR_H_ */

--- a/include/condvar.h
+++ b/include/condvar.h
@@ -2,8 +2,6 @@
 #define _SYS_CONDVAR_H_
 
 #include <common.h>
-// TODO we include it just for sq_wakeup_t. Maybe we should define cv_wakeup_t?
-#include <sleepq.h>
 
 typedef struct condvar {
   const char *name;
@@ -18,8 +16,8 @@ void cv_init(condvar_t *cv, const char *name);
 #define cv_destroy(m)
 
 void cv_wait(condvar_t *cv, mtx_t *mtx);
-sq_wakeup_t cv_wait_intr(condvar_t *cv, mtx_t *mtx);
-sq_wakeup_t cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout_ms);
+int cv_wait_intr(condvar_t *cv, mtx_t *mtx);
+int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout_ms);
 void cv_signal(condvar_t *cv);
 void cv_broadcast(condvar_t *cv);
 

--- a/include/sleepq.h
+++ b/include/sleepq.h
@@ -32,7 +32,11 @@ void sleepq_wait(void *wchan, const void *waitpt);
 
 /*! \brief Performs interruptible sleep with timeout.
  *
- * \param timeout in system ticks. 0 is no timeout.
+ * Timed sleep is also interruptible. The only guarantee about timeout is that
+ * the thread's sleep will not timeout before the given time passes. It may
+ * happen any time after that point.
+ *
+ * \param timeout in system ticks, if 0 waits indefinitely
  * \returns how the thread was actually woken up */
 int sleepq_wait_timed(void *wchan, const void *waitpt, systime_t timeout);
 

--- a/include/sleepq.h
+++ b/include/sleepq.h
@@ -35,25 +35,27 @@ void sleepq_destroy(sleepq_t *sq);
  * \param waitpt caller associated with sleep action
  */
 #define sleepq_wait(wchan, waitpt)                                             \
-  ((void)_sleepq_wait(wchan, waitpt, SQ_NORMAL))
+  ((void)_sleepq_wait(wchan, waitpt, SQ_NORMAL, 0))
 
 /*! \brief Same as \a sleepq_wait but allows the sleep to be aborted. */
 #define sleepq_wait_abortable(wchan, waitpt)                                   \
-  (_sleepq_wait(wchan, waitpt, SQ_ABORT))
+  (_sleepq_wait(wchan, waitpt, SQ_ABORT, 0))
 
-/*! \brief Puts a thread to sleep until it's woken up or its sleep is aborted.
+/*! \brief Puts a thread to sleep until it's woken up, its sleep is aborted or
+ *         the time runs out.
  *
  * If sleep is abortable other threads can wake up forcefully the thread with \a
  * sleepq_abort procedure.
  */
-sq_wakeup_t _sleepq_wait(void *wchan, const void *waitpt, sq_wakeup_t sleep);
+sq_wakeup_t _sleepq_wait(void *wchan, const void *waitpt, sq_wakeup_t sleep,
+                         systime_t timeout);
 
 /*! \brief Performs abortable sleep with timeout.
  *
- * \param timeout in system ticks must be greater than 0
+ * \param timeout in system ticks. 0 is no timeout.
  * \returns how the thread was actually woken up */
-sq_wakeup_t sleepq_wait_timed(void *wchan, const void *waitpt,
-                              systime_t timeout_ms);
+#define sleepq_wait_timed(wchan, waitpt, timeout)                              \
+  _sleepq_wait(wchan, waitpt, SQ_TIMEOUT, timeout)
 
 /*! \brief Wakes up highest priority thread waiting on \a wchan.
  *

--- a/include/sleepq.h
+++ b/include/sleepq.h
@@ -9,15 +9,6 @@ typedef struct sleepq sleepq_t;
 
 /*! \file sleepq.h */
 
-/*! \typedef sq_wakeup_t
- * \brief Sleeping mode or wakeup reason.
- *
- * Used to return reason of wakeup from `_sleepq_wait` and select sleeping mode
- * in `_sleepq_wait`. For sleeping purposes given mode implies former modes,
- * i.e. sleep with timeout (`SQ_TIMEOUT`) is also interruptible (`SQ_INTR`).
- */
-typedef enum { SQ_NORMAL = 0, SQ_INTR = 1, SQ_TIMEOUT = 2 } sq_wakeup_t;
-
 /*! \brief Initializes sleep queues.
  *
  * \warning To be called only from early kernel initialization! */
@@ -43,8 +34,7 @@ void sleepq_wait(void *wchan, const void *waitpt);
  *
  * \param timeout in system ticks. 0 is no timeout.
  * \returns how the thread was actually woken up */
-sq_wakeup_t sleepq_wait_timed(void *wchan, const void *waitpt,
-                              systime_t timeout);
+int sleepq_wait_timed(void *wchan, const void *waitpt, systime_t timeout);
 
 /*! \brief Wakes up highest priority thread waiting on \a wchan.
  *

--- a/sys/condvar.c
+++ b/sys/condvar.c
@@ -20,6 +20,8 @@ static int errno_of_sq_wakeup(sq_wakeup_t s) {
   panic("Unexpected value of sq_wakeup_t");
 }
 
+/* If we exposed this function outside, we would have to
+ * expose `sq_wakeup_t` and whole sleepq stuff as well. */
 static int _cv_wait(condvar_t *cv, mtx_t *mtx, sq_wakeup_t wkp, systime_t tm) {
   sq_wakeup_t status;
   WITH_NO_PREEMPTION {
@@ -31,14 +33,17 @@ static int _cv_wait(condvar_t *cv, mtx_t *mtx, sq_wakeup_t wkp, systime_t tm) {
   return errno_of_sq_wakeup(status);
 }
 
+/* Can't make this a macro because _cv_wait is static */
 void cv_wait(condvar_t *cv, mtx_t *mtx) {
   _cv_wait(cv, mtx, SQ_NORMAL, 0);
 }
 
+/* Can't make this a macro because _cv_wait is static */
 int cv_wait_intr(condvar_t *cv, mtx_t *mtx) {
   return _cv_wait(cv, mtx, SQ_ABORT, 0);
 }
 
+/* Can't make this a macro because _cv_wait is static */
 int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout) {
   return _cv_wait(cv, mtx, SQ_TIMEOUT, timeout);
 }

--- a/sys/condvar.c
+++ b/sys/condvar.c
@@ -9,16 +9,7 @@ void cv_init(condvar_t *cv, const char *name) {
   cv->waiters = 0;
 }
 
-static int errno_of_sq_wakeup(sq_wakeup_t s) {
-  if (s == SQ_NORMAL)
-    return 0;
-  if (s == SQ_TIMEOUT)
-    return ETIMEDOUT;
-  if (s == SQ_ABORT)
-    return EINTR;
-
-  panic("Unexpected value of sq_wakeup_t");
-}
+static int errno_of_sq_wakeup(sq_wakeup_t s);
 
 /* If we exposed this function outside, we would have to
  * expose `sq_wakeup_t` and whole sleepq stuff as well. */
@@ -31,6 +22,17 @@ static int _cv_wait(condvar_t *cv, mtx_t *mtx, sq_wakeup_t wkp, systime_t tm) {
   }
   _mtx_lock(mtx, __caller(0));
   return errno_of_sq_wakeup(status);
+}
+
+static int errno_of_sq_wakeup(sq_wakeup_t s) {
+  if (s == SQ_NORMAL)
+    return 0;
+  if (s == SQ_TIMEOUT)
+    return ETIMEDOUT;
+  if (s == SQ_ABORT)
+    return EINTR;
+
+  panic("Unexpected value of sq_wakeup_t");
 }
 
 /* Can't make this a macro because _cv_wait is static */

--- a/sys/condvar.c
+++ b/sys/condvar.c
@@ -40,12 +40,12 @@ int cv_wait_intr(condvar_t *cv, mtx_t *mtx) {
   return errno_of_sq_wakeup(status);
 }
 
-int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout_ms) {
+int cv_wait_timed(condvar_t *cv, mtx_t *mtx, systime_t timeout) {
   sq_wakeup_t status;
   WITH_NO_PREEMPTION {
     cv->waiters++;
     mtx_unlock(mtx);
-    status = sleepq_wait_timed(cv, __caller(0), timeout_ms);
+    status = sleepq_wait_timed(cv, __caller(0), timeout);
   }
   _mtx_lock(mtx, __caller(0));
   return errno_of_sq_wakeup(status);

--- a/sys/sleepq.c
+++ b/sys/sleepq.c
@@ -9,6 +9,7 @@
 #include <spinlock.h>
 #include <thread.h>
 #include <interrupt.h>
+#include <errno.h>
 #include <callout.h>
 
 #define SC_TABLESIZE 256 /* Must be power of 2. */
@@ -23,6 +24,14 @@ typedef struct sleepq_chain {
   spinlock_t sc_lock;
   TAILQ_HEAD(, sleepq) sc_queues; /*!< list of sleep queues */
 } sleepq_chain_t;
+
+/*! \brief Sleeping mode.
+ *
+ * Used to select sleeping mode in `_sleepq_wait`. For sleeping purposes given
+ * mode implies former modes, i.e. sleep with timeout (`SLP_TIMED`) is also
+ * interruptible (`SLP_INTR`).
+ */
+typedef enum { SLP_NORMAL = 0, SLP_INTR = 1, SLP_TIMED = 2 } sleep_t;
 
 static sleepq_chain_t sleepq_chains[SC_TABLESIZE];
 
@@ -113,7 +122,7 @@ static sleepq_t *sq_lookup(sleepq_chain_t *sc, void *wchan) {
 }
 
 static void sq_enter(thread_t *td, void *wchan, const void *waitpt,
-                     sq_wakeup_t sleep) {
+                     sleep_t sleep) {
   klog("Thread %ld goes to sleep on %p at pc=%p", td->td_tid, wchan, waitpt);
 
   assert(td->td_wchan == NULL);
@@ -154,9 +163,9 @@ static void sq_enter(thread_t *td, void *wchan, const void *waitpt,
      * sched_switch - it may get interrupted on the way, so mark our intent. */
     td->td_flags |= TDF_SLEEPY;
 
-    if (sleep >= SQ_INTR)
+    if (sleep >= SLP_INTR)
       td->td_flags |= TDF_SLPINTR;
-    if (sleep >= SQ_TIMEOUT)
+    if (sleep >= SLP_TIMED)
       td->td_flags |= TDF_SLPTIMED;
   }
 
@@ -200,15 +209,14 @@ static void sq_leave(thread_t *td, sleepq_chain_t *sc, sleepq_t *sq) {
   }
 }
 
-static sq_wakeup_t _sleepq_wait(void *wchan, const void *waitpt,
-                                sq_wakeup_t mode) {
+static int _sleepq_wait(void *wchan, const void *waitpt, sleep_t sleep) {
   thread_t *td = thread_self();
-  sq_wakeup_t wakeup = SQ_NORMAL;
+  int status = 0;
 
   if (waitpt == NULL)
     waitpt = __caller(0);
 
-  sq_enter(td, wchan, waitpt, mode);
+  sq_enter(td, wchan, waitpt, sleep);
 
   /* The code can be interrupted in here.
    * A race is avoided by clever use of TDF_SLEEPY flag. */
@@ -224,36 +232,36 @@ static sq_wakeup_t _sleepq_wait(void *wchan, const void *waitpt,
      *  - TDF_SLPTIMED if sleep has timed out. */
     if (td->td_flags & TDF_SLPINTR) {
       td->td_flags &= ~TDF_SLPINTR;
-      wakeup = SQ_INTR;
+      status = EINTR;
     } else if (td->td_flags & TDF_SLPTIMED) {
       td->td_flags &= ~TDF_SLPTIMED;
-      wakeup = SQ_TIMEOUT;
+      status = ETIMEDOUT;
     }
   }
 
-  return wakeup;
+  return status;
 }
 
 /* Remove a thread from the sleep queue and resume it. */
 static bool sq_wakeup(thread_t *td, sleepq_chain_t *sc, sleepq_t *sq,
-                      sq_wakeup_t wakeup) {
+                      int wakeup) {
   /* Only sq_enter sets TDF_SLP... flags and it holds the same sleepq spinlock
    * as sq_wakeup. Hence it's safe to read flags without holding thread's
    * spinlock. */
 
   /* Do not try to abort thread's sleep if it's not prepared for that. */
-  if ((wakeup == SQ_INTR) && !(td->td_flags & TDF_SLPINTR))
+  if ((wakeup == EINTR) && !(td->td_flags & TDF_SLPINTR))
     return false;
-  if ((wakeup == SQ_TIMEOUT) && !(td->td_flags & TDF_SLPTIMED))
+  if ((wakeup == ETIMEDOUT) && !(td->td_flags & TDF_SLPTIMED))
     return false;
 
   sq_leave(td, sc, sq);
 
   WITH_SPINLOCK(td->td_spin) {
     /* Clear TDF_SLPINTR flag if thread's sleep was not aborted. */
-    if (wakeup != SQ_INTR)
+    if (wakeup != EINTR)
       td->td_flags &= ~TDF_SLPINTR;
-    if (wakeup != SQ_TIMEOUT)
+    if (wakeup != ETIMEDOUT)
       td->td_flags &= ~TDF_SLPTIMED;
     /* Do not try to wake up a thread that is sleepy but did not fall asleep! */
     if (td->td_flags & TDF_SLEEPY) {
@@ -281,7 +289,7 @@ bool sleepq_signal(void *wchan) {
       best_td = td;
   }
 
-  sq_wakeup(best_td, sc, sq, SQ_NORMAL);
+  sq_wakeup(best_td, sc, sq, SLP_NORMAL);
   sq_release(sq);
   sc_release(sc);
 
@@ -300,7 +308,7 @@ bool sleepq_broadcast(void *wchan) {
 
   thread_t *td;
   TAILQ_FOREACH (td, &sq->sq_blocked, td_sleepq)
-    sq_wakeup(td, sc, sq, SQ_NORMAL);
+    sq_wakeup(td, sc, sq, SLP_NORMAL);
   sq_release(sq);
   sc_release(sc);
 
@@ -308,7 +316,7 @@ bool sleepq_broadcast(void *wchan) {
   return true;
 }
 
-static bool _sleepq_abort(thread_t *td, sq_wakeup_t reason) {
+static bool _sleepq_abort(thread_t *td, int reason) {
   sleepq_chain_t *sc = sc_acquire(td->td_wchan);
   sleepq_t *sq = sq_lookup(sc, td->td_wchan);
   bool aborted = false;
@@ -327,28 +335,28 @@ static bool _sleepq_abort(thread_t *td, sq_wakeup_t reason) {
 }
 
 bool sleepq_abort(thread_t *td) {
-  return _sleepq_abort(td, SQ_INTR);
+  return _sleepq_abort(td, EINTR);
 }
 
 void sleepq_wait(void *wchan, const void *waitpt) {
-  (void)_sleepq_wait(wchan, waitpt, SQ_NORMAL);
+  int status = _sleepq_wait(wchan, waitpt, 0);
+  assert(status == 0);
 }
 
 static void sq_timeout(thread_t *td) {
-  _sleepq_abort(td, SQ_TIMEOUT);
+  _sleepq_abort(td, ETIMEDOUT);
 }
 
-sq_wakeup_t sleepq_wait_timed(void *wchan, const void *waitpt,
-                              systime_t timeout) {
+int sleepq_wait_timed(void *wchan, const void *waitpt, systime_t timeout) {
   callout_t co;
-  sq_wakeup_t reason = SQ_NORMAL;
+  int status = 0;
   WITH_INTR_DISABLED {
     if (timeout > 0)
       callout_setup_relative(&co, timeout, (timeout_t)sq_timeout,
                              thread_self());
-    reason = _sleepq_wait(wchan, waitpt, SQ_TIMEOUT);
+    status = _sleepq_wait(wchan, waitpt, timeout ? SLP_TIMED : SLP_INTR);
   }
   if (timeout > 0)
     callout_stop(&co);
-  return reason;
+  return -status; /* FIXME errno number in kernel are still negative */
 }

--- a/tests/sleepq_abort.c
+++ b/tests/sleepq_abort.c
@@ -33,9 +33,9 @@ static volatile int interrupted;
  * when waiters can't.
  * Therefore there should be only one waiter active at once */
 static void waiter_routine(void *_arg) {
-  int rsn = sleepq_wait_abortable(&some_val, __caller(0));
+  int rsn = sleepq_wait_intr(&some_val, __caller(0));
 
-  if (rsn == SQ_ABORT)
+  if (rsn == SQ_INTR)
     interrupted++;
   else if (rsn == SQ_NORMAL)
     wakened_gracefully++;

--- a/tests/sleepq_abort.c
+++ b/tests/sleepq_abort.c
@@ -1,6 +1,7 @@
 #include <sleepq.h>
 #include <runq.h>
 #include <ktest.h>
+#include <errno.h>
 #include <sched.h>
 
 #define T 6
@@ -35,9 +36,9 @@ static volatile int interrupted;
 static void waiter_routine(void *_arg) {
   int rsn = sleepq_wait_intr(&some_val, __caller(0));
 
-  if (rsn == SQ_INTR)
+  if (rsn == -EINTR)
     interrupted++;
-  else if (rsn == SQ_NORMAL)
+  else if (rsn == 0)
     wakened_gracefully++;
   else
     panic("unknown wakeup reason: %d", rsn);

--- a/tests/sleepq_timed.c
+++ b/tests/sleepq_timed.c
@@ -47,7 +47,7 @@ static void waiter_routine(void *_arg) {
 static void waker_routine(void *_arg) {
   /* try to wake up half of the threads before timeout */
   for (int i = 0; i < THREADS / 2; i++) {
-    bool status = sleepq_signal(&wchan);
+    bool status = sleepq_abort(waiters[i]);
     if (status)
       signaled_sent++;
   }

--- a/tests/sleepq_timed.c
+++ b/tests/sleepq_timed.c
@@ -37,7 +37,7 @@ static void waiter_routine(void *_arg) {
   if (status == -ETIMEDOUT) {
     timed_received++;
     assert(diff >= SLEEP_TICKS);
-  } else if (status == -EINTR) {
+  } else if (status == 0) {
     signaled_received++;
   } else {
     panic("Got unexpected wakeup status: %d!", status);
@@ -47,7 +47,7 @@ static void waiter_routine(void *_arg) {
 static void waker_routine(void *_arg) {
   /* try to wake up half of the threads before timeout */
   for (int i = 0; i < THREADS / 2; i++) {
-    bool status = sleepq_abort(waiters[i]);
+    bool status = sleepq_signal(&wchan);
     if (status)
       signaled_sent++;
   }


### PR DESCRIPTION
We added interruptible and timed sleep. In this PR we expose it through a higher-level `condvar` interface.