### PR TITLE
Read kernel memory while on bp in user-space.

### DIFF
--- a/toolchain/qemu-mimiker/patches/page-table-walk-for-gdb.patch
+++ b/toolchain/qemu-mimiker/patches/page-table-walk-for-gdb.patch
@@ -3,7 +3,29 @@ Index: qemu-mimiker/qemu-4.1.0/target/mips/helper.c
 ===================================================================
 --- qemu-mimiker.orig/qemu-4.1.0/target/mips/helper.c
 +++ qemu-mimiker/qemu-4.1.0/target/mips/helper.c
-@@ -523,16 +523,41 @@ static void raise_mmu_exception(CPUMIPSS
+@@ -36,6 +36,8 @@ enum {
+     TLBRET_MATCH = 0
+ };
+ 
++static int debug_mode = 0;
++
+ #if !defined(CONFIG_USER_ONLY)
+ 
+ /* no MMU emulation */
+@@ -152,8 +154,10 @@ static int is_seg_am_mapped(unsigned int
+         /* fall through */
+     check_ade:
+         /* does this AM cause AdE in current execution mode */
+-        if ((adetlb_mask << am) < 0) {
+-            return TLBRET_BADADDR;
++        if(!debug_mode){
++            if ((adetlb_mask << am) < 0) {
++                return TLBRET_BADADDR;
++            }
+         }
+         adetlb_mask <<= 8;
+         /* fall through */
+@@ -523,18 +527,54 @@ static void raise_mmu_exception(CPUMIPSS
      env->error_code = error_code;
  }
  
@@ -21,8 +43,12 @@ Index: qemu-mimiker/qemu-4.1.0/target/mips/helper.c
      MIPSCPU *cpu = MIPS_CPU(cs);
      CPUMIPSState *env = &cpu->env;
      hwaddr phys_addr;
++    /* Setting EXL==3 just to allow GDB reading kernel memory while
++     * on breakpoint in user-space. */
 +    int mem_idx = cpu_mmu_index(env, false);
++    //int mem_idx = 3;
      int prot;
++    debug_mode = 1;
  
      if (get_physical_address(env, &phys_addr, &prot, addr, 0, ACCESS_INT,
 -                             cpu_mmu_index(env, false)) != 0) {
@@ -34,15 +60,24 @@ Index: qemu-mimiker/qemu-4.1.0/target/mips/helper.c
 +                                 ACCESS_INT, mem_idx) == 0) {
 +            uint32_t pde, pte;
 +            cpu_physical_memory_read(pde_addr, (void *)&pde, sizeof(pde));
-+            if (!VALID(pde))
++            if (!VALID(pde)){
++              debug_mode = 0;
 +              return -1;
++            }
 +            hwaddr pte_addr = PHYSADDR(pde) + PT_INDEX(addr);
 +            cpu_physical_memory_read(pte_addr, (void *)&pte, sizeof(pte));
-+            if (!VALID(pte))
++            if (!VALID(pte)){
++              debug_mode = 0;
 +              return -1;
++            }
++            debug_mode = 0;
 +            return PHYSADDR(pte) + PG_OFFSET(addr);
 +        }
 +
++        debug_mode = 0;
          return -1;
      }
++    debug_mode = 0;
      return phys_addr;
+ }
+ #endif


### PR DESCRIPTION
This patch lets gdb read kernel memory while on bp in user-space. User processes still are not allowed to read kernel memory. This code looks nasty but this is the only working solution among few others.