### PR TITLE
Add read/write operations for tmpfs

### DIFF
--- a/bin/utest/main.c
+++ b/bin/utest/main.c
@@ -54,6 +54,7 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(sigaction_with_setjmp);
   CHECKRUN_TEST(sigaction_handler_returns);
   CHECKRUN_TEST(vfs_dir);
+  CHECKRUN_TEST(vfs_rw);
 
   CHECKRUN_TEST(setpgid);
   CHECKRUN_TEST(kill);

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -59,6 +59,7 @@ int test_sigaction_with_setjmp(void);
 int test_sigaction_handler_returns(void);
 
 int test_vfs_dir(void);
+int test_vfs_rw(void);
 
 int test_setpgid(void);
 int test_kill(void);

--- a/bin/utest/vfs.c
+++ b/bin/utest/vfs.c
@@ -56,11 +56,11 @@ int test_vfs_rw(void) {
   assert(!memcmp(buff1, buff2, 1500 * sizeof(uint32_t)));
   assert_lseek_ok(0, 0, SEEK_SET);
 
-  /* Write 64KB to test indirect blocks */
-  for (int i = 0; i < 4; i++)
+  /* Write 32KB to test indirect blocks */
+  for (int i = 0; i < 2; i++)
     assert_write_ok(0, buff1, 4096 * sizeof(uint32_t));
   assert_lseek_ok(0, 0, SEEK_SET);
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 2; i++) {
     assert(read(3, buff2, 4096 * sizeof(uint32_t)) == 4096 * sizeof(uint32_t));
     assert(!memcmp(buff1, buff2, 4096 * sizeof(uint32_t)));
   }

--- a/bin/utest/vfs.c
+++ b/bin/utest/vfs.c
@@ -2,15 +2,77 @@
 
 #include <sys/stat.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <string.h>
+
+static int n;
+#define FD_OFFSET 3
+#include "utest_fd.h"
 
 #define TESTDIR "/tmp"
 
 #define assert_ok(expr) assert(expr == 0)
 #define assert_fail(expr, err) assert(expr == -1 && errno == err)
+
+/* Generate pseudo random data */
+static void gen_test_data(size_t n, uint32_t *data) {
+  uint32_t a = 1;
+  for (size_t i = 0; i < n; i++) {
+    a ^= a << 13;
+    a ^= a >> 17;
+    a ^= a << 5;
+    data[i] = a;
+  }
+}
+
+int test_vfs_rw(void) {
+  uint32_t *buff1 = malloc(4096 * sizeof(uint32_t));
+  uint32_t *buff2 = malloc(4096 * sizeof(uint32_t));
+
+  gen_test_data(4096, buff1);
+
+  assert_open_ok(0, TESTDIR "/file", 0, O_RDWR | O_CREAT);
+
+  /* Write and read aligned amount of bytes */
+  assert_write_ok(0, buff1, 1024 * sizeof(uint32_t));
+  assert_lseek_ok(0, 0, SEEK_SET);
+  assert(read(3, buff2, 5000) == 4096);
+  assert(!memcmp(buff1, buff2, 1024 * sizeof(uint32_t)));
+  assert(read(3, buff2, 5000) == 0);
+  assert_lseek_ok(0, 0, SEEK_SET);
+
+  /* Write 3000 bytes in two batches and then partially read */
+  assert_write_ok(0, buff1, 2000 * sizeof(uint32_t));
+  assert_write_ok(0, buff1 + 2000, 1000 * sizeof(uint32_t));
+  assert_lseek_ok(0, 0, SEEK_SET);
+  assert(read(3, buff2, 1500 * sizeof(uint32_t)) == 1500 * sizeof(uint32_t));
+  assert(!memcmp(buff1, buff2, 1500 * sizeof(uint32_t)));
+  assert(read(3, buff2 + 1500, 3000 * sizeof(uint32_t)) ==
+         1500 * sizeof(uint32_t));
+  assert(!memcmp(buff1, buff2, 1500 * sizeof(uint32_t)));
+  assert_lseek_ok(0, 0, SEEK_SET);
+
+  /* Write 64KB to test indirect blocks */
+  for (int i = 0; i < 4; i++)
+    assert_write_ok(0, buff1, 4096 * sizeof(uint32_t));
+  assert_lseek_ok(0, 0, SEEK_SET);
+  for (int i = 0; i < 4; i++) {
+    assert(read(3, buff2, 4096 * sizeof(uint32_t)) == 4096 * sizeof(uint32_t));
+    assert(!memcmp(buff1, buff2, 4096 * sizeof(uint32_t)));
+  }
+
+  free(buff1);
+  free(buff2);
+
+  close(3);
+  unlink(TESTDIR "/file");
+
+  return 0;
+}
 
 int test_vfs_dir(void) {
   assert_ok(mkdir(TESTDIR "/test", 0));

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -225,7 +225,14 @@ static int tmpfs_vop_getattr(vnode_t *v, vattr_t *va) {
 }
 
 static int tmpfs_vop_setattr(vnode_t *v, vattr_t *va) {
-  return ENOTSUP;
+  tmpfs_mount_t *tfm = TMPFS_ROOT_OF(v->v_mount);
+  tmpfs_node_t *node = TMPFS_NODE_OF(v);
+
+  if (va->va_size != (size_t)VNOVAL) {
+    tmpfs_reg_resize(tfm, node, va->va_size);
+  }
+
+  return 0;
 }
 
 static int tmpfs_vop_create(vnode_t *dv, const char *name, vattr_t *va,

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -99,6 +99,7 @@ UTEST_ADD_SIMPLE(sigaction_with_setjmp);
 UTEST_ADD_SIMPLE(sigaction_handler_returns);
 
 UTEST_ADD_SIMPLE(vfs_dir);
+UTEST_ADD_SIMPLE(vfs_rw);
 
 #if 0
 UTEST_ADD_SIMPLE(fpu_fcsr);


### PR DESCRIPTION
Read and write operations for tmpfs are now fully working. Addressing a file's data blocks is based on a structure adopted from [ext2](http://web.mit.edu/tytso/www/linux/ext2intro.html) filesystem. The key features are fixed logical block size, ease of data location and indirect blocks. Default level of indirection is 2, which should be enough (file's size can be up to roughly 4GiB). 
I also have written some unit tests for this code.