### PR TITLE
Fix log2 function in mimiker.h

### DIFF
--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -15,7 +15,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
-#define log2(x) (__builtin_ffs(x) - 1)
+#define log2(x) (63 - __builtin_clzl(x))
 #define ffs(x) (size_t)(__builtin_ffs(x))
 #define clz(x) (size_t)(__builtin_clz(x))
 #define ctz(x) (size_t)(__builtin_ctz(x))

--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -15,7 +15,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
-#define log2(x) (63 - __builtin_clzl(x))
+#define log2(x) (31 - __builtin_clz(x))
 #define ffs(x) (size_t)(__builtin_ffs(x))
 #define clz(x) (size_t)(__builtin_clz(x))
 #define ctz(x) (size_t)(__builtin_ctz(x))

--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -15,7 +15,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
-#define log2(x) (31 - __builtin_clz(x))
+#define log2(x) (CHAR_BIT * sizeof(unsigned long) - __builtin_clzl(x) - 1)
 #define ffs(x) (size_t)(__builtin_ffs(x))
 #define clz(x) (size_t)(__builtin_clz(x))
 #define ctz(x) (size_t)(__builtin_ctz(x))


### PR DESCRIPTION
Currently our `log2(x)` implementation works fine iff `x` is a power of 2. This PR fixes it.
You can find a simple comparison of old-`log` vs new-`log` here: https://ideone.com/BNRNFU