### PR TITLE
Specify clang-format version in Makefile

### DIFF
--- a/.circleci/image/Dockerfile
+++ b/.circleci/image/Dockerfile
@@ -16,4 +16,3 @@ RUN wget http://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.2_amd64.deb
 RUN dpkg -i mipsel-mimiker-elf_1.2_amd64.deb
 RUN wget http://mimiker.ii.uni.wroc.pl/download/qemu-system-mimiker_2.12.0-1_amd64.deb
 RUN dpkg -i qemu-system-mimiker_2.12.0-1_amd64.deb
-RUN ln -s /usr/bin/clang-format-6.0 /usr/local/bin/clang-format

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ FORMATTABLE = $(filter-out $(FORMATTABLE_EXCLUDE),$(SOURCES_C))
 
 format:
 	@echo "Formatting files: $(FORMATTABLE:./%=%)"
-	clang-format -style=file -i $(FORMATTABLE)
+	clang-format-6.0 -style=file -i $(FORMATTABLE)
 
 test: mimiker.elf
 	./run_tests.py


### PR DESCRIPTION
`clang-format-6.0` instead of `clang-format`, so wrong one will rise error.

Removed making symbolic link in Dockerfile, because it is not necessay now.