### PR TITLE
Alignment correction in exeve arguments roll-in function

### DIFF
--- a/sys/exec.c
+++ b/sys/exec.c
@@ -32,6 +32,7 @@ static inline void buffer_advance(buffer_t *buf, size_t len) {
 static inline void buffer_align(buffer_t *buf, size_t align) {
   intptr_t last_data = (intptr_t)buf->data;
   buf->data = align(buf->data, align);
+  assert((long long)buf->nleft >= (intptr_t)buf->data - last_data);
   buf->nleft -= (intptr_t)buf->data - last_data;
 }
 
@@ -87,6 +88,8 @@ int exec_args_copyin(exec_args_t *exec_args, char *user_path, char **user_argv,
   buf->nleft = PATH_MAX;
   if ((error = buffer_copyin_str(buf, user_path, &exec_args->prog_name)))
     return error;
+
+  buffer_align(buf, PTR_SIZE);
 
   buf->nleft = ARG_MAX;
   if ((error = buffer_copyin_strv(buf, user_argv, &exec_args->argv)))

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -84,18 +84,16 @@ static int buffer_copyin_strv(buffer_t *buf, char **user_strv, char ***strv_p) {
 int exec_args_copyin(exec_args_t *exec_args, char *user_path, char **user_argv,
                      char **user_envp) {
   int error;
-  buffer_t *buf = &(buffer_t){.data = exec_args->data};
+  buffer_t buf;
 
-  buf->nleft = PATH_MAX;
-  if ((error = buffer_copyin_str(buf, user_path, &exec_args->prog_name)))
+  buf = (buffer_t){.data = exec_args->data, .nleft = PATH_MAX};
+  if ((error = buffer_copyin_str(&buf, user_path, &exec_args->prog_name)))
     return error;
 
-  buffer_align(buf, PTR_SIZE);
-
-  buf->nleft = ARG_MAX;
-  if ((error = buffer_copyin_strv(buf, user_argv, &exec_args->argv)))
+  buf = (buffer_t){.data = exec_args->data + PATH_MAX, .nleft = ARG_MAX};
+  if ((error = buffer_copyin_strv(&buf, user_argv, &exec_args->argv)))
     return error;
-  if ((error = buffer_copyin_strv(buf, user_envp, &exec_args->envp)))
+  if ((error = buffer_copyin_strv(&buf, user_envp, &exec_args->envp)))
     return error;
   return 0;
 }

--- a/sys/exec.c
+++ b/sys/exec.c
@@ -32,8 +32,9 @@ static inline void buffer_advance(buffer_t *buf, size_t len) {
 static inline void buffer_align(buffer_t *buf, size_t align) {
   intptr_t last_data = (intptr_t)buf->data;
   buf->data = align(buf->data, align);
-  assert((long long)buf->nleft >= (intptr_t)buf->data - last_data);
-  buf->nleft -= (intptr_t)buf->data - last_data;
+  size_t padding = (intptr_t)buf->data - last_data;
+  assert(buf->nleft >= padding);
+  buf->nleft -= padding;
 }
 
 static int buffer_copyin_ptr(buffer_t *buf, char **user_ptr_p) {

--- a/sys/proc.c
+++ b/sys/proc.c
@@ -165,7 +165,8 @@ noreturn void proc_exit(int exitstatus) {
 
     /* When the process is dead we can finally signal the parent. */
     proc_t *parent = p->p_parent;
-    assert(parent != NULL);
+    if (!parent)
+      panic("'init' process died!");
 
     klog("Wakeup PID(%d) because child PID(%d) died", parent->p_pid, p->p_pid);
 


### PR DESCRIPTION
A `buffer_t` structure used by `exec_args_copyin` needs more alignment.