### PR TITLE
vmem: implement free() & destroy() calls

### DIFF
--- a/include/sys/vmem.h
+++ b/include/sys/vmem.h
@@ -15,10 +15,8 @@ typedef struct vmem vmem_t;
  */
 
 /*! \brief Create a new vmem arena.
- * Pass non-zero base and size if you need an initial span.
  * You need to specify quantum, the smallest unit of allocation. */
-vmem_t *vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
-                    vmem_size_t quantum);
+vmem_t *vmem_create(const char *name, vmem_size_t quantum);
 
 /*! \brief Add a new address span to the arena. */
 int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size);

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -10,7 +10,7 @@
 static vmem_t *kvspace; /* Kernel virtual address space allocator. */
 
 void kmem_bootstrap(void) {
-  kvspace = vmem_create("kvspace", 0, 0, PAGESIZE);
+  kvspace = vmem_create("kvspace", PAGESIZE);
   if (KERNEL_SPACE_BEGIN < (vaddr_t)__kernel_start)
     vmem_add(kvspace, KERNEL_SPACE_BEGIN,
              (vaddr_t)__kernel_start - KERNEL_SPACE_BEGIN);

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -252,7 +252,7 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp) {
   bt_t *btnew = pool_alloc(P_BT, PF_ZERO);
   bt_t *bt;
 
-  WITH_MTX_LOCK(&vm->vm_lock) {
+  WITH_MTX_LOCK (&vm->vm_lock) {
     vmem_check_sanity(vm);
 
     bt = bt_find_freeseg(vm, size);
@@ -305,7 +305,7 @@ void vmem_free(vmem_t *vm, vmem_addr_t addr, vmem_size_t size) {
   bt_t *prev = NULL;
   bt_t *next = NULL;
 
-  WITH_MTX_LOCK(&vm->vm_lock) {
+  WITH_MTX_LOCK (&vm->vm_lock) {
     vmem_check_sanity(vm);
 
     bt_t *bt = bt_lookupbusy(vm, addr);

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -9,6 +9,8 @@
 #include <sys/hash.h>
 #include <sys/mutex.h>
 
+#define VMEM_DEBUG 0
+
 #define VMEM_MAXORDER ((int)(sizeof(vmem_size_t) * CHAR_BIT))
 #define VMEM_MAXHASH 512
 #define VMEM_NAME_MAX 16
@@ -79,10 +81,6 @@ static vmem_freelist_t *bt_freehead(vmem_t *vm, vmem_size_t size) {
   int idx = SIZE2ORDER(qsize);
   assert(idx >= 0 && idx < VMEM_MAXORDER);
   return &vm->vm_freelist[idx];
-}
-
-static bool bt_isspan(const bt_t *bt) {
-  return bt->bt_type == BT_TYPE_SPAN;
 }
 
 static vmem_addr_t bt_end(const bt_t *bt) {
@@ -165,6 +163,11 @@ static bt_t *bt_find_freeseg(vmem_t *vm, vmem_size_t size) {
   return NULL;
 }
 
+#if VMEM_DEBUG
+static bool bt_isspan(const bt_t *bt) {
+  return bt->bt_type == BT_TYPE_SPAN;
+}
+
 static void vmem_check_sanity(vmem_t *vm) {
   assert(mtx_owned(&vm->vm_lock));
 
@@ -186,6 +189,9 @@ static void vmem_check_sanity(vmem_t *vm) {
     }
   }
 }
+#else
+#define vmem_check_sanity(vm) (void)vm
+#endif
 
 vmem_t *vmem_create(const char *name, vmem_size_t quantum) {
   vmem_t *vm = pool_alloc(P_VMEM, PF_ZERO);

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -166,9 +166,8 @@ static bt_t *bt_find_freeseg(vmem_t *vm, vmem_size_t size) {
   for (vmem_freelist_t *list = first; list < end; list++) {
     bt_t *bt;
     LIST_FOREACH (bt, list, bt_freelink) {
-      if (bt->bt_size >= size) {
+      if (bt->bt_size >= size)
         return bt;
-      }
     }
   }
   return NULL;

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -167,8 +167,7 @@ static void vmem_check_sanity(vmem_t *vm) {
   }
 }
 
-vmem_t *vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
-                    vmem_size_t quantum) {
+vmem_t *vmem_create(const char *name, vmem_size_t quantum) {
   vmem_t *vm = pool_alloc(P_VMEM, PF_ZERO);
 
   vm->vm_quantum = quantum;
@@ -185,9 +184,6 @@ vmem_t *vmem_create(const char *name, vmem_addr_t base, vmem_size_t size,
     LIST_INIT(&vm->vm_freelist[i]);
   for (int i = 0; i < VMEM_MAXHASH; i++)
     LIST_INIT(&vm->vm_hashlist[i]);
-
-  if (size != 0)
-    vmem_add(vm, base, size);
 
   WITH_MTX_LOCK (&vmem_alllist_lock)
     LIST_INSERT_HEAD(&vmem_alllist, vm, vm_alllist_link);

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -369,6 +369,7 @@ void vmem_destroy(vmem_t *vm) {
   /* check #2
    * - each segment is either free, or is a span,
    * - total size of all spans is equal to vm_size
+   * - vm_inuse is equal to 0
    */
   bt_t *bt;
   vmem_size_t span_size_sum = 0;
@@ -378,6 +379,7 @@ void vmem_destroy(vmem_t *vm) {
       span_size_sum += bt->bt_size;
   }
   assert(vm->vm_size == span_size_sum);
+  assert(vm->vm_inuse == 0);
 
   /* check #3
    * - first segment is a span,

--- a/sys/tests/vmem.c
+++ b/sys/tests/vmem.c
@@ -15,7 +15,7 @@ static void assert_addr_is_in_span(vmem_addr_t addr, vmem_size_t size,
 
 static int test_vmem(void) {
   int quantum = 1 << 12;
-  vmem_t *vm = vmem_create("test vmem", 0, 0, quantum);
+  vmem_t *vm = vmem_create("test vmem", quantum);
   assert(vm != NULL);
 
   int rc;

--- a/sys/tests/vmem.c
+++ b/sys/tests/vmem.c
@@ -19,7 +19,6 @@ static int test_vmem(void) {
   assert(vm != NULL);
 
   int rc;
-  vmem_addr_t addr;
   vmem_size_t size;
 
   /* add span #1 */
@@ -34,26 +33,46 @@ static int test_vmem(void) {
 
   /* alloc 16 quantums, should return addr from span #2 */
   size = 16 * quantum;
-  rc = vmem_alloc(vm, size, &addr);
+  vmem_addr_t addr16;
+  rc = vmem_alloc(vm, size, &addr16);
   assert(rc == 0);
-  assert_addr_is_in_span(addr, size, &span2);
+  assert_addr_is_in_span(addr16, size, &span2);
 
   /* alloc 8 quantums, should return addr from span #1 */
   size = 8 * quantum;
-  rc = vmem_alloc(vm, size, &addr);
+  vmem_addr_t addr8;
+  rc = vmem_alloc(vm, size, &addr8);
   assert(rc == 0);
-  assert_addr_is_in_span(addr, size, &span1);
+  assert_addr_is_in_span(addr8, size, &span1);
 
   /* alloc 1 quantum, should return addr from span #2 */
   size = 1 * quantum;
-  rc = vmem_alloc(vm, size, &addr);
+  vmem_addr_t addr1;
+  rc = vmem_alloc(vm, size, &addr1);
   assert(rc == 0);
-  assert_addr_is_in_span(addr, size, &span2);
+  assert_addr_is_in_span(addr1, size, &span2);
 
   /* alloc 10 quantums, should fail */
   size = 10 * quantum;
-  rc = vmem_alloc(vm, size, &addr);
+  vmem_addr_t addr10;
+  rc = vmem_alloc(vm, size, &addr10);
   assert(rc == ENOMEM);
+
+  /* free 16 quantums */
+  vmem_free(vm, addr16, 16 * quantum);
+
+  /* alloc 10 quantums, should return addr from span #2 */
+  size = 10 * quantum;
+  rc = vmem_alloc(vm, size, &addr10);
+  assert(rc == 0);
+  assert_addr_is_in_span(addr10, size, &span2);
+
+  /* free all segments */
+  vmem_free(vm, addr1, 1 * quantum);
+  vmem_free(vm, addr8, 8 * quantum);
+  vmem_free(vm, addr10, 10 * quantum);
+
+  vmem_destroy(vm);
 
   return KTEST_SUCCESS;
 }


### PR DESCRIPTION
* Parameters `base` and `size` have been removed from `vmem_create()` call, so that fresh `vmem` instance has no initial span, and one must call `vmem_add()` explicitly
* Implemented `vmem_free()`
* Implemented `vmem_destroy()` with extensive sanity check -- the kernel check that the destroyed `vmem` instance is empty and its memory is not corrupted
* Updated `sys/tests/vmem.c` test, so that it uses `vmem_free()` and `vmem_destroy()`