### PR TITLE
Add support for creating file using open syscall.

### DIFF
--- a/include/sys/vfs.h
+++ b/include/sys/vfs.h
@@ -80,9 +80,10 @@ int do_getdirentries(proc_t *p, int fd, uio_t *uio, off_t *basep);
  * Increases use count on returned vnode. */
 int vfs_namelookup(const char *path, vnode_t **vp);
 
-/* Finds the parent of vnode corresponding to the given path.
- * Returned vnode is locked and held. */
-int vfs_namecreate(const char *path, vnode_t **dvp, componentname_t *cn);
+/* Yield the vnode for an existing entry; or, if there is none, yield NULL.
+ * Parent vnode is locked and held; vnode, if exists, is only held.*/
+int vfs_namecreate(const char *path, vnode_t **dvp, vnode_t **vp,
+                   componentname_t *cn);
 
 /* Both vnode and its parent is held and locked. */
 int vfs_namedelete(const char *path, vnode_t **dvp, vnode_t **vp,

--- a/sys/kern/vfs.c
+++ b/sys/kern/vfs.c
@@ -11,6 +11,7 @@
 #include <sys/linker_set.h>
 #include <sys/sysinit.h>
 #include <sys/mimiker.h>
+#include <sys/stat.h>
 
 /* Internal state for a vnr operation. */
 typedef struct {
@@ -343,24 +344,16 @@ int vfs_namelookup(const char *path, vnode_t **vp) {
   return error;
 }
 
-int vfs_namecreate(const char *path, vnode_t **dvp, componentname_t *cn) {
+int vfs_namecreate(const char *path, vnode_t **dvp, vnode_t **vp,
+                   componentname_t *cn) {
   vnrstate_t vs;
   vnrstate_init(&vs, VNR_CREATE, path);
   int error = vfs_nameresolve(&vs);
   if (error)
     return error;
 
-  if (vs.vs_vp != NULL) {
-    if (vs.vs_vp != vs.vs_dvp)
-      vnode_put(vs.vs_dvp);
-    else
-      vnode_drop(vs.vs_dvp);
-
-    vnode_drop(vs.vs_vp);
-    return EEXIST;
-  }
-
   *dvp = vs.vs_dvp;
+  *vp = vs.vs_vp;
   memcpy(cn, &vs.vs_cn, sizeof(componentname_t));
 
   return 0;
@@ -384,14 +377,47 @@ int vfs_namedelete(const char *path, vnode_t **dvp, vnode_t **vp,
 int vfs_open(file_t *f, char *pathname, int flags, int mode) {
   vnode_t *v;
   int error = 0;
-  error = vfs_namelookup(pathname, &v);
-  if (error)
-    return error;
-  int res = VOP_OPEN(v, flags, f);
+  if (flags & O_CREAT) {
+    vnode_t *dvp;
+    componentname_t cn;
+    if ((error = vfs_namecreate(pathname, &dvp, &v, &cn)))
+      return error;
+
+    if (v == NULL) {
+      char *namecopy = kmalloc(M_TEMP, NAME_MAX + 1, 0);
+      memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);
+      namecopy[cn.cn_namelen] = 0;
+
+      vattr_t va;
+      memset(&va, 0, sizeof(vattr_t));
+      va.va_mode = S_IFREG | (mode & ALLPERMS);
+      error = VOP_CREATE(dvp, namecopy, &va, &v);
+      vnode_put(dvp);
+      kfree(M_TEMP, namecopy);
+      if (error)
+        return error;
+    } else {
+      if (v == dvp)
+        vnode_drop(dvp);
+      else
+        vnode_put(dvp);
+
+      if (mode & O_EXCL)
+        error = EEXIST;
+      mode &= ~O_CREAT;
+    }
+  } else {
+    if ((error = vfs_namelookup(pathname, &v)))
+      return error;
+  }
+
+  if (!error)
+    error = VOP_OPEN(v, flags, f);
+
   /* Drop our reference to v. We received it from vfs_namelookup, but we no
      longer need it - file f keeps its own reference to v after open. */
   vnode_drop(v);
-  return res;
+  return error;
 }
 
 SYSINIT_ADD(vfs, vfs_init, NODEPS);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -211,8 +211,18 @@ int do_mkdir(proc_t *p, char *path, mode_t mode) {
   vnode_t *vn, *dvn;
   componentname_t cn;
 
-  if ((error = vfs_namecreate(path, &dvn, &cn)))
+  if ((error = vfs_namecreate(path, &dvn, &vn, &cn)))
     return error;
+
+  if (vn != NULL) {
+    if (vn != dvn)
+      vnode_put(dvn);
+    else
+      vnode_drop(dvn);
+
+    vnode_drop(vn);
+    return EEXIST;
+  }
 
   char *namecopy = kmalloc(M_TEMP, NAME_MAX + 1, 0);
   memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);

--- a/sys/kern/vfs_vnode.c
+++ b/sys/kern/vfs_vnode.c
@@ -205,7 +205,7 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
   fp->f_ops = &default_vnode_fileops;
   fp->f_type = FT_VNODE;
   fp->f_vnode = v;
-  switch (mode) {
+  switch (mode & O_ACCMODE) {
     case O_RDONLY:
       fp->f_flags = FF_READ;
       break;
@@ -215,9 +215,11 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
     case O_RDWR:
       fp->f_flags = FF_READ | FF_WRITE;
       break;
-    default:
-      return EINVAL;
   }
+
+  if (mode & O_APPEND)
+    fp->f_flags |= FF_APPEND;
+
   return 0;
 }
 


### PR DESCRIPTION
We can create new regular files using `open` syscall with `O_CREATE` flag specified. I have also handled `O_APPEND` flag. It doesn't have any effect now, but at least it doesn't return with error, as it did before.