### PR TITLE
Rename vfs_lookup to vfs_namelookup.

### DIFF
--- a/include/sys/vfs.h
+++ b/include/sys/vfs.h
@@ -78,7 +78,7 @@ int do_getdirentries(proc_t *p, int fd, uio_t *uio, off_t *basep);
 
 /* Finds the vnode corresponding to the given path.
  * Increases use count on returned vnode. */
-int vfs_lookup(const char *path, vnode_t **vp);
+int vfs_namelookup(const char *path, vnode_t **vp);
 
 /* Looks up the vnode corresponding to the pathname and opens it into f. */
 int vfs_open(file_t *f, char *pathname, int flags, int mode);

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -232,7 +232,7 @@ static int open_executable(const char *path, vnode_t **vn_p) {
   klog("Loading program '%s'", path);
 
   /* Translate program name to vnode. */
-  if ((error = vfs_lookup(path, &vn)))
+  if ((error = vfs_namelookup(path, &vn)))
     return error;
 
   /* It must be a regular executable file with non-zero size. */

--- a/sys/kern/vfs.c
+++ b/sys/kern/vfs.c
@@ -333,7 +333,7 @@ static void vnrstate_init(vnrstate_t *vs, vnrop_t op, const char *path) {
   vs->vs_nextcn = path;
 }
 
-int vfs_lookup(const char *path, vnode_t **vp) {
+int vfs_namelookup(const char *path, vnode_t **vp) {
   vnrstate_t vs;
   vnrstate_init(&vs, VNR_LOOKUP, path);
   int error = vfs_nameresolve(&vs);
@@ -344,12 +344,12 @@ int vfs_lookup(const char *path, vnode_t **vp) {
 int vfs_open(file_t *f, char *pathname, int flags, int mode) {
   vnode_t *v;
   int error = 0;
-  error = vfs_lookup(pathname, &v);
+  error = vfs_namelookup(pathname, &v);
   if (error)
     return error;
   int res = VOP_OPEN(v, flags, f);
-  /* Drop our reference to v. We received it from vfs_lookup, but we no longer
-     need it - file f keeps its own reference to v after open. */
+  /* Drop our reference to v. We received it from vfs_namelookup, but we no
+     longer need it - file f keeps its own reference to v after open. */
   vnode_drop(v);
   return res;
 }

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -87,7 +87,7 @@ int do_stat(proc_t *p, char *path, stat_t *sb) {
   vattr_t va;
   int error;
 
-  if ((error = vfs_lookup(path, &v)))
+  if ((error = vfs_namelookup(path, &v)))
     return error;
   if ((error = VOP_GETATTR(v, &va)))
     goto fail;
@@ -153,7 +153,7 @@ int do_mount(const char *fs, const char *path) {
 
   if (!(vfs = vfs_get_by_name(fs)))
     return EINVAL;
-  if ((error = vfs_lookup(path, &v)))
+  if ((error = vfs_namelookup(path, &v)))
     return error;
 
   return vfs_domount(vfs, v);
@@ -194,7 +194,7 @@ int do_access(proc_t *p, char *path, int amode) {
     return EINVAL;
 
   vnode_t *v;
-  if ((error = vfs_lookup(path, &v)))
+  if ((error = vfs_namelookup(path, &v)))
     return error;
   error = VOP_ACCESS(v, amode);
   vnode_drop(v);

--- a/sys/tests/vfs.c
+++ b/sys/tests/vfs.c
@@ -14,36 +14,36 @@ static int test_vfs(void) {
   vnode_t *v;
   int error;
 
-  error = vfs_lookup("/dev/SPAM", &v);
+  error = vfs_namelookup("/dev/SPAM", &v);
   assert(error == ENOENT);
-  error = vfs_lookup("/", &v);
+  error = vfs_namelookup("/", &v);
   assert(error == 0);
   assert(fsname_of(v, "initrd"));
   vnode_drop(v);
-  error = vfs_lookup("/dev////", &v);
+  error = vfs_namelookup("/dev////", &v);
   assert(error == 0);
   assert(fsname_of(v, "devfs"));
   vnode_drop(v);
 
-  error = vfs_lookup("/dev", &v);
+  error = vfs_namelookup("/dev", &v);
   assert(error == 0 && !is_mountpoint(v));
   vnode_drop(v);
 
   vnode_t *dev_null, *dev_zero;
-  error = vfs_lookup("/dev/null", &dev_null);
+  error = vfs_namelookup("/dev/null", &dev_null);
   assert(error == 0);
   vnode_drop(dev_null);
-  error = vfs_lookup("/dev/zero", &dev_zero);
+  error = vfs_namelookup("/dev/zero", &dev_zero);
   assert(error == 0);
   vnode_drop(dev_zero);
 
   assert(dev_zero->v_usecnt == 1);
   /* Ask for the same vnode multiple times and check for correct v_usecnt. */
-  error = vfs_lookup("/dev/zero", &dev_zero);
+  error = vfs_namelookup("/dev/zero", &dev_zero);
   assert(error == 0);
-  error = vfs_lookup("/dev/zero", &dev_zero);
+  error = vfs_namelookup("/dev/zero", &dev_zero);
   assert(error == 0);
-  error = vfs_lookup("/dev/zero", &dev_zero);
+  error = vfs_namelookup("/dev/zero", &dev_zero);
   assert(error == 0);
   assert(dev_zero->v_usecnt == 4);
   vnode_drop(dev_zero);
@@ -72,7 +72,7 @@ static int test_vfs(void) {
 
   /* Test writing to UART */
   vnode_t *dev_cons;
-  error = vfs_lookup("/dev/cons", &dev_cons);
+  error = vfs_namelookup("/dev/cons", &dev_cons);
   assert(error == 0);
   char *str = "Some string for testing UART write\n";
 


### PR DESCRIPTION
Renamed `vfs_lookup` to make VNR naming more consistent.