### PR TITLE
Successfully compile the kernel with Clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ make
 in project root. This will result with a `mimiker.elf` file containing the
 kernel image.
 
+Building the kernel with Clang
+---
+
+You can also choose to build the kernel with the Clang compiler.
+To do so, first make sure you have Clang installed.
+Then, go to project root and run:
+```
+make setup
+make sys-build CLANG=1
+```
+Now you should have the kernel image inside the `sys/` directory.
+To build the rest of the system, simply run:
+```
+make
+```
+in project root. This command won't work if you try to use Clang, but this isn't
+hard to fix.
+
 Running
 ---
 

--- a/build/arch.mips.mk
+++ b/build/arch.mips.mk
@@ -1,8 +1,4 @@
 TARGET := mipsel-mimiker-elf
-ABIFLAGS := -mips32r2 -EL -DELFSIZE=32
+GCC_ABIFLAGS := -mips32r2 -EL -DELFSIZE=32
+CLANG_ABIFLAGS := -target mipsel-elf -march=mips32r2 -mno-abicalls -DELFSIZE=32
 ELFTYPE := elf32-littlemips 
-
-# Pass "CLANG=1" at command line to switch kernel compiler to Clang.
-ifeq ($(CLANG), 1)
-CC = clang -target mipsel-elf -march=mips32r2 -mno-abicalls -g
-endif

--- a/build/arch.mips.mk
+++ b/build/arch.mips.mk
@@ -1,4 +1,4 @@
 TARGET := mipsel-mimiker-elf
 GCC_ABIFLAGS := -mips32r2 -EL -DELFSIZE=32
-CLANG_ABIFLAGS := -target mipsel-elf -march=mips32r2 -mno-abicalls -DELFSIZE=32
+CLANG_ABIFLAGS := -target mipsel-elf -march=mips32r2 -mno-abicalls -modd-spreg -DELFSIZE=32
 ELFTYPE := elf32-littlemips 

--- a/build/common.mk
+++ b/build/common.mk
@@ -38,7 +38,7 @@ DSTPATH = $(DIR)$@
 
 assym.h: genassym.cf
 	@echo "[ASSYM] $(DSTPATH)"
-	$(GENASSYM) $(CC) $(CFLAGS) $(CPPFLAGS) < $^ > $@
+	$(GENASSYM) $(CC) $(ASSYM_CFLAGS) $(CFLAGS) $(CPPFLAGS) < $^ > $@
 
 include $(TOPDIR)/config.mk
 include $(TOPDIR)/build/arch.$(ARCH).mk

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -2,36 +2,29 @@ ifndef ARCH
   $(error ARCH variable not defined. Have you included config.mk?)
 endif
 
-TOOLCHAIN_FOUND = $(shell which $(TARGET)-gcc > /dev/null; echo $$?)
-ifneq ($(TOOLCHAIN_FOUND), 0)
-  $(error $(TARGET) toolchain not found. Please refer to README.md)
+GCC_FOUND = $(shell which $(TARGET)-gcc > /dev/null; echo $$?)
+ifneq ($(GCC_FOUND), 0)
+  $(error $(TARGET)-gcc compiler not found - please refer to README.md!)
 endif
-
-ifeq ($(CLANG), 1)
-CLANG_FOUND = $(shell which clang > /dev/null; echo $$?)
-ifneq ($(CLANG_FOUND), 0)
-  $(error Clang not found. Please refer to README.md)
-endif
-endif
-
-
-TARGET_GCC = $(TARGET)-gcc $(GCC_ABIFLAGS) -g
-TARGET_CLANG = clang $(CLANG_ABIFLAGS) -g
 
 # Pass "CLANG=1" at command line to switch kernel compiler to Clang.
 ifeq ($(CLANG), 1)
-CC_AS = $(TARGET_CLANG)
+CLANG_FOUND = $(shell which clang > /dev/null; echo $$?)
+ifneq ($(CLANG_FOUND), 0)
+  $(error clang compiler not found - please refer to README.md!)
+endif
+TARGET_CC = clang $(CLANG_ABIFLAGS) -g
 # The genassym script produces C code with asm statements that have
 # garbage instructions, which Clang checks using its built-in assembler
 # and refuses to compile. This option disables this check.
 ASSYM_CFLAGS += -no-integrated-as
 else
-CC_AS = $(TARGET_GCC)
+TARGET_CC = $(TARGET)-gcc $(GCC_ABIFLAGS) -g
 endif
 
-CC       = $(CC_AS)
-AS       = $(CC_AS)
-LD       = $(TARGET_GCC)
+CC       = $(TARGET_CC)
+AS       = $(TARGET_CC)
+LD       = $(TARGET)-gcc $(GCC_ABIFLAGS) -g
 AR       = $(TARGET)-ar
 NM       = $(TARGET)-nm
 GDB      = $(TARGET)-gdb

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -7,10 +7,32 @@ ifneq ($(TOOLCHAIN_FOUND), 0)
   $(error $(TARGET) toolchain not found. Please refer to README.md)
 endif
 
-CC       = $(TARGET)-gcc $(ABIFLAGS) -g
+ifeq ($(CLANG), 1)
+CLANG_FOUND = $(shell which clang > /dev/null; echo $$?)
+ifneq ($(CLANG_FOUND), 0)
+  $(error Clang not found. Please refer to README.md)
+endif
+endif
+
+
+TARGET_GCC = $(TARGET)-gcc $(GCC_ABIFLAGS) -g
+TARGET_CLANG = clang $(CLANG_ABIFLAGS) -g
+
+# Pass "CLANG=1" at command line to switch kernel compiler to Clang.
+ifeq ($(CLANG), 1)
+CC_AS = $(TARGET_CLANG)
+# The genassym script produces C code with asm statements that have
+# garbage instructions, which Clang checks using its built-in assembler
+# and refuses to compile. This option disables this check.
+ASSYM_CFLAGS += -no-integrated-as
+else
+CC_AS = $(TARGET_GCC)
+endif
+
+CC       = $(CC_AS)
+AS       = $(CC_AS)
+LD       = $(TARGET_GCC)
 AR       = $(TARGET)-ar
-AS       = $(TARGET)-gcc $(ABIFLAGS) -g
-LD       = $(TARGET)-gcc $(ABIFLAGS) -g
 NM       = $(TARGET)-nm
 GDB      = $(TARGET)-gdb
 RANLIB	 = $(TARGET)-ranlib

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -1,4 +1,4 @@
-#ifndef _INTTYPES_H
+#ifndef _INTTYPES_H_
 #define _INTTYPES_H_
 
 #include <stdint.h>

--- a/include/mips/m32c0.h
+++ b/include/mips/m32c0.h
@@ -875,37 +875,6 @@
 #define C0_KSCRATCH5	$31,6
 #define C0_KSCRATCH6	$31,7
 
-$index		=	$0
-$random		=	$1
-$entrylo0	=	$2
-$entrylo1	=	$3
-$context	=	$4
-$pagemask	=	$5
-$wired		=	$6
-$hwrena		=	$7
-$vaddr 		=	$8
-$badvaddr	=	$8
-$count 		=	$9
-$entryhi	=	$10
-$compare	=	$11
-$sr		=	$12
-$cr		=	$13
-$epc 		=	$14
-$prid		=	$15
-$config		=	$16
-$lladdr		=	$17
-$watchlo	=	$18
-$watchhi	=	$19
-$debug		= 	$23
-$depc		= 	$24
-$perfcnt	= 	$25
-$errctl		=	$26
-$cacheerr	=	$27
-$taglo		=	$28
-$taghi		=	$29
-$errpc		=	$30
-$desave		=	$31
-
 
 #else /* !__ASSEMBLER__ */
 

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -67,7 +67,13 @@
 #define __restrict restrict
 #define __long_call __attribute__((long_call))
 #define __transparent_union __attribute__((__transparent_union__))
+
+/* Clang introduces support for the fallthrough attribute in C2x. */
+#ifdef __clang__
+#define __fallthrough
+#else
 #define __fallthrough __attribute__((fallthrough))
+#endif
 
 /*
  * Compiler-dependent macros to declare that functions take printf-like

--- a/sys/mips/exc.S
+++ b/sys/mips/exc.S
@@ -95,7 +95,7 @@ user_exc_leave:
         # Disable interrupts and extract interrupt mask into t1.
         di      t1
         ehb
-        ext     t1, SR_IMASK_SHIFT, SR_IMASK_BITS
+        ext     t1, t1, SR_IMASK_SHIFT, SR_IMASK_BITS
 
         # Set current stack pointer to user exception frame.
         # This is crucial on first entry to user-space for this thread.
@@ -186,7 +186,7 @@ kern_exc_leave:
         # Disable interrupts and extract interrupt mask into t1.
         di      t1
         ehb
-        ext     t1, SR_IMASK_SHIFT, SR_IMASK_BITS
+        ext     t1, t1, SR_IMASK_SHIFT, SR_IMASK_BITS
 
         # Load status register from exception frame and update it with current
         # interrupt mask.

--- a/sys/mips/sigcode.S
+++ b/sys/mips/sigcode.S
@@ -10,8 +10,8 @@ LEAF_NOPROFILE(sigcode)
         # just in case sigreturn fails
         j 0     # TODO: replace with "break 0" when SIGTRAP is implemented
 
-# Not an alternative entry. Used just to compute size of this code.
-XLEAF(esigcode)
+# esigcode is used just to compute size of this code.
+EXPORT(esigcode)
 END(sigcode)
 
 # vim: sw=8 ts=8 et

--- a/sys/mips/switch.S
+++ b/sys/mips/switch.S
@@ -76,7 +76,7 @@ ctx_resume:
 
         # restore status register with updated interrupt mask
         mfc0    t1, C0_SR
-        ext     t1, SR_IMASK_SHIFT, SR_IMASK_BITS
+        ext     t1, t1, SR_IMASK_SHIFT, SR_IMASK_BITS
         ins     t0, t1, SR_IMASK_SHIFT, SR_IMASK_BITS
         mtc0    t0, C0_SR
 


### PR DESCRIPTION
The entire kernel can now be compiled with Clang by setting the `CLANG` make variable to 1. We still use the GNU linker to link the kernel.
In order to build the whole system with Clang, either some minor adjustments need to be made in a couple of places (due to Clang being a bit more strict with its warnings), or we can turn some warnings off. You can check out a sample warning by running `make CLANG=1` in project root.