### PR TITLE
Add O_CLOEXEC support.

### DIFF
--- a/include/sys/fcntl.h
+++ b/include/sys/fcntl.h
@@ -48,11 +48,12 @@
 /* Constants used for fcntl(2) */
 
 /* command values */
-#define F_DUPFD 0 /* duplicate file descriptor */
-#define F_GETFD 1 /* get file descriptor flags */
-#define F_SETFD 2 /* set file descriptor flags */
-#define F_GETFL 3 /* get file status flags */
-#define F_SETFL 4 /* set file status flags */
+#define F_DUPFD 0          /* duplicate file descriptor */
+#define F_GETFD 1          /* get file descriptor flags */
+#define F_SETFD 2          /* set file descriptor flags */
+#define F_GETFL 3          /* get file status flags */
+#define F_SETFL 4          /* set file status flags */
+#define F_DUPFD_CLOEXEC 12 /* close on exec duplicated fd */
 
 /* file descriptor flags (F_GETFD, F_SETFD) */
 #define FD_CLOEXEC 1 /* close-on-exec flag */

--- a/include/sys/filedesc.h
+++ b/include/sys/filedesc.h
@@ -14,8 +14,13 @@
 /* Separate macro defining a hard limit on open files. */
 #define MAXFILES 1024
 
+typedef struct fdfile {
+  file_t *fdt_file;
+  bool execlose;
+} fdfile_t;
+
 typedef struct fdtab {
-  file_t **fdt_files; /* Open files array */
+  fdfile_t *fdt_files; /* Open files array */
   bitstr_t *fdt_map;  /* Bitmap of used fds */
   unsigned fdt_flags;
   int fdt_nfiles;     /* Number of files allocated */
@@ -35,11 +40,11 @@ fdtab_t *fdtab_copy(fdtab_t *fdt);
 /* Frees the table and possibly closes underlying files. */
 void fdtab_destroy(fdtab_t *fdt);
 /* Assign a file structure to a new descriptor with number >= minfd. */
-int fdtab_install_file(fdtab_t *fdt, file_t *f, int minfd, int *fdp);
+int fdtab_install_file(fdtab_t *fdt, fdfile_t f, int minfd, int *fdp);
 /* Assign a file structure to a certain descriptor number. */
-int fdtab_install_file_at(fdtab_t *fdt, file_t *f, int fd);
+int fdtab_install_file_at(fdtab_t *fdt, fdfile_t f, int fd);
 /* Extracts a reference to file from descriptor table for given number. */
-int fdtab_get_file(fdtab_t *fdt, int fd, int flags, file_t **fp);
+int fdtab_get_file(fdtab_t *fdt, int fd, int flags, fdfile_t *fp);
 /* Closes a file descriptor.
  * If it was the last reference to a file, the file is closed as well. */
 int fdtab_close_fd(fdtab_t *fdt, int fd);

--- a/include/sys/filedesc.h
+++ b/include/sys/filedesc.h
@@ -1,32 +1,10 @@
 #ifndef _SYS_FILEDESC_H_
 #define _SYS_FILEDESC_H_
 
-#include <sys/file.h>
-#include <sys/refcnt.h>
-#include <sys/mutex.h>
-#include <bitstring.h>
+#include <stdbool.h>
 
-/* The initial size of space allocated for file descriptors. According
-   to FreeBSD, this is more than enough for most applications. Each
-   process starts with this many descriptors, and more are allocated
-   on demand. */
-#define NDFILE 20
-/* Separate macro defining a hard limit on open files. */
-#define MAXFILES 1024
-
-typedef struct fdent {
-  file_t *fde_file;
-  bool fde_cloexec;
-} fdent_t;
-
-typedef struct fdtab {
-  fdent_t *fdt_entries; /* Open files array */
-  bitstr_t *fdt_map;    /* Bitmap of used fds */
-  unsigned fdt_flags;
-  int fdt_nfiles;     /* Number of files allocated */
-  refcnt_t fdt_count; /* Reference count */
-  mtx_t fdt_mtx;
-} fdtab_t;
+typedef struct file file_t;
+typedef struct fdtab fdtab_t;
 
 /*! \brief Increments reference counter. */
 void fdtab_hold(fdtab_t *fdt);

--- a/include/sys/filedesc.h
+++ b/include/sys/filedesc.h
@@ -51,6 +51,6 @@ int fdtab_close_fd(fdtab_t *fdt, int fd);
 /* Set cloexec flag. */
 int fd_set_cloexec(fdtab_t *fdt, int fd, bool exclose);
 /* Close file descriptors with cloexec flag. */
-int fd_closeexec(fdtab_t *fdt);
+int fdtab_onexec(fdtab_t *fdt);
 
 #endif /* !_SYS_FILEDESC_H_ */

--- a/include/sys/filedesc.h
+++ b/include/sys/filedesc.h
@@ -14,14 +14,14 @@
 /* Separate macro defining a hard limit on open files. */
 #define MAXFILES 1024
 
-typedef struct fdfile {
-  file_t *fdt_file;
-  bool execlose;
-} fdfile_t;
+typedef struct fdent {
+  file_t *fde_file;
+  bool fde_cloexec;
+} fdent_t;
 
 typedef struct fdtab {
-  fdfile_t *fdt_files; /* Open files array */
-  bitstr_t *fdt_map;  /* Bitmap of used fds */
+  fdent_t *fdt_entries; /* Open files array */
+  bitstr_t *fdt_map;    /* Bitmap of used fds */
   unsigned fdt_flags;
   int fdt_nfiles;     /* Number of files allocated */
   refcnt_t fdt_count; /* Reference count */
@@ -40,11 +40,11 @@ fdtab_t *fdtab_copy(fdtab_t *fdt);
 /* Frees the table and possibly closes underlying files. */
 void fdtab_destroy(fdtab_t *fdt);
 /* Assign a file structure to a new descriptor with number >= minfd. */
-int fdtab_install_file(fdtab_t *fdt, fdfile_t f, int minfd, int *fdp);
+int fdtab_install_file(fdtab_t *fdt, fdent_t f, int minfd, int *fdp);
 /* Assign a file structure to a certain descriptor number. */
-int fdtab_install_file_at(fdtab_t *fdt, fdfile_t f, int fd);
+int fdtab_install_file_at(fdtab_t *fdt, fdent_t f, int fd);
 /* Extracts a reference to file from descriptor table for given number. */
-int fdtab_get_file(fdtab_t *fdt, int fd, int flags, fdfile_t *fp);
+int fdtab_get_file(fdtab_t *fdt, int fd, int flags, fdent_t *fp);
 /* Closes a file descriptor.
  * If it was the last reference to a file, the file is closed as well. */
 int fdtab_close_fd(fdtab_t *fdt, int fd);

--- a/include/sys/filedesc.h
+++ b/include/sys/filedesc.h
@@ -40,13 +40,15 @@ fdtab_t *fdtab_copy(fdtab_t *fdt);
 /* Frees the table and possibly closes underlying files. */
 void fdtab_destroy(fdtab_t *fdt);
 /* Assign a file structure to a new descriptor with number >= minfd. */
-int fdtab_install_file(fdtab_t *fdt, fdent_t f, int minfd, int *fdp);
+int fdtab_install_file(fdtab_t *fdt, file_t *f, int minfd, int *fdp);
 /* Assign a file structure to a certain descriptor number. */
-int fdtab_install_file_at(fdtab_t *fdt, fdent_t f, int fd);
+int fdtab_install_file_at(fdtab_t *fdt, file_t *f, int fd);
 /* Extracts a reference to file from descriptor table for given number. */
-int fdtab_get_file(fdtab_t *fdt, int fd, int flags, fdent_t *fp);
+int fdtab_get_file(fdtab_t *fdt, int fd, int flags, file_t **fp);
 /* Closes a file descriptor.
  * If it was the last reference to a file, the file is closed as well. */
 int fdtab_close_fd(fdtab_t *fdt, int fd);
+/* Set cloexec flag. */
+int fd_set_cloexec(fdtab_t *fdt, int fd, bool exclose);
 
 #endif /* !_SYS_FILEDESC_H_ */

--- a/include/sys/filedesc.h
+++ b/include/sys/filedesc.h
@@ -50,5 +50,7 @@ int fdtab_get_file(fdtab_t *fdt, int fd, int flags, file_t **fp);
 int fdtab_close_fd(fdtab_t *fdt, int fd);
 /* Set cloexec flag. */
 int fd_set_cloexec(fdtab_t *fdt, int fd, bool exclose);
+/* Close file descriptors with cloexec flag. */
+int fd_closeexec(fdtab_t *fdt);
 
 #endif /* !_SYS_FILEDESC_H_ */

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -9,6 +9,7 @@
 #include <sys/thread.h>
 #include <sys/errno.h>
 #include <sys/filedesc.h>
+#include <sys/fcntl.h>
 #include <sys/sbrk.h>
 #include <sys/syslimits.h>
 #include <sys/vfs.h>

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -357,7 +357,7 @@ static int _do_execve(exec_args_t *args) {
   if ((error = exec_args_copyout(args, &stack_top)))
     goto fail;
 
-  fd_closeexec(p->p_fdtable);
+  fdtab_onexec(p->p_fdtable);
 
   /* Set up user context. */
   exc_frame_init(td->td_uframe, (void *)eh.e_entry, (void *)stack_top, EF_USER);

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -357,6 +357,8 @@ static int _do_execve(exec_args_t *args) {
   if ((error = exec_args_copyout(args, &stack_top)))
     goto fail;
 
+  fd_closeexec(p->p_fdtable);
+
   /* Set up user context. */
   exc_frame_init(td->td_uframe, (void *)eh.e_entry, (void *)stack_top, EF_USER);
 

--- a/sys/kern/filedesc.c
+++ b/sys/kern/filedesc.c
@@ -227,4 +227,3 @@ int fd_set_cloexec(fdtab_t *fdt, int fd, bool cloexec) {
   fdt->fdt_entries[fd].fde_cloexec = cloexec;
   return 0;
 }
-

--- a/sys/kern/filedesc.c
+++ b/sys/kern/filedesc.c
@@ -227,3 +227,14 @@ int fd_set_cloexec(fdtab_t *fdt, int fd, bool cloexec) {
   fdt->fdt_entries[fd].fde_cloexec = cloexec;
   return 0;
 }
+
+int fd_closeexec(fdtab_t *fdt) {
+  int error;
+  for (int fd = 0; fd < fdt->fdt_nfiles; ++fd) {
+    if (fd_is_used(fdt, fd) && fdt->fdt_entries[fd].fde_cloexec) {
+      if ((error = fdtab_close_fd(fdt, fd)))
+        return error;
+    }
+  }
+  return 0;
+}

--- a/sys/kern/filedesc.c
+++ b/sys/kern/filedesc.c
@@ -228,7 +228,7 @@ int fd_set_cloexec(fdtab_t *fdt, int fd, bool cloexec) {
   return 0;
 }
 
-int fd_closeexec(fdtab_t *fdt) {
+int fdtab_onexec(fdtab_t *fdt) {
   int error;
   for (int fd = 0; fd < fdt->fdt_nfiles; ++fd) {
     if (fd_is_used(fdt, fd) && fdt->fdt_entries[fd].fde_cloexec) {

--- a/sys/kern/pipe.c
+++ b/sys/kern/pipe.c
@@ -178,14 +178,17 @@ int do_pipe(proc_t *p, int fds[2]) {
   file_t *file0 = make_pipe_file(consumer);
   file_t *file1 = make_pipe_file(producer);
 
+  fdfile_t fdfile0 = { .fdt_file = file0, .execlose = false };
+  fdfile_t fdfile1 = { .fdt_file = file1, .execlose = false };
+
   int error;
 
-  error = fdtab_install_file(p->p_fdtable, file0, 0, &fds[0]);
+  error = fdtab_install_file(p->p_fdtable, fdfile0, 0, &fds[0]);
   if (error) {
     pipe_close(file0);
     return error;
   }
-  error = fdtab_install_file(p->p_fdtable, file1, 0, &fds[1]);
+  error = fdtab_install_file(p->p_fdtable, fdfile1, 0, &fds[1]);
   if (error) {
     fdtab_close_fd(p->p_fdtable, fds[0]);
     pipe_close(file1);

--- a/sys/kern/pipe.c
+++ b/sys/kern/pipe.c
@@ -178,8 +178,8 @@ int do_pipe(proc_t *p, int fds[2]) {
   file_t *file0 = make_pipe_file(consumer);
   file_t *file1 = make_pipe_file(producer);
 
-  fdfile_t fdfile0 = { .fdt_file = file0, .execlose = false };
-  fdfile_t fdfile1 = { .fdt_file = file1, .execlose = false };
+  fdent_t fdfile0 = {.fde_file = file0, .fde_cloexec = false};
+  fdent_t fdfile1 = {.fde_file = file1, .fde_cloexec = false};
 
   int error;
 

--- a/sys/kern/pipe.c
+++ b/sys/kern/pipe.c
@@ -182,9 +182,8 @@ int do_pipe(proc_t *p, int fds[2]) {
 
   if (!(error = fdtab_install_file(p->p_fdtable, file0, 0, &fds[0]))) {
     if (!(error = fdtab_install_file(p->p_fdtable, file1, 0, &fds[1]))) {
-      if (!(error = fd_set_cloexec(p->p_fdtable, fds[0], false))) {
+      if (!(error = fd_set_cloexec(p->p_fdtable, fds[0], false)))
         return fd_set_cloexec(p->p_fdtable, fds[1], false);
-      }
       fdtab_close_fd(p->p_fdtable, fds[1]);
     }
     fdtab_close_fd(p->p_fdtable, fds[0]);

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -14,6 +14,7 @@
 #include <sys/sched.h>
 #include <sys/malloc.h>
 #include <sys/vfs.h>
+#include <bitstring.h>
 
 #define NPROC 64 /* maximum number of processes */
 #define CHILDREN(p) (&(p)->p_children)

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -18,11 +18,13 @@ int do_open(proc_t *p, char *pathname, int flags, mode_t mode, int *fd) {
 
   /* Allocate a file structure, but do not install descriptor yet. */
   file_t *f = file_alloc();
+  fdfile_t fdf = { .fdt_file = f, 
+                   .execlose = (flags | O_CLOEXEC) ? true : false };
   /* Try opening file. Fill the file structure. */
   if ((error = vfs_open(f, pathname, flags, mode)))
     goto fail;
   /* Now install the file in descriptor table. */
-  if ((error = fdtab_install_file(p->p_fdtable, f, 0, fd)))
+  if ((error = fdtab_install_file(p->p_fdtable, fdf, 0, fd)))
     goto fail;
   return 0;
 
@@ -36,52 +38,52 @@ int do_close(proc_t *p, int fd) {
 }
 
 int do_read(proc_t *p, int fd, uio_t *uio) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
-  uio->uio_offset = f->f_offset;
-  error = FOP_READ(f, uio);
-  f->f_offset = uio->uio_offset;
-  file_drop(f);
+  uio->uio_offset = f.fdt_file->f_offset;
+  error = FOP_READ(f.fdt_file, uio);
+  f.fdt_file->f_offset = uio->uio_offset;
+  file_drop(f.fdt_file);
   return error;
 }
 
 int do_write(proc_t *p, int fd, uio_t *uio) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_WRITE, &f)))
     return error;
-  uio->uio_offset = f->f_offset;
-  error = FOP_WRITE(f, uio);
-  f->f_offset = uio->uio_offset;
-  file_drop(f);
+  uio->uio_offset = f.fdt_file->f_offset;
+  error = FOP_WRITE(f.fdt_file, uio);
+  f.fdt_file->f_offset = uio->uio_offset;
+  file_drop(f.fdt_file);
   return error;
 }
 
 int do_lseek(proc_t *p, int fd, off_t offset, int whence, off_t *newoffp) {
   /* TODO: RW file flag! For now we just file_get_read */
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
     return error;
-  error = FOP_SEEK(f, offset, whence);
-  *newoffp = f->f_offset;
-  file_drop(f);
+  error = FOP_SEEK(f.fdt_file, offset, whence);
+  *newoffp = f.fdt_file->f_offset;
+  file_drop(f.fdt_file);
   return error;
 }
 
 int do_fstat(proc_t *p, int fd, stat_t *sb) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
-  error = FOP_STAT(f, sb);
-  file_drop(f);
+  error = FOP_STAT(f.fdt_file, sb);
+  file_drop(f.fdt_file);
   return error;
 }
 
@@ -103,18 +105,20 @@ fail:
 }
 
 int do_dup(proc_t *p, int oldfd, int *newfdp) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, oldfd, 0, &f)))
     return error;
+
+  f.execlose = false;
   error = fdtab_install_file(p->p_fdtable, f, 0, newfdp);
-  file_drop(f);
+  file_drop(f.fdt_file);
   return error;
 }
 
 int do_dup2(proc_t *p, int oldfd, int newfd) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if (oldfd == newfd)
@@ -122,13 +126,15 @@ int do_dup2(proc_t *p, int oldfd, int newfd) {
 
   if ((error = fdtab_get_file(p->p_fdtable, oldfd, 0, &f)))
     return error;
+
+  f.execlose = false;
   error = fdtab_install_file_at(p->p_fdtable, f, newfd);
-  file_drop(f);
+  file_drop(f.fdt_file);
   return 0;
 }
 
 int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
@@ -145,7 +151,7 @@ int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {
       break;
   }
 
-  file_drop(f);
+  file_drop(f.fdt_file);
   return error;
 }
 
@@ -163,17 +169,17 @@ int do_mount(const char *fs, const char *path) {
 }
 
 int do_getdirentries(proc_t *p, int fd, uio_t *uio, off_t *basep) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
 
-  uio->uio_offset = f->f_offset;
-  error = VOP_READDIR(f->f_vnode, uio);
-  f->f_offset = uio->uio_offset;
-  *basep = f->f_offset;
-  file_drop(f);
+  uio->uio_offset = f.fdt_file->f_offset;
+  error = VOP_READDIR(f.fdt_file->f_vnode, uio);
+  f.fdt_file->f_offset = uio->uio_offset;
+  *basep = f.fdt_file->f_offset;
+  file_drop(f.fdt_file);
   return error;
 }
 
@@ -278,13 +284,13 @@ int do_access(proc_t *p, char *path, int amode) {
 }
 
 int do_ioctl(proc_t *p, int fd, u_long cmd, void *data) {
-  file_t *f;
+  fdfile_t f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
     return error;
-  error = FOP_IOCTL(f, cmd, data);
-  file_drop(f);
+  error = FOP_IOCTL(f.fdt_file, cmd, data);
+  file_drop(f.fdt_file);
   if (error == EPASSTHROUGH)
     error = ENOTTY;
   return error;

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -18,14 +18,17 @@ int do_open(proc_t *p, char *pathname, int flags, mode_t mode, int *fd) {
 
   /* Allocate a file structure, but do not install descriptor yet. */
   file_t *f = file_alloc();
-  fdent_t fdf = {.fde_file = f,
-                 .fde_cloexec = (flags | O_CLOEXEC) ? true : false};
   /* Try opening file. Fill the file structure. */
   if ((error = vfs_open(f, pathname, flags, mode)))
     goto fail;
   /* Now install the file in descriptor table. */
-  if ((error = fdtab_install_file(p->p_fdtable, fdf, 0, fd)))
+  if ((error = fdtab_install_file(p->p_fdtable, f, 0, fd)))
     goto fail;
+  /* Set cloexec flag */
+  if ((error = fd_set_cloexec(p->p_fdtable, *fd, 
+                              (flags & O_CLOEXEC) ? true : false)))
+    goto fail;
+
   return 0;
 
 fail:
@@ -38,52 +41,52 @@ int do_close(proc_t *p, int fd) {
 }
 
 int do_read(proc_t *p, int fd, uio_t *uio) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
-  uio->uio_offset = f.fde_file->f_offset;
-  error = FOP_READ(f.fde_file, uio);
-  f.fde_file->f_offset = uio->uio_offset;
-  file_drop(f.fde_file);
+  uio->uio_offset = f->f_offset;
+  error = FOP_READ(f, uio);
+  f->f_offset = uio->uio_offset;
+  file_drop(f);
   return error;
 }
 
 int do_write(proc_t *p, int fd, uio_t *uio) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_WRITE, &f)))
     return error;
-  uio->uio_offset = f.fde_file->f_offset;
-  error = FOP_WRITE(f.fde_file, uio);
-  f.fde_file->f_offset = uio->uio_offset;
-  file_drop(f.fde_file);
+  uio->uio_offset = f->f_offset;
+  error = FOP_WRITE(f, uio);
+  f->f_offset = uio->uio_offset;
+  file_drop(f);
   return error;
 }
 
 int do_lseek(proc_t *p, int fd, off_t offset, int whence, off_t *newoffp) {
   /* TODO: RW file flag! For now we just file_get_read */
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
     return error;
-  error = FOP_SEEK(f.fde_file, offset, whence);
-  *newoffp = f.fde_file->f_offset;
-  file_drop(f.fde_file);
+  error = FOP_SEEK(f, offset, whence);
+  *newoffp = f->f_offset;
+  file_drop(f);
   return error;
 }
 
 int do_fstat(proc_t *p, int fd, stat_t *sb) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
-  error = FOP_STAT(f.fde_file, sb);
-  file_drop(f.fde_file);
+  error = FOP_STAT(f, sb);
+  file_drop(f);
   return error;
 }
 
@@ -105,20 +108,24 @@ fail:
 }
 
 int do_dup(proc_t *p, int oldfd, int *newfdp) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, oldfd, 0, &f)))
     return error;
 
-  f.fde_cloexec = false;
   error = fdtab_install_file(p->p_fdtable, f, 0, newfdp);
-  file_drop(f.fde_file);
+  file_drop(f);
+  if (error)
+    return error;
+
+  /* The close-on-exec flag (FD_CLOEXEC) for the duplicate descriptor is off. */
+  error = fd_set_cloexec(p->p_fdtable, *newfdp, false);
   return error;
 }
 
 int do_dup2(proc_t *p, int oldfd, int newfd) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if (oldfd == newfd)
@@ -127,14 +134,15 @@ int do_dup2(proc_t *p, int oldfd, int newfd) {
   if ((error = fdtab_get_file(p->p_fdtable, oldfd, 0, &f)))
     return error;
 
-  f.fde_cloexec = false;
   error = fdtab_install_file_at(p->p_fdtable, f, newfd);
-  file_drop(f.fde_file);
+  file_drop(f);
+  /* The close-on-exec flag (FD_CLOEXEC) for the duplicate descriptor is off. */
+  error = fd_set_cloexec(p->p_fdtable, newfd, false);
   return 0;
 }
 
 int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
@@ -151,7 +159,7 @@ int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {
       break;
   }
 
-  file_drop(f.fde_file);
+  file_drop(f);
   return error;
 }
 
@@ -169,17 +177,17 @@ int do_mount(const char *fs, const char *path) {
 }
 
 int do_getdirentries(proc_t *p, int fd, uio_t *uio, off_t *basep) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
 
-  uio->uio_offset = f.fde_file->f_offset;
-  error = VOP_READDIR(f.fde_file->f_vnode, uio);
-  f.fde_file->f_offset = uio->uio_offset;
-  *basep = f.fde_file->f_offset;
-  file_drop(f.fde_file);
+  uio->uio_offset = f->f_offset;
+  error = VOP_READDIR(f->f_vnode, uio);
+  f->f_offset = uio->uio_offset;
+  *basep = f->f_offset;
+  file_drop(f);
   return error;
 }
 
@@ -284,13 +292,13 @@ int do_access(proc_t *p, char *path, int amode) {
 }
 
 int do_ioctl(proc_t *p, int fd, u_long cmd, void *data) {
-  fdent_t f;
+  file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
     return error;
-  error = FOP_IOCTL(f.fde_file, cmd, data);
-  file_drop(f.fde_file);
+  error = FOP_IOCTL(f, cmd, data);
+  file_drop(f);
   if (error == EPASSTHROUGH)
     error = ENOTTY;
   return error;

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -129,7 +129,7 @@ int do_dup2(proc_t *p, int oldfd, int newfd) {
 
   error = fdtab_install_file_at(p->p_fdtable, f, newfd);
   file_drop(f);
-  return 0;
+  return error;
 }
 
 int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -160,7 +160,13 @@ int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {
         file_drop(f);
         return error;
       }
-      error = fd_set_cloexec(p->p_fdtable, *resp, cloexec);
+      error = fd_set_cloexec(p->p_fdtable, fd, cloexec);
+      break;
+
+    case F_SETFD:
+      if (arg == FD_CLOEXEC)
+        cloexec = true;
+      error = fd_set_cloexec(p->p_fdtable, fd, cloexec);
       break;
 
     default:

--- a/sys/tests/resizable_fdt.c
+++ b/sys/tests/resizable_fdt.c
@@ -7,9 +7,9 @@ static int test_resizable_fdt(void) {
 
   for (int i = 0; i < 100; i++) {
     file_t *tmp_file = file_alloc();
-    fdent_t fdtmp_file = {.fde_file = tmp_file, .fde_cloexec = false};
     int new_fd;
-    fdtab_install_file(fdt_test, fdtmp_file, 0, &new_fd);
+    fdtab_install_file(fdt_test, tmp_file, 0, &new_fd);
+    fd_set_cloexec(fdt_test, new_fd, false);
   }
 
   fdtab_t *another_fdt_test = fdtab_copy(fdt_test);

--- a/sys/tests/resizable_fdt.c
+++ b/sys/tests/resizable_fdt.c
@@ -7,7 +7,7 @@ static int test_resizable_fdt(void) {
 
   for (int i = 0; i < 100; i++) {
     file_t *tmp_file = file_alloc();
-    fdfile_t fdtmp_file = { .fdt_file = tmp_file, .execlose = false };
+    fdent_t fdtmp_file = {.fde_file = tmp_file, .fde_cloexec = false};
     int new_fd;
     fdtab_install_file(fdt_test, fdtmp_file, 0, &new_fd);
   }

--- a/sys/tests/resizable_fdt.c
+++ b/sys/tests/resizable_fdt.c
@@ -9,7 +9,6 @@ static int test_resizable_fdt(void) {
     file_t *tmp_file = file_alloc();
     int new_fd;
     fdtab_install_file(fdt_test, tmp_file, 0, &new_fd);
-    fd_set_cloexec(fdt_test, new_fd, false);
   }
 
   fdtab_t *another_fdt_test = fdtab_copy(fdt_test);

--- a/sys/tests/resizable_fdt.c
+++ b/sys/tests/resizable_fdt.c
@@ -7,8 +7,9 @@ static int test_resizable_fdt(void) {
 
   for (int i = 0; i < 100; i++) {
     file_t *tmp_file = file_alloc();
+    fdfile_t fdtmp_file = { .fdt_file = tmp_file, .execlose = false };
     int new_fd;
-    fdtab_install_file(fdt_test, tmp_file, 0, &new_fd);
+    fdtab_install_file(fdt_test, fdtmp_file, 0, &new_fd);
   }
 
   fdtab_t *another_fdt_test = fdtab_copy(fdt_test);


### PR DESCRIPTION
Add `O_CLOEXEC` suport.

Introduce `fdent` structure into `fdtab` that contains open file and flag for file descriptor. It's based on `fdfile` from [NetBSD](http://bxr.su/NetBSD/sys/sys/filedesc.h#106).

Add `O_CLOEXEC` support for `open`, `dup`, `dup2`, `fcntl`, `execve`.