### PR TITLE
vmem: change instant-fit to best-fit allocation strategy

### DIFF
--- a/sys/tests/vmem.c
+++ b/sys/tests/vmem.c
@@ -32,8 +32,8 @@ static int test_vmem(void) {
   rc = vmem_add(vm, span2.addr, span2.size);
   assert(rc == 0);
 
-  /* alloc 16 quantums, should return addr from span #2 */
-  size = 16 * quantum;
+  /* alloc 17 quantums, should return addr from span #2 */
+  size = 17 * quantum;
   rc = vmem_alloc(vm, size, &addr);
   assert(rc == 0);
   assert_addr_is_in_span(addr, size, &span2);


### PR DESCRIPTION
Currently in `vmem` we support only instant-fit allocation strategy. Why is that less than ideal? Suppose we want to allocate a new block of size `N`. Then instant-fit can fail to find free segments of size `M`, if `log2(N)` is equal to `log2(M)`.

I've changed instant-fit to best-fit, which is slower in general, but always succeeds (if there exists any block of size `M`, where `M >= N`). I've also changed our test case a little bit -- the current test would fail for instant-fit strategy.

Note: in NetBSD both strategies are implemented. If instant-fit cannot find any block, the strategy is switched to best-fit.