### PR TITLE
Add Clang build & tests to CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - downloads-20181227-1920
+            - downloads-20191128-1600
       - run: 'make download'
       - save_cache:
-          key: downloads-20181227-1920
+          key: downloads-20191128-1600
           paths:
             - bin/lua/lua-5.3.5.tar.gz
-            - lib/newlib/newlib-3.0.0.tar.gz
       - run: 'make CLANG=<< parameters.use_clang >>'
       - store_artifacts:
           path: sys/mimiker.elf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 defaults: &defaults
   working_directory: ~/mimiker
@@ -20,6 +20,11 @@ jobs:
 
   build:
     <<: *defaults
+    parameters:
+      use_clang:
+        description: 'Whether to use Clang as the compiler (1 = yes, 0 = no)'
+        default: '0'
+        type: string
     steps:
       - checkout
       - restore_cache:
@@ -31,15 +36,15 @@ jobs:
           paths:
             - bin/lua/lua-5.3.5.tar.gz
             - lib/newlib/newlib-3.0.0.tar.gz
-      - run: 'make'
+      - run: 'make CLANG=<< parameters.use_clang >>'
       - store_artifacts:
           path: sys/mimiker.elf
           prefix: kernel_image
       - store_artifacts:
           path: initrd.cpio
           prefix: initial_ramdisk
-      - save_cache:
-          key: mimiker-{{ .Branch }}-{{ .Revision }}
+      - persist_to_workspace:
+          root: ./
           paths:
             - sys/mimiker.elf
             - initrd.cpio
@@ -50,17 +55,27 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: mimiker-{{ .Branch }}-{{ .Revision }}
+      - attach_workspace:
+          at: ./
       - run: './run_tests.py --thorough --non-interactive'
 
 workflows:
-  version: 2
+  version: 2.1
   build_and_test:
     jobs:
       - verify_formatting
       - verify_pycodestyle
-      - build
+      - build:
+          name: build_gcc
+          use_clang: '0'
+      - build:
+          name: build_clang
+          use_clang: '1'
       - kernel_tests:
+          name: kernel_tests_gcc
           requires:
-            - build
+            - build_gcc
+      - kernel_tests:
+          name: kernel_tests_clang
+          requires:
+            - build_clang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/mimiker
   docker:
-    - image: cahirwpz/mimiker-circleci:1.7.1
+    - image: cahirwpz/mimiker-circleci:1.7.2
 
 jobs:
   verify_formatting:

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -16,5 +16,5 @@ RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.4_amd64
     dpkg -i mipsel-mimiker-elf_1.4_amd64.deb && rm -f mipsel-mimiker-elf_1.4_amd64.deb
 RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_1.4_amd64.deb && \
     dpkg -i aarch64-mimiker-elf_1.4_amd64.deb && rm -f aarch64-mimiker-elf_1.4_amd64.deb
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_4.1.0+mimiker1_amd64.deb && \
-    dpkg -i qemu-mimiker_4.1.0+mimiker1_amd64.deb && rm -f qemu-mimiker_4.1.0+mimiker1_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_4.1.0+mimiker2_amd64.deb && \
+    dpkg -i qemu-mimiker_4.1.0+mimiker2_amd64.deb && rm -f qemu-mimiker_4.1.0+mimiker2_amd64.deb

--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /root
 RUN apt-get -q update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends \
       git make cpio curl exuberant-ctags cscope rsync socat patch \
-      bmake byacc python3-pip clang-format device-tree-compiler \
+      bmake byacc python3-pip clang clang-format device-tree-compiler \
       libfdt1 libpython3.7 libsdl2-2.0-0 libglib2.0-0 libpixman-1-0
 # rsync required by verify-format.sh
 # patch required by bin/lua

--- a/.circleci/docker/Makefile
+++ b/.circleci/docker/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.7.1
+VERSION = 1.7.2
 
 all:
 


### PR DESCRIPTION
The `build_clang` job is failing due to the docker container not having Clang installed. It is up to @cahirwpz to update the image used in `config.yml`.