### PR TITLE
Define name and unit fields for a device and provide related functions

### DIFF
--- a/drv/atkbdc.c
+++ b/drv/atkbdc.c
@@ -188,7 +188,7 @@ extern device_t *gt_pci;
 
 static void atkbdc_init(void) {
   vnodeops_init(&scancode_vnodeops);
-  (void)make_device(gt_pci, &atkbdc_driver);
+  (void)make_device(gt_pci, &atkbdc_driver, "atkbdc", 0x60);
 }
 
 SYSINIT_ADD(atkbdc, atkbdc_init, DEPS("rootdev"));

--- a/drv/ns16550.c
+++ b/drv/ns16550.c
@@ -168,7 +168,7 @@ static driver_t ns16550_driver = {
 extern device_t *gt_pci;
 
 static void ns16550_init(void) {
-  (void)make_device(gt_pci, &ns16550_driver);
+  (void)make_device(gt_pci, &ns16550_driver, "serial", 0x3f8);
 }
 
 SYSINIT_ADD(ns16550, ns16550_init, DEPS("rootdev"));

--- a/drv/pit.c
+++ b/drv/pit.c
@@ -147,7 +147,7 @@ static driver_t pit_driver = {
 extern device_t *gt_pci;
 
 static void pit_init(void) {
-  (void)make_device(gt_pci, &pit_driver);
+  (void)make_device(gt_pci, &pit_driver, "pit", 0x40);
 }
 
 SYSINIT_ADD(pit, pit_init, DEPS("rootdev"));

--- a/drv/rtc.c
+++ b/drv/rtc.c
@@ -123,7 +123,7 @@ extern device_t *gt_pci;
 
 static void rtc_init(void) {
   vnodeops_init(&rtc_time_vnodeops);
-  (void)make_device(gt_pci, &rtc_driver);
+  (void)make_device(gt_pci, &rtc_driver, "rtc", 0x70);
 }
 
 SYSINIT_ADD(rtc, rtc_init, DEPS("rootdev"));

--- a/include/device.h
+++ b/include/device.h
@@ -68,7 +68,7 @@ void device_add_resource(device_t *dev, resource_t *r, int rid);
 int device_get_fullname(device_t *dev, char *buff, int size);
 
 /* Construct device's full path to the root store it in \buff */
-void device_construct_fullpath(device_t *dev, char* buff, size_t size);
+void device_construct_fullpath(device_t *dev, char *buff, size_t size);
 
 /* A universal memory pool to be used by all drivers. */
 MALLOC_DECLARE(M_DEV);

--- a/include/device.h
+++ b/include/device.h
@@ -17,6 +17,9 @@ typedef int (*d_probe_t)(device_t *dev);
 typedef int (*d_attach_t)(device_t *dev);
 typedef int (*d_detach_t)(device_t *dev);
 
+#define MAX_DEV_NAME_LEN 32
+#define PATHBUF_LEN 100
+
 struct driver {
   const char *desc;      /* short driver description */
   size_t size;           /* device->state object size */
@@ -39,6 +42,8 @@ struct device {
   res_list_t resources;     /* head of resources belonging to this device */
 
   /* Device information and state. */
+  int unit;
+  char *name;
   device_bus_t bus;
   driver_t *driver;
   void *instance; /* used by bus driver to store data in children */
@@ -50,13 +55,20 @@ int device_probe(device_t *dev);
 int device_attach(device_t *dev);
 int device_detach(device_t *dev);
 
-/* Manually create a device with given driver and parent device. */
-device_t *make_device(device_t *parent, driver_t *driver);
+/* Create a device with given \parent device, \driver
+ * and set device's \name and \unit  */
+device_t *make_device(device_t *parent, driver_t *driver, char *name, int unit);
 
 /*! \brief Prepares and adds a resource to a device.
  *
  * \note Mostly used in bus drivers. */
 void device_add_resource(device_t *dev, resource_t *r, int rid);
+
+/* Construct device's full name and store it in \buff */
+int device_get_fullname(device_t *dev, char *buff, int size);
+
+/* Construct device's full path to the root store it in \buff */
+void device_construct_fullpath(device_t *dev, char* buff, size_t size);
 
 /* A universal memory pool to be used by all drivers. */
 MALLOC_DECLARE(M_DEV);

--- a/mips/rootdev.c
+++ b/mips/rootdev.c
@@ -37,6 +37,9 @@ static int rootdev_attach(device_t *dev) {
 
   gt_pci = device_add_child(dev);
   gt_pci->driver = &gt_pci_bus.driver;
+  // TODO: Is it the right place to provide name and unit?
+  gt_pci->name = "pci";
+  gt_pci->unit = 0;
   if (device_probe(gt_pci))
     device_attach(gt_pci);
   return 0;
@@ -100,6 +103,9 @@ static device_t rootdev = (device_t){
   .driver = (driver_t *)&rootdev_driver,
   .instance = &(rootdev_t){},
   .state = NULL,
+  .parent = NULL,
+  .name = "root",
+  .unit = 0,
 };
 
 static void rootdev_init(void) {

--- a/sys/device.c
+++ b/sys/device.c
@@ -46,7 +46,8 @@ int device_detach(device_t *dev) {
   return res;
 }
 
-device_t *make_device(device_t *parent, driver_t *driver, char *name, int unit) {
+device_t *make_device(device_t *parent, driver_t *driver, char *name,
+                      int unit) {
   assert(strlen(name) < MAX_DEV_NAME_LEN);
   device_t *dev = device_add_child(parent);
   dev->driver = driver;
@@ -64,23 +65,23 @@ void device_add_resource(device_t *dev, resource_t *r, int rid) {
 }
 
 int device_get_fullname(device_t *dev, char *buff, int size) {
-    assert(dev != NULL);
-    return snprintf(buff, size, "%s@%d", dev->name, dev->unit);
+  assert(dev != NULL);
+  return snprintf(buff, size, "%s@%d", dev->name, dev->unit);
 }
 
-static void _device_construct_fullpath_aux(device_t *dev, char* buff, size_t size) {
-    if (dev == NULL || !strcmp(dev->name, "root"))
-        return;
-    char dev_name_buff[MAX_DEV_NAME_LEN];
-    device_get_fullname(dev, dev_name_buff, MAX_DEV_NAME_LEN);
+static void _construct_fullpath_aux(device_t *dev, char *buff, size_t size) {
+  if (dev == NULL || !strcmp(dev->name, "root"))
+    return;
+  char dev_name_buff[MAX_DEV_NAME_LEN];
+  device_get_fullname(dev, dev_name_buff, MAX_DEV_NAME_LEN);
 
-    char tmp_buff[PATHBUF_LEN];
-    snprintf(tmp_buff, size, "/%s%s", dev_name_buff, buff);
-    snprintf(buff, size, "%s", tmp_buff);
-    _device_construct_fullpath_aux(dev->parent, buff, size);
+  char tmp_buff[PATHBUF_LEN];
+  snprintf(tmp_buff, size, "/%s%s", dev_name_buff, buff);
+  snprintf(buff, size, "%s", tmp_buff);
+  _construct_fullpath_aux(dev->parent, buff, size);
 }
 
-void device_construct_fullpath(device_t *dev, char* buff, size_t size) {
-    buff[0] = '\0';
-    _device_construct_fullpath_aux(dev, buff, size);
+void device_construct_fullpath(device_t *dev, char *buff, size_t size) {
+  buff[0] = '\0';
+  _construct_fullpath_aux(dev, buff, size);
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,6 +4,8 @@ SOURCES = \
 	broken.c \
 	callout.c \
 	crash.c \
+	devclass.c \
+	device.c \
 	klog.c \
 	linker_set.c \
 	malloc.c \
@@ -29,7 +31,6 @@ SOURCES = \
 	uiomove.c \
 	utest.c \
 	vm_map.c \
-	devclass.c \
 	vfs.c
 
 include $(TOPDIR)/build/build.kobj.mk

--- a/tests/device.c
+++ b/tests/device.c
@@ -6,24 +6,24 @@
 extern device_t *gt_pci;
 
 static int test_device_get_fullname(void) {
-    // TODO: This test depends on the fact that gt_pci exists
-    char *expected_name = "pci@0";
-    char name_buff[MAX_DEV_NAME_LEN];
-    device_get_fullname(gt_pci, name_buff, MAX_DEV_NAME_LEN);
+  // TODO: This test depends on the fact that gt_pci exists
+  char *expected_name = "pci@0";
+  char name_buff[MAX_DEV_NAME_LEN];
+  device_get_fullname(gt_pci, name_buff, MAX_DEV_NAME_LEN);
 
-    assert(strcmp(name_buff, expected_name) == 0);
+  assert(strcmp(name_buff, expected_name) == 0);
 
-    return KTEST_SUCCESS;
+  return KTEST_SUCCESS;
 }
 
 static int test_device_construct_fullpath(void) {
-    // TODO: This test depends on the fact that gt_pci exists
-    // TODO: Test more complex paths
-    char *expected_path = "/pci@0";
-    char path_buff[PATHBUF_LEN];
-    device_construct_fullpath(gt_pci, path_buff, PATHBUF_LEN);
-    assert(strcmp(path_buff, expected_path) == 0);
-    return KTEST_SUCCESS;
+  // TODO: This test depends on the fact that gt_pci exists
+  // TODO: Test more complex paths
+  char *expected_path = "/pci@0";
+  char path_buff[PATHBUF_LEN];
+  device_construct_fullpath(gt_pci, path_buff, PATHBUF_LEN);
+  assert(strcmp(path_buff, expected_path) == 0);
+  return KTEST_SUCCESS;
 }
 
 KTEST_ADD(device_get_fullname, test_device_get_fullname, 0);

--- a/tests/device.c
+++ b/tests/device.c
@@ -1,0 +1,30 @@
+#include <stdc.h>
+#include <ktest.h>
+#include <klog.h>
+#include <device.h>
+
+extern device_t *gt_pci;
+
+static int test_device_get_fullname(void) {
+    // TODO: This test depends on the fact that gt_pci exists
+    char *expected_name = "pci@0";
+    char name_buff[MAX_DEV_NAME_LEN];
+    device_get_fullname(gt_pci, name_buff, MAX_DEV_NAME_LEN);
+
+    assert(strcmp(name_buff, expected_name) == 0);
+
+    return KTEST_SUCCESS;
+}
+
+static int test_device_construct_fullpath(void) {
+    // TODO: This test depends on the fact that gt_pci exists
+    // TODO: Test more complex paths
+    char *expected_path = "/pci@0";
+    char path_buff[PATHBUF_LEN];
+    device_construct_fullpath(gt_pci, path_buff, PATHBUF_LEN);
+    assert(strcmp(path_buff, expected_path) == 0);
+    return KTEST_SUCCESS;
+}
+
+KTEST_ADD(device_get_fullname, test_device_get_fullname, 0);
+KTEST_ADD(device_construct_fullpath, test_device_construct_fullpath, 0);


### PR DESCRIPTION
This change is necessary in order to search for a device in FDT. Names for the devices are based on `malta.dts` file.

* device_get_fullname
* device_construct_fullpath
* Provide tests for the above functions