### PR TITLE
Fix group id in Dockerfile

### DIFF
--- a/docker/Dockerfile.tpl
+++ b/docker/Dockerfile.tpl
@@ -5,7 +5,8 @@ FROM cahirwpz/mimiker-circleci:1.6
 RUN addgroup --gid ${MIMIKER_GID} mimiker && \
     adduser --uid ${MIMIKER_UID} --disabled-password \
     --gecos "" --force-badname \
-    --ingroup mimiker --ingroup sudo mimiker
+    --ingroup mimiker mimiker && \
+    adduser mimiker sudo
 
 WORKDIR /home/mimiker
 


### PR DESCRIPTION
`--ingroup` option allowed only one GID (https://manpages.debian.org/jessie/adduser/adduser.8.en.html)
so user was added only to `sudo` group

Previously files inside container were created with `sudo` group.

before:
```
_  mimiker git:(master) _ id
uid=1000(mimiker) gid=27(sudo) groups=27(sudo)
```
after:
```
_  mimiker git:(master) _ id
uid=1000(mimiker) gid=1000(mimiker) groups=1000(mimiker),27(sudo)

```