### PR TITLE
Separate debug symbols in sysroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ usr.bin-before: lib-install
 initrd.cpio: bin-install
 	@echo "[INITRD] Building $@..."
 	cd sysroot && \
-	  find -depth -print | sort | $(CPIO) -o -F ../$@ 2> /dev/null
+	  find -depth \( ! -name "*.dbg" -and -print \) | sort | \
+	    $(CPIO) -o -F ../$@ 2> /dev/null
 
 INSTALL-FILES += initrd.cpio
 CLEAN-FILES += initrd.cpio

--- a/bin/lua/Makefile
+++ b/bin/lua/Makefile
@@ -46,6 +46,10 @@ build-here: patch
 install-here:
 	@echo "[INSTALL] /bin/lua"
 	$(INSTALL) -m 755 lua-5.3.5/src/lua $(SYSROOT)/bin/lua
+	@echo "[OBJCOPY] $(SYSROOT)/bin/lua -> \
+		$(SYSROOT)/bin/lua.dbg"
+	$(OBJCOPY) --only-keep-debug $(SYSROOT)/bin/lua \
+		$(SYSROOT)/bin/lua.dbg
 	@echo "[STRIP] /bin/lua"
 	$(STRIP) --strip-all $(SYSROOT)/bin/lua
 	@echo "[INSTALL] /lib/lua/init.lua"

--- a/build/build.prog.mk
+++ b/build/build.prog.mk
@@ -32,5 +32,9 @@ $(PROGRAM).uelf: $(OBJECTS)
 $(SYSROOT)/bin/$(PROGRAM): $(PROGRAM).uelf
 	@echo "[INSTALL] $(DIR)$< -> /bin/$(PROGRAM)"
 	$(INSTALL) -D $(PROGRAM).uelf $(SYSROOT)/bin/$(PROGRAM)
+	@echo "[OBJCOPY] $(SYSROOT)/bin/$(PROGRAM) -> \
+		$(SYSROOT)/bin/$(PROGRAM).dbg"
+	$(OBJCOPY) --only-keep-debug $(SYSROOT)/bin/$(PROGRAM) \
+		$(SYSROOT)/bin/$(PROGRAM).dbg
 	@echo "[STRIP] /bin/$(PROGRAM)"
 	$(STRIP) --strip-all $(SYSROOT)/bin/$(PROGRAM)


### PR DESCRIPTION
Files with just debug symbols for user-space executables are now placed in `sysroot/bin` - the same path as corresponding executable. They are not packed into initrd.
It makes mapping from mimikerOS executables paths to hostOS symbol files trivial.