### PR TITLE
vmem: comments & simplify vmem_alloc & little refactor

### DIFF
--- a/include/sys/vmem.h
+++ b/include/sys/vmem.h
@@ -10,15 +10,26 @@ typedef struct vmem vmem_t;
 
 /*
  * The following interface is a simplified version of NetBSD's vmem interface.
- * For documentation, please refer to VMEM(9), e.g. here:
+ * For detailed documentation, please refer to VMEM(9), e.g. here:
  * https://netbsd.gw.com/cgi-bin/man-cgi?vmem+9+NetBSD-current
  */
 
+/*! \brief Create a new vmem arena.
+ * Pass non-zero base and size if you need an initial span.
+ * You need to specify quantum, the smallest unit of allocation. */
 vmem_t *vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
                     vmem_size_t quantum);
+
+/*! \brief Add a new address span to the arena. */
 int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size);
+
+/*! \brief Allocate an address segment from the arena. */
 int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp);
+
+/*! \brief Free segment previously allocated by vmem_alloc(). */
 void vmem_free(vmem_t *vm, vmem_addr_t addr, vmem_size_t size);
+
+/*! \brief Destroy existing vmem arena. */
 void vmem_destroy(vmem_t *vm);
 
 #endif /* _SYS_VMEM_H_ */

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -239,7 +239,7 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
   for (vmem_freelist_t *list = first; list < end; list++) {
     bt = LIST_FIRST(list);
     if (bt != NULL) {
-      /* This is INSTANTFIT strategy, we know that any segment found on these
+      /* This is instant-fit strategy, we know that any segment found on these
        * lists is large enough. */
       assert(bt->bt_size >= size);
       found = true;

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -81,10 +81,7 @@ static vmem_freelist_t *bt_freehead_tofree(vmem_t *vm, vmem_size_t size) {
   return &vm->vm_freelist[idx];
 }
 
-/* Returns the freelist for the given size and allocation strategy.
- *
- * For VMEM_INSTANTFIT, returns the list in which any blocks are large enough.
- * For VMEM_BESTFIT, returns the list which can have blocks large enough. */
+/* Returns the freelist in which any block is large enough for allocation */
 static vmem_freelist_t *bt_freehead_toalloc(vmem_t *vm, vmem_size_t size) {
   assert(is_aligned(size, vm->vm_quantum));
   vmem_size_t qsize = size >> vm->vm_quantum_shift;

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -243,7 +243,10 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
   bool found = false;
   for (vmem_freelist_t *list = first; list < end; list++) {
     bt = LIST_FIRST(list);
-    if (bt != NULL && bt->bt_size >= size) {
+    if (bt != NULL) {
+      /* This is INSTANTFIT strategy, we know that any segment found on these
+       * lists is large enough. */
+      assert(bt->bt_size >= size);
       found = true;
       break;
     }

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -29,7 +29,7 @@ typedef struct vmem {
   mtx_t vm_lock;
   size_t vm_size;
   size_t vm_inuse;
-  size_t vm_quantum_mask;
+  size_t vm_quantum;
   int vm_quantum_shift;
   char vm_name[VMEM_NAME_MAX];
   vmem_seglist_t vm_seglist;
@@ -67,7 +67,7 @@ static vmem_freelist_t *bt_freehead_tofree(vmem_t *vm, vmem_size_t size) {
  * For VMEM_INSTANTFIT, returns the list in which any blocks are large enough.
  * For VMEM_BESTFIT, returns the list which can have blocks large enough. */
 static vmem_freelist_t *bt_freehead_toalloc(vmem_t *vm, vmem_size_t size) {
-  assert((size & vm->vm_quantum_mask) == 0);
+  assert(is_aligned(size, vm->vm_quantum));
   vmem_size_t qsize = size >> vm->vm_quantum_shift;
   assert(size != 0 && qsize != 0);
   int idx = SIZE2ORDER(qsize);
@@ -129,20 +129,15 @@ static void bt_insbusy(vmem_t *vm, bt_t *bt) {
   vm->vm_inuse += bt->bt_size;
 }
 
-static vmem_size_t vmem_roundup_size(vmem_t *vm, vmem_size_t size) {
-  return (size + vm->vm_quantum_mask) & ~vm->vm_quantum_mask;
-}
-
-static vmem_addr_t vmem_alignup_addr(vmem_addr_t addr, vmem_size_t align) {
-  return (addr + align - 1) & ~(align - 1);
-}
-
 static void vmem_check_sanity(vmem_t *vm) {
   VMEM_ASSERT_LOCKED(vm);
 
   const bt_t *bt1;
-  TAILQ_FOREACH (bt1, &vm->vm_seglist, bt_seglink)
+  TAILQ_FOREACH (bt1, &vm->vm_seglist, bt_seglink) {
     assert(bt1->bt_start <= bt_end(bt1));
+    assert(bt1->bt_size >= vm->vm_quantum);
+    assert(is_aligned(bt1->bt_start, vm->vm_quantum));
+  }
 
   const bt_t *bt2;
   TAILQ_FOREACH (bt1, &vm->vm_seglist, bt_seglink) {
@@ -156,36 +151,16 @@ static void vmem_check_sanity(vmem_t *vm) {
   }
 }
 
-static int vmem_align_and_fit(const bt_t *bt, vmem_size_t size,
-                              vmem_size_t align, vmem_addr_t *addrp) {
-  assert(size > 0);
-  assert(bt->bt_type == BT_TYPE_FREE);
-  assert(bt->bt_size >= size); /* caller's responsibility */
-
-  vmem_addr_t start = bt->bt_start;
-  vmem_addr_t end = bt_end(bt);
-
-  vmem_addr_t start_aligned = vmem_alignup_addr(start, align);
-  assert(start_aligned >= start);
-  assert((start_aligned & (align - 1)) == 0);
-
-  if (start_aligned <= end && end - start_aligned >= size - 1) {
-    *addrp = start_aligned;
-    return 0;
-  }
-
-  return ENOMEM;
-}
-
 vmem_t *vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
                     vmem_size_t quantum) {
-  assert(quantum > 0);
-
   vmem_t *vm = pool_alloc(P_VMEM, PF_ZERO);
 
-  vm->vm_quantum_mask = quantum - 1;
+  vm->vm_quantum = quantum;
+  assert(quantum > 0);
   vm->vm_quantum_shift = SIZE2ORDER(quantum);
+  /* Check that quantum is a power of 2 */
   assert(ORDER2SIZE(vm->vm_quantum_shift) == quantum);
+
   mtx_init(&vm->vm_lock, 0);
   strlcpy(vm->vm_name, name, sizeof(vm->vm_name));
 
@@ -231,16 +206,11 @@ int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size) {
 }
 
 int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
+  size = align(size, vm->vm_quantum);
   assert(size > 0);
 
-  size = vmem_roundup_size(vm, size);
-  assert(size > 0);
-
-  vmem_size_t align = vm->vm_quantum_mask + 1;
-
-  /* Allocate boundary tags before acquiring the vmem lock */
-  bt_t *btnew_prev = pool_alloc(P_BT, PF_ZERO);
-  bt_t *btnew_next = pool_alloc(P_BT, PF_ZERO);
+  /* Allocate new boundary tag before acquiring the vmem lock */
+  bt_t *btnew = pool_alloc(P_BT, PF_ZERO);
 
   vmem_freelist_t *first = bt_freehead_toalloc(vm, size);
   vmem_freelist_t *end = &vm->vm_freelist[VMEM_MAXORDER];
@@ -249,11 +219,10 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
   vmem_check_sanity(vm);
 
   bt_t *bt;
-  vmem_addr_t start;
   bool found = false;
   for (vmem_freelist_t *list = first; list < end; list++) {
     bt = LIST_FIRST(list);
-    if (bt != NULL && vmem_align_and_fit(bt, size, align, &start) == 0) {
+    if (bt != NULL && bt->bt_size >= size) {
       found = true;
       break;
     }
@@ -261,8 +230,7 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
 
   if (!found) {
     vmem_unlock(vm);
-    pool_free(P_BT, btnew_prev);
-    pool_free(P_BT, btnew_next);
+    pool_free(P_BT, btnew);
     klog("alloc of size %lu for vmem '%s' failed (ENOMEM)", size, vm->vm_name);
     return ENOMEM;
   }
@@ -270,35 +238,19 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
   bt_remfree(vm, bt);
   vmem_check_sanity(vm);
 
-  if (bt->bt_start != start) {
-    /* Split [bt] into [btnew_prev | bt] */
-    btnew_prev->bt_type = BT_TYPE_FREE;
-    btnew_prev->bt_start = bt->bt_start;
-    btnew_prev->bt_size = start - bt->bt_start;
-    bt->bt_start = start;
-    bt->bt_size -= btnew_prev->bt_size;
-    bt_insfree(vm, btnew_prev);
-    bt_insseg_after(vm, btnew_prev, TAILQ_PREV(bt, vmem_seglist, bt_seglink));
-    /* Set btnew_prev to NULL so that it won't be deallocated after exiting
-     * from the vmem lock */
-    btnew_prev = NULL;
-    vmem_check_sanity(vm);
-  }
-
-  assert(bt->bt_start == start);
-  if (bt->bt_size != size && bt->bt_size - size > vm->vm_quantum_mask) {
-    /* Split [bt] into [bt | btnew_next] */
-    btnew_next->bt_type = BT_TYPE_FREE;
-    btnew_next->bt_start = bt->bt_start + size;
-    btnew_next->bt_size = bt->bt_size - size;
+  if (bt->bt_size > size && bt->bt_size - size >= vm->vm_quantum) {
+    /* Split [bt] into [bt | btnew] */
+    btnew->bt_type = BT_TYPE_FREE;
+    btnew->bt_start = bt->bt_start + size;
+    btnew->bt_size = bt->bt_size - size;
     bt->bt_type = BT_TYPE_BUSY;
     bt->bt_size = size;
-    bt_insfree(vm, btnew_next);
-    bt_insseg_after(vm, btnew_next, bt);
+    bt_insfree(vm, btnew);
+    bt_insseg_after(vm, btnew, bt);
     bt_insbusy(vm, bt);
-    /* Set btnew_next to NULL so that it won't be deallocated after exiting
+    /* Set btnew to NULL so that it won't be deallocated after exiting
      * from the vmem lock */
-    btnew_next = NULL;
+    btnew = NULL;
   } else {
     bt->bt_type = BT_TYPE_BUSY;
     bt_insbusy(vm, bt);
@@ -307,10 +259,8 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
   vmem_check_sanity(vm);
   vmem_unlock(vm);
 
-  if (btnew_prev != NULL)
-    pool_free(P_BT, btnew_prev);
-  if (btnew_next != NULL)
-    pool_free(P_BT, btnew_next);
+  if (btnew != NULL)
+    pool_free(P_BT, btnew);
 
   assert(bt->bt_size >= size);
   assert(bt->bt_type == BT_TYPE_BUSY);


### PR DESCRIPTION
* Added comments in `vmem.h` and to structures in `vmem.c`
* Changed `vmem_assert_locked()` function to `VMEM_ASSERT_LOCKED()` macro
* Make use of `align()` and `is_aligned()` from `include/sys/mimiker.h`
* Change `vm_quantum_mask` field to `vm_quantum`, as the latter is used more frequently (note that `mask` = `quantum` - 1)
* Delete `vmem_align_and_fit()` call from `vmem_alloc()` (no need to align as all existing segments are already aligned to `vm_quantum`, no need to check size as it's INSTANTFIT strategy)
* Delete "`btnew_prev`" case inside `vmem_alloc()`, as it would never happen
* Check that segments' start addresses are aligned to `vm_quantum` in `vmem_check_sanity()`
* Check that segments' sizes are at least equal `vm_quantum` in `vmem_check_sanity()`