### PR TITLE
Introduce v-node locking consistency in vop operations.

### DIFF
--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -37,10 +37,10 @@ typedef int vnode_seek_t(vnode_t *v, off_t oldoff, off_t newoff, void *state);
 typedef int vnode_getattr_t(vnode_t *v, vattr_t *va);
 typedef int vnode_create_t(vnode_t *dv, const char *name, vattr_t *va,
                            vnode_t **vp);
-typedef int vnode_remove_t(vnode_t *dv, const char *name);
+typedef int vnode_remove_t(vnode_t *dv, vnode_t *v, const char *name);
 typedef int vnode_mkdir_t(vnode_t *dv, const char *name, vattr_t *va,
                           vnode_t **vp);
-typedef int vnode_rmdir_t(vnode_t *dv, const char *name);
+typedef int vnode_rmdir_t(vnode_t *dv, vnode_t *v, const char *name);
 typedef int vnode_access_t(vnode_t *v, accmode_t mode);
 typedef int vnode_ioctl_t(vnode_t *v, u_long cmd, void *data);
 typedef int vnode_reclaim_t(vnode_t *v);
@@ -140,8 +140,8 @@ static inline int VOP_CREATE(vnode_t *dv, const char *name, vattr_t *va,
   return VOP_CALL(create, dv, name, va, vp);
 }
 
-static inline int VOP_REMOVE(vnode_t *dv, const char *name) {
-  return VOP_CALL(remove, dv, name);
+static inline int VOP_REMOVE(vnode_t *dv, vnode_t *v, const char *name) {
+  return VOP_CALL(remove, dv, v, name);
 }
 
 static inline int VOP_MKDIR(vnode_t *dv, const char *name, vattr_t *va,
@@ -149,8 +149,8 @@ static inline int VOP_MKDIR(vnode_t *dv, const char *name, vattr_t *va,
   return VOP_CALL(mkdir, dv, name, va, vp);
 }
 
-static inline int VOP_RMDIR(vnode_t *dv, const char *name) {
-  return VOP_CALL(rmdir, dv, name);
+static inline int VOP_RMDIR(vnode_t *dv,vnode_t *v, const char *name) {
+  return VOP_CALL(rmdir, dv, v, name);
 }
 
 static inline int VOP_ACCESS(vnode_t *v, mode_t mode) {

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -149,7 +149,7 @@ static inline int VOP_MKDIR(vnode_t *dv, const char *name, vattr_t *va,
   return VOP_CALL(mkdir, dv, name, va, vp);
 }
 
-static inline int VOP_RMDIR(vnode_t *dv,vnode_t *v, const char *name) {
+static inline int VOP_RMDIR(vnode_t *dv, vnode_t *v, const char *name) {
   return VOP_CALL(rmdir, dv, v, name);
 }
 

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -169,7 +169,7 @@ static int tmpfs_vop_create(vnode_t *dv, const char *name, vattr_t *va,
   return tmpfs_create_file(dv, vp, V_REG, name);
 }
 
-static int tmpfs_vop_remove(vnode_t *dv, const char *name) {
+static int tmpfs_vop_remove(vnode_t *dv, vnode_t *v, const char *name) {
   tmpfs_node_t *dnode = TMPFS_NODE_OF(dv);
   tmpfs_dirent_t *de = tmpfs_dir_lookup(dnode, &COMPONENTNAME(name));
   assert(de != NULL);
@@ -185,7 +185,7 @@ static int tmpfs_vop_mkdir(vnode_t *dv, const char *name, vattr_t *va,
   return tmpfs_create_file(dv, vp, V_DIR, name);
 }
 
-static int tmpfs_vop_rmdir(vnode_t *dv, const char *name) {
+static int tmpfs_vop_rmdir(vnode_t *dv, vnode_t *v, const char *name) {
   tmpfs_node_t *dnode = TMPFS_NODE_OF(dv);
   tmpfs_dirent_t *de = tmpfs_dir_lookup(dnode, &COMPONENTNAME(name));
   assert(de != NULL);
@@ -201,8 +201,6 @@ static int tmpfs_vop_rmdir(vnode_t *dv, const char *name) {
   } else {
     error = ENOTEMPTY;
   }
-
-  vnode_put(node->tfn_vnode);
 
   return error;
 }

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -236,8 +236,9 @@ int do_rmdir(proc_t *p, char *path) {
   memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);
   namecopy[cn.cn_namelen] = 0;
 
-  error = VOP_RMDIR(dvn, namecopy);
+  error = VOP_RMDIR(dvn, vn, namecopy);
   vnode_put(dvn);
+  vnode_put(vn);
   kfree(M_TEMP, namecopy);
 
   return error;


### PR DESCRIPTION
I have changed `VOP_REMOVE` and `VOP_RMDIR` interface to take removed v-node as argument. The point is that file system implementations should not lock/unlock v-nodes in this operations. It is related to this [comment](https://github.com/cahirwpz/mimiker/issues/369#issuecomment-306614249).