### PR TITLE
Fix return value of sys_getdirentries

### DIFF
--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -380,6 +380,7 @@ static int sys_getdirentries(proc_t *p, getdirentries_args_t *args,
     if ((error = copyout_s(base, u_basep)))
       return error;
 
+  *res = len - uio.uio_resid;
   return 0;
 }
 


### PR DESCRIPTION
**This PR fixes `ls` application.**

* Currently `sys_getdirentires()` returns 0 on success.
* According to https://netbsd.gw.com/cgi-bin/man-cgi?getdirentries+3+NetBSD-current, the return value should be:
   > If successful, the number of bytes actually transferred is returned.