### PR TITLE
Add sigaction tests that i.a. check returning from signal handler

### DIFF
--- a/bin/utest/Makefile
+++ b/bin/utest/Makefile
@@ -14,6 +14,7 @@ SOURCES = \
 	signal.c \
 	stat.c \
 	setjmp.c \
+	sigaction.c \
 	utest.c
 
 PROGRAM = utest

--- a/bin/utest/main.c
+++ b/bin/utest/main.c
@@ -51,6 +51,8 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(exc_sigsys);
   CHECKRUN_TEST(syscall_in_bds);
   CHECKRUN_TEST(setjmp);
+  CHECKRUN_TEST(sigaction_with_setjmp);
+  CHECKRUN_TEST(sigaction_handler_returns);
 
   CHECKRUN_TEST(fpu_fcsr);
   CHECKRUN_TEST(fpu_gpr_preservation);

--- a/bin/utest/setjmp.c
+++ b/bin/utest/setjmp.c
@@ -9,8 +9,9 @@
 
 static jmp_buf jump_buffer;
 
-noreturn void do_longjmp(int count) {
+noreturn static void do_longjmp(int count) {
   longjmp(jump_buffer, count);
+  assert(0); /* Shouldn't reach here. */
 }
 
 int test_setjmp(void) {

--- a/bin/utest/sigaction.c
+++ b/bin/utest/sigaction.c
@@ -34,7 +34,7 @@ static void sigusr1_handler(int signo) {
 
 int test_sigaction_handler_returns(void) {
   struct sigaction sa;
-  
+
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sigusr1_handler;
   assert(sigaction(SIGUSR1, &sa, NULL) == 0);

--- a/bin/utest/sigaction.c
+++ b/bin/utest/sigaction.c
@@ -4,10 +4,10 @@
 #include <setjmp.h>
 #include <stdnoreturn.h>
 
-static jmp_buf jump_buffer;
+static sigjmp_buf jump_buffer;
 
 noreturn static void sigint_handler(int signo) {
-  longjmp(jump_buffer, 1);
+  siglongjmp(jump_buffer, 42);
   assert(0); /* Shouldn't reach here. */
 }
 
@@ -18,7 +18,7 @@ int test_sigaction_with_setjmp(void) {
   sa.sa_handler = sigint_handler;
   assert(sigaction(SIGINT, &sa, NULL) == 0);
 
-  if (setjmp(jump_buffer) != 1) {
+  if (sigsetjmp(jump_buffer, 1) != 42) {
     raise(SIGINT);
     assert(0); /* Shouldn't reach here. */
   }

--- a/bin/utest/sigaction.c
+++ b/bin/utest/sigaction.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+#include <signal.h>
+#include <string.h>
+#include <setjmp.h>
+#include <stdnoreturn.h>
+
+static jmp_buf jump_buffer;
+
+noreturn static void sigint_handler(int signo) {
+  longjmp(jump_buffer, 1);
+  assert(0); /* Shouldn't reach here. */
+}
+
+int test_sigaction_with_setjmp(void) {
+  struct sigaction sa;
+
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = sigint_handler;
+  assert(sigaction(SIGINT, &sa, NULL) == 0);
+
+  if (setjmp(jump_buffer) != 1) {
+    raise(SIGINT);
+    assert(0); /* Shouldn't reach here. */
+  }
+
+  return 0;
+}
+
+static volatile int sigusr1_handled;
+
+static void sigusr1_handler(int signo) {
+  sigusr1_handled = 1;
+}
+
+int test_sigaction_handler_returns(void) {
+  struct sigaction sa;
+  
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = sigusr1_handler;
+  assert(sigaction(SIGUSR1, &sa, NULL) == 0);
+
+  assert(sigusr1_handled == 0);
+  raise(SIGUSR1);
+  assert(sigusr1_handled == 1);
+
+  return 0;
+}

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -55,4 +55,7 @@ int test_syscall_in_bds(void);
 
 int test_setjmp(void);
 
+int test_sigaction_with_setjmp(void);
+int test_sigaction_handler_returns(void);
+
 #endif /* __UTEST_H__ */

--- a/sys/mips/signal.c
+++ b/sys/mips/signal.c
@@ -55,7 +55,6 @@ int sig_send(signo_t sig, sigaction_t *sa) {
    * before the stored context! */
   uframe->sp = (register_t)((intptr_t *)scp - 1);
   /* Also, make sure the restorer runs when the handler exits. */
-  assert(sa->sa_restorer != NULL);
   uframe->ra = (register_t)sa->sa_restorer;
 
   return 0;

--- a/sys/mips/signal.c
+++ b/sys/mips/signal.c
@@ -55,6 +55,7 @@ int sig_send(signo_t sig, sigaction_t *sa) {
    * before the stored context! */
   uframe->sp = (register_t)((intptr_t *)scp - 1);
   /* Also, make sure the restorer runs when the handler exits. */
+  assert(sa->sa_restorer != NULL);
   uframe->ra = (register_t)sa->sa_restorer;
 
   return 0;

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -94,6 +94,9 @@ UTEST_ADD_SIMPLE(fstat);
 
 UTEST_ADD_SIMPLE(setjmp);
 
+UTEST_ADD_SIMPLE(sigaction_with_setjmp);
+UTEST_ADD_SIMPLE(sigaction_handler_returns);
+
 #if 0
 UTEST_ADD_SIMPLE(fpu_fcsr);
 UTEST_ADD_SIMPLE(fpu_gpr_preservation);


### PR DESCRIPTION
This PR adds two `sigaction` tests:
* `sigaction_with_setjmp()` -- which checks whether we can jump out of a signal handler using `setjmp()`/`longjmp()`,
* `sigaction_handler_returns()` -- which checks whether returning from a signal handler works,

Currently the aforementioned tests fail since `sa->sa_restorer` is always NULL when we call `sigaction`. That is also the reason why currently `/bin/ksh` keeps getting SIGSEGV.