### PR TITLE
Include more swap file extension types in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ etags
 assym.h
 
 # Editor swap files
-*.swp
+*.sw[a-p]
 
 # Temporary test data
 tests/*_test_files


### PR DESCRIPTION
After failing to create *.swp file, vim might create other *.swX
files which will make mess in the repository

Reference: http://vimdoc.sourceforge.net/htmldoc/recover.html#swap-file