### PR TITLE
Fixing #594. Do not deliver signals to zombies, ...

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -26,7 +26,7 @@ static mtx_t *all_proc_mtx = &MTX_INITIALIZER(0);
 static proc_list_t proc_list = TAILQ_HEAD_INITIALIZER(proc_list);
 static proc_list_t zombie_list = TAILQ_HEAD_INITIALIZER(zombie_list);
 static pgrp_list_t pgrp_list = TAILQ_HEAD_INITIALIZER(pgrp_list);
-static bitstr_t pid_used[bitstr_size(NPROC)] = {0};
+static bitstr_t pid_used[bitstr_size(NPROC)] = {[0] = 1, 0};
 
 /* Process ID management functions */
 static pid_t pid_alloc(void) {

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -245,7 +245,7 @@ __noreturn void proc_exit(int exitstatus) {
     /* Process orphans, but firstly find init process. */
     proc_t *init;
     TAILQ_FOREACH (init, &proc_list, p_all) {
-      if (init->p_pid == 0)
+      if (init->p_pid == 1)
         break;
     }
     proc_reparent(p, init);

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -26,6 +26,9 @@ static mtx_t *all_proc_mtx = &MTX_INITIALIZER(0);
 static proc_list_t proc_list = TAILQ_HEAD_INITIALIZER(proc_list);
 static proc_list_t zombie_list = TAILQ_HEAD_INITIALIZER(zombie_list);
 static pgrp_list_t pgrp_list = TAILQ_HEAD_INITIALIZER(pgrp_list);
+
+/* Pid 0 is never available, because of its special treatment by some
+ * syscalls e.g. kill. */
 static bitstr_t pid_used[bitstr_size(NPROC)] = {[0] = 1, 0};
 
 /* Process ID management functions */

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -81,10 +81,10 @@ void sig_kill(proc_t *proc, signo_t sig) {
   assert(mtx_owned(&proc->p_lock));
   assert(sig < NSIG);
 
+  /* Zombie processes shouldn't accept any signals. */
   if (proc->p_state == PS_ZOMBIE)
     return;
 
-  /* Zombie processes shouldn't accept any signals. */
   thread_t *td = proc->p_thread;
 
   /* If the signal is ignored, don't even bother posting it. */

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -81,6 +81,10 @@ void sig_kill(proc_t *proc, signo_t sig) {
   assert(mtx_owned(&proc->p_lock));
   assert(sig < NSIG);
 
+  if (proc->p_state == PS_ZOMBIE)
+    return;
+
+  /* Zombie processes shouldn't accept any signals. */
   thread_t *td = proc->p_thread;
 
   /* If the signal is ignored, don't even bother posting it. */


### PR DESCRIPTION
* signals are not delivered to zombies
  That caused #594 .
* pids start at 1
  Pids shouldn't start at 0, [because](https://www.freebsd.org/cgi/man.cgi?query=kill&apropos=0&sektion=2&manpath=FreeBSD+12.1-RELEASE+and+Ports&arch=default&format=html):
```
If	pid is zero:
	     The sig signal is sent to all processes whose group ID is equal
	     to	the process group ID of	the sender, and	for which the process
	     has permission; this is a variant of killpg(2).
```


