### PR TITLE
Use proper ENOTSUP value & fix VOP_CALL

### DIFF
--- a/include/sys/errno.h
+++ b/include/sys/errno.h
@@ -148,11 +148,7 @@
 
 /* From IEEE Std 1003.1-2001 */
 /* Base, Realtime, Threads or Thread Priority Scheduling option errors */
-#if 0
 #define ENOTSUP 86 /* Not supported */
-#else
-#define ENOTSUP 134 /* XXX: matches newlib declaration! */
-#endif
 
 /* Realtime option errors */
 #define ECANCELED 87 /* Operation canceled */

--- a/include/sys/errno.h
+++ b/include/sys/errno.h
@@ -179,9 +179,4 @@
 #define ERESTART 257    /* restart syscall */
 #endif
 
-#if !defined(_KERNEL) && !defined(__ASSEMBLER__)
-#define errno (*__errno())
-extern int *__errno(void);
-#endif
-
 #endif /* !_SYS_ERRNO_H_ */

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -94,7 +94,7 @@ typedef struct vattr {
 void va_convert(vattr_t *va, stat_t *sb);
 
 #define VOP_CALL(op, v, ...)                                                   \
-  ((v)->v_ops->v_##op) ? ((v)->v_ops->v_##op(v, __VA_ARGS__)) : -ENOTSUP
+  ((v)->v_ops->v_##op) ? ((v)->v_ops->v_##op(v, __VA_ARGS__)) : ENOTSUP
 
 static inline int VOP_LOOKUP(vnode_t *dv, const char *name, vnode_t **vp) {
   return VOP_CALL(lookup, dv, name, vp);

--- a/lib/libc/sys/signal.c
+++ b/lib/libc/sys/signal.c
@@ -1,4 +1,4 @@
-#include <sys/errno.h>
+#include <errno.h>
 #include <signal.h>
 
 sig_t signal(int sig, sig_t handler) {


### PR DESCRIPTION
* Change `ENOTSUP` from 134 (newlib) to 86 (NetBSD)
* `VOP_CALL` now returns `ENOTSUP` instead of `-ENOTSUP`