### PR TITLE
Cleanup after "Do not deliver signals to zombies"

### DIFF
--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -11,7 +11,7 @@ int kmain(void) {
   char *init = kenv_get("init");
   char *test = kenv_get("test");
 
-  /* Main kernel thread becomes PID(0) - a god process! */
+  /* Main kernel thread becomes PID(1) - a god process! */
   proc_add(proc_create(thread_self(), NULL));
 
   if (init) {

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -29,7 +29,7 @@ static pgrp_list_t pgrp_list = TAILQ_HEAD_INITIALIZER(pgrp_list);
 
 /* Pid 0 is never available, because of its special treatment by some
  * syscalls e.g. kill. */
-static bitstr_t pid_used[bitstr_size(NPROC)] = {[0] = 1, 0};
+static bitstr_t pid_used[bitstr_size(NPROC)] = {1};
 
 /* Process ID management functions */
 static pid_t pid_alloc(void) {


### PR DESCRIPTION
* Array equal to `{[0] = 1, 0}` is in fact equal to `{1}`.
* Changed a comment about PID(0) -- now it's PID(1).