### PR TITLE
Kernel panic during VOP_READDIR

### DIFF
--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -206,7 +206,7 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp);
 int vnode_seek_generic(vnode_t *v, off_t oldoff, off_t newoff);
 int vnode_access_generic(vnode_t *v, accmode_t mode);
 
-uint8_t vnode_to_dt(vnode_t *v);
+uint8_t vnode_to_dt(vnodetype_t v_type);
 
 #define DIRENT_DOT ((void *)-2)
 #define DIRENT_DOTDOT ((void *)-1)

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -206,7 +206,7 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp);
 int vnode_seek_generic(vnode_t *v, off_t oldoff, off_t newoff);
 int vnode_access_generic(vnode_t *v, accmode_t mode);
 
-uint8_t vnode_to_dt(vnodetype_t v_type);
+uint8_t vt2dt(vnodetype_t v_type);
 
 #define DIRENT_DOT ((void *)-2)
 #define DIRENT_DOTDOT ((void *)-1)

--- a/sys/kern/devfs.c
+++ b/sys/kern/devfs.c
@@ -162,7 +162,7 @@ static void devfs_to_dirent(vnode_t *v, void *it, dirent_t *dir) {
     name = node->dn_name;
   }
   dir->d_fileno = node->dn_ino;
-  dir->d_type = vnode_to_dt(node->dn_vnode->v_type);
+  dir->d_type = vt2dt(node->dn_vnode->v_type);
   memcpy(dir->d_name, name, dir->d_namlen + 1);
 }
 

--- a/sys/kern/devfs.c
+++ b/sys/kern/devfs.c
@@ -162,7 +162,7 @@ static void devfs_to_dirent(vnode_t *v, void *it, dirent_t *dir) {
     name = node->dn_name;
   }
   dir->d_fileno = node->dn_ino;
-  dir->d_type = vnode_to_dt(node->dn_vnode);
+  dir->d_type = vnode_to_dt(node->dn_vnode->v_type);
   memcpy(dir->d_name, name, dir->d_namlen + 1);
 }
 

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -161,7 +161,7 @@ static void tmpfs_to_dirent(vnode_t *v, void *it, dirent_t *dir) {
     name = ((tmpfs_dirent_t *)it)->tfd_name;
   }
   dir->d_fileno = node->tfn_ino;
-  dir->d_type = vnode_to_dt(node->tfn_type);
+  dir->d_type = vt2dt(node->tfn_type);
   memcpy(dir->d_name, name, dir->d_namlen + 1);
 }
 

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -161,7 +161,7 @@ static void tmpfs_to_dirent(vnode_t *v, void *it, dirent_t *dir) {
     name = ((tmpfs_dirent_t *)it)->tfd_name;
   }
   dir->d_fileno = node->tfn_ino;
-  dir->d_type = vnode_to_dt(node->tfn_vnode);
+  dir->d_type = vnode_to_dt(node->tfn_type);
   memcpy(dir->d_name, name, dir->d_namlen + 1);
 }
 

--- a/sys/kern/vfs_readdir.c
+++ b/sys/kern/vfs_readdir.c
@@ -12,7 +12,7 @@ static const uint8_t vttodt_tab[] = {
                    // may require changes in future.
 };
 
-uint8_t vnode_to_dt(vnodetype_t v_type) {
+uint8_t vt2dt(vnodetype_t v_type) {
   return vttodt_tab[v_type];
 }
 

--- a/sys/kern/vfs_readdir.c
+++ b/sys/kern/vfs_readdir.c
@@ -12,8 +12,8 @@ static const uint8_t vttodt_tab[] = {
                    // may require changes in future.
 };
 
-uint8_t vnode_to_dt(vnode_t *v) {
-  return vttodt_tab[v->v_type];
+uint8_t vnode_to_dt(vnodetype_t v_type) {
+  return vttodt_tab[v_type];
 }
 
 int readdir_generic(vnode_t *v, uio_t *uio, readdir_ops_t *ops) {


### PR DESCRIPTION
Reproduction:
- create regular file in `/tmp`,
- list content of `/tmp/` directory.

The problem was in this function:
https://github.com/cahirwpz/mimiker/blob/ee3c796e0d9d080554303090941baa2242bdb72a/sys/kern/vfs_readdir.c#L15-L17

While listing content of the directory, some child might not have any reference and this means that there isn't any vnode attached to it. Then, this causes dereferencing NULL pointer - kernel panic.