### PR TITLE
jmp to __sc_error inside SYSCALL is now local

### DIFF
--- a/include/mips/syscall.h
+++ b/include/mips/syscall.h
@@ -27,8 +27,12 @@
   LEAF(name);                                                                  \
   li v0, num;                                                                  \
   syscall;                                                                     \
-  bnez v1, _C_LABEL(__sc_error);                                               \
+  bnez v1, ___sc_error##name;                                                  \
+  nop;                                                                         \
   j ra;                                                                        \
+  nop;                                                                         \
+  ___sc_error##name : j _C_LABEL(__sc_error);                                  \
+  nop;                                                                         \
   END(name)
 
 #endif /* !__ASSEMBLER__ */

--- a/include/mips/syscall.h
+++ b/include/mips/syscall.h
@@ -27,12 +27,9 @@
   LEAF(name);                                                                  \
   li v0, num;                                                                  \
   syscall;                                                                     \
-  bnez v1, ___sc_error##name;                                                  \
-  nop;                                                                         \
+  bnez v1, 1f;                                                                 \
   j ra;                                                                        \
-  nop;                                                                         \
-  ___sc_error##name : j _C_LABEL(__sc_error);                                  \
-  nop;                                                                         \
+  1 : j _C_LABEL(__sc_error);                                                  \
   END(name)
 
 #endif /* !__ASSEMBLER__ */


### PR DESCRIPTION
`bnez` is I-type instruction so it can't jump too far.
That caused failure in build 9010 of pull/578 (#578) on CircleCI.

Now it jumps to local label, and then `j` instruction (J-type) is used to jump further.

