### PR TITLE
Change VOP_READDIR so that it returns 0 on success

### DIFF
--- a/sys/kern/vfs_readdir.c
+++ b/sys/kern/vfs_readdir.c
@@ -37,5 +37,5 @@ int readdir_generic(vnode_t *v, uio_t *uio, readdir_ops_t *ops) {
       return -error;
   }
 
-  return uio->uio_offset - offset;
+  return 0;
 }

--- a/sys/kern/vfs_readdir.c
+++ b/sys/kern/vfs_readdir.c
@@ -33,8 +33,8 @@ int readdir_generic(vnode_t *v, uio_t *uio, readdir_ops_t *ops) {
     ops->convert(v, it, dir);
     error = uiomove(dir, reclen, uio);
     kfree(M_TEMP, dir);
-    if (error < 0)
-      return -error;
+    if (error)
+      return error;
   }
 
   return 0;


### PR DESCRIPTION
This PR:
* changes successful return value of `readdir_generic()` from `uio->uio_offset - offset` to `0`.

Why:
* `VOP_READDIR` should return 0 or error code (https://netbsd.gw.com/cgi-bin/man-cgi?VOP_LOOKUP+9+NetBSD-6.0+i386), and our `VOP_READDIR` is implemented by calling `readdir_generic()`.

