### PR TITLE
Consistency in using componentname in vfs.

### DIFF
--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -38,12 +38,12 @@ typedef int vnode_write_t(vnode_t *v, uio_t *uio);
 typedef int vnode_seek_t(vnode_t *v, off_t oldoff, off_t newoff);
 typedef int vnode_getattr_t(vnode_t *v, vattr_t *va);
 typedef int vnode_setattr_t(vnode_t *v, vattr_t *va);
-typedef int vnode_create_t(vnode_t *dv, const char *name, vattr_t *va,
+typedef int vnode_create_t(vnode_t *dv, componentname_t *cn, vattr_t *va,
                            vnode_t **vp);
-typedef int vnode_remove_t(vnode_t *dv, vnode_t *v, const char *name);
-typedef int vnode_mkdir_t(vnode_t *dv, const char *name, vattr_t *va,
+typedef int vnode_remove_t(vnode_t *dv, vnode_t *v, componentname_t *cn);
+typedef int vnode_mkdir_t(vnode_t *dv, componentname_t *cn, vattr_t *va,
                           vnode_t **vp);
-typedef int vnode_rmdir_t(vnode_t *dv, vnode_t *v, const char *name);
+typedef int vnode_rmdir_t(vnode_t *dv, vnode_t *v, componentname_t *cn);
 typedef int vnode_access_t(vnode_t *v, accmode_t mode);
 typedef int vnode_ioctl_t(vnode_t *v, u_long cmd, void *data);
 typedef int vnode_reclaim_t(vnode_t *v);
@@ -144,22 +144,22 @@ static inline int VOP_SETATTR(vnode_t *v, vattr_t *va) {
   return VOP_CALL(setattr, v, va);
 }
 
-static inline int VOP_CREATE(vnode_t *dv, const char *name, vattr_t *va,
+static inline int VOP_CREATE(vnode_t *dv, componentname_t *cn, vattr_t *va,
                              vnode_t **vp) {
-  return VOP_CALL(create, dv, name, va, vp);
+  return VOP_CALL(create, dv, cn, va, vp);
 }
 
-static inline int VOP_REMOVE(vnode_t *dv, vnode_t *v, const char *name) {
-  return VOP_CALL(remove, dv, v, name);
+static inline int VOP_REMOVE(vnode_t *dv, vnode_t *v, componentname_t *cn) {
+  return VOP_CALL(remove, dv, v, cn);
 }
 
-static inline int VOP_MKDIR(vnode_t *dv, const char *name, vattr_t *va,
+static inline int VOP_MKDIR(vnode_t *dv, componentname_t *cn, vattr_t *va,
                             vnode_t **vp) {
-  return VOP_CALL(mkdir, dv, name, va, vp);
+  return VOP_CALL(mkdir, dv, cn, va, vp);
 }
 
-static inline int VOP_RMDIR(vnode_t *dv, vnode_t *v, const char *name) {
-  return VOP_CALL(rmdir, dv, v, name);
+static inline int VOP_RMDIR(vnode_t *dv, vnode_t *v, componentname_t *cn) {
+  return VOP_CALL(rmdir, dv, v, cn);
 }
 
 static inline int VOP_ACCESS(vnode_t *v, mode_t mode) {

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -68,9 +68,10 @@ static void tmpfs_attach_vnode(tmpfs_node_t *tfn, mount_t *mp);
 static tmpfs_node_t *tmpfs_new_node(tmpfs_mount_t *tfm, vnodetype_t ntype);
 static void tmpfs_free_node(tmpfs_node_t *tfn);
 static int tmpfs_create_file(vnode_t *dv, vnode_t **vp, vnodetype_t ntype,
-                             const char *name);
+                             componentname_t *cn);
 static int tmpfs_get_vnode(mount_t *mp, tmpfs_node_t *tfn, vnode_t **vp);
-static int tmpfs_alloc_dirent(const char *name, tmpfs_dirent_t **dep);
+static int tmpfs_alloc_dirent(const char *name, size_t namelen,
+                              tmpfs_dirent_t **dep);
 static tmpfs_dirent_t *tmpfs_dir_lookup(tmpfs_node_t *tfn,
                                         const componentname_t *cn);
 static void tmpfs_dir_detach(tmpfs_node_t *dv, tmpfs_dirent_t *de);
@@ -167,15 +168,15 @@ static int tmpfs_vop_setattr(vnode_t *v, vattr_t *va) {
   return ENOTSUP;
 }
 
-static int tmpfs_vop_create(vnode_t *dv, const char *name, vattr_t *va,
+static int tmpfs_vop_create(vnode_t *dv, componentname_t *cn, vattr_t *va,
                             vnode_t **vp) {
   assert(S_ISREG(va->va_mode));
-  return tmpfs_create_file(dv, vp, V_REG, name);
+  return tmpfs_create_file(dv, vp, V_REG, cn);
 }
 
-static int tmpfs_vop_remove(vnode_t *dv, vnode_t *v, const char *name) {
+static int tmpfs_vop_remove(vnode_t *dv, vnode_t *v, componentname_t *cn) {
   tmpfs_node_t *dnode = TMPFS_NODE_OF(dv);
-  tmpfs_dirent_t *de = tmpfs_dir_lookup(dnode, &COMPONENTNAME(name));
+  tmpfs_dirent_t *de = tmpfs_dir_lookup(dnode, cn);
   assert(de != NULL);
 
   tmpfs_dir_detach(dnode, de);
@@ -183,15 +184,15 @@ static int tmpfs_vop_remove(vnode_t *dv, vnode_t *v, const char *name) {
   return 0;
 }
 
-static int tmpfs_vop_mkdir(vnode_t *dv, const char *name, vattr_t *va,
+static int tmpfs_vop_mkdir(vnode_t *dv, componentname_t *cn, vattr_t *va,
                            vnode_t **vp) {
   assert(S_ISDIR(va->va_mode));
-  return tmpfs_create_file(dv, vp, V_DIR, name);
+  return tmpfs_create_file(dv, vp, V_DIR, cn);
 }
 
-static int tmpfs_vop_rmdir(vnode_t *dv, vnode_t *v, const char *name) {
+static int tmpfs_vop_rmdir(vnode_t *dv, vnode_t *v, componentname_t *cn) {
   tmpfs_node_t *dnode = TMPFS_NODE_OF(dv);
-  tmpfs_dirent_t *de = tmpfs_dir_lookup(dnode, &COMPONENTNAME(name));
+  tmpfs_dirent_t *de = tmpfs_dir_lookup(dnode, cn);
   assert(de != NULL);
 
   tmpfs_node_t *node = de->tfd_node;
@@ -294,13 +295,13 @@ static void tmpfs_free_node(tmpfs_node_t *tfn) {
  * into the parent directory.
  */
 static int tmpfs_create_file(vnode_t *dv, vnode_t **vp, vnodetype_t ntype,
-                             const char *name) {
+                             componentname_t *cn) {
   tmpfs_node_t *dnode = TMPFS_NODE_OF(dv);
   tmpfs_dirent_t *de;
   int error = 0;
 
   /* Allocate a new directory entry for the new file. */
-  error = tmpfs_alloc_dirent(name, &de);
+  error = tmpfs_alloc_dirent(cn->cn_nameptr, cn->cn_namelen, &de);
   if (error)
     return error;
 
@@ -339,15 +340,16 @@ static int tmpfs_get_vnode(mount_t *mp, tmpfs_node_t *tfn, vnode_t **vp) {
 /*
  * tmpfs_alloc_dirent: allocate a new directory entry.
  */
-static int tmpfs_alloc_dirent(const char *name, tmpfs_dirent_t **dep) {
-  size_t namelen = strlen(name);
+static int tmpfs_alloc_dirent(const char *name, size_t namelen,
+                              tmpfs_dirent_t **dep) {
   if (namelen + 1 > TMPFS_NAME_MAX)
     return ENAMETOOLONG;
 
   tmpfs_dirent_t *dirent = pool_alloc(P_TMPFS_DIRENT, M_ZERO);
   dirent->tfd_node = NULL;
   dirent->tfd_namelen = namelen;
-  memcpy(dirent->tfd_name, name, namelen + 1);
+  memcpy(dirent->tfd_name, name, namelen);
+  dirent->tfd_name[namelen] = 0;
 
   *dep = dirent;
   return 0;

--- a/sys/kern/vfs.c
+++ b/sys/kern/vfs.c
@@ -385,16 +385,11 @@ int vfs_open(file_t *f, char *pathname, int flags, int mode) {
       return error;
 
     if (v == NULL) {
-      char *namecopy = kmalloc(M_TEMP, NAME_MAX + 1, 0);
-      memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);
-      namecopy[cn.cn_namelen] = 0;
-
       vattr_t va;
       vattr_null(&va);
       va.va_mode = S_IFREG | (mode & ALLPERMS);
-      error = VOP_CREATE(dvp, namecopy, &va, &v);
+      error = VOP_CREATE(dvp, &cn, &va, &v);
       vnode_put(dvp);
-      kfree(M_TEMP, namecopy);
       if (error)
         return error;
       flags &= ~O_TRUNC;

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -194,14 +194,9 @@ int do_unlink(proc_t *p, char *path) {
     return EPERM;
   }
 
-  char *namecopy = kmalloc(M_TEMP, NAME_MAX + 1, 0);
-  memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);
-  namecopy[cn.cn_namelen] = 0;
-
-  error = VOP_REMOVE(dvn, vn, namecopy);
+  error = VOP_REMOVE(dvn, vn, &cn);
   vnode_put(dvn);
   vnode_put(vn);
-  kfree(M_TEMP, namecopy);
 
   return error;
 }
@@ -225,18 +220,12 @@ int do_mkdir(proc_t *p, char *path, mode_t mode) {
     return EEXIST;
   }
 
-  char *namecopy = kmalloc(M_TEMP, NAME_MAX + 1, 0);
-  memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);
-  namecopy[cn.cn_namelen] = 0;
-
   memset(&va, 0, sizeof(vattr_t));
   va.va_mode = S_IFDIR | (mode & ALLPERMS);
 
-  error = VOP_MKDIR(dvn, namecopy, &va, &vn);
+  error = VOP_MKDIR(dvn, &cn, &va, &vn);
   if (!error)
     vnode_drop(vn);
-
-  kfree(M_TEMP, namecopy);
 
   vnode_put(dvn);
   return error;
@@ -266,14 +255,9 @@ int do_rmdir(proc_t *p, char *path) {
     return error;
   }
 
-  char *namecopy = kmalloc(M_TEMP, NAME_MAX + 1, 0);
-  memcpy(namecopy, cn.cn_nameptr, cn.cn_namelen);
-  namecopy[cn.cn_namelen] = 0;
-
-  error = VOP_RMDIR(dvn, vn, namecopy);
+  error = VOP_RMDIR(dvn, vn, &cn);
   vnode_put(dvn);
   vnode_put(vn);
-  kfree(M_TEMP, namecopy);
 
   return error;
 }


### PR DESCRIPTION
There was some inconsistency in calling some vfs functions. They haven taken `const char *` as argument, which resulted in unnecessary memory allocations. Now they all use `componentname` like in NetBSD.