### PR TITLE
Fix inappropriate usage of MIPS_KSEG0_TO_PHYS macro

### DIFF
--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -68,9 +68,9 @@ __boot_text void mips_init(void) {
   for (int i = 0; i < PT_ENTRIES; i++)
     pte[i] = PTE_GLOBAL;
 
-  paddr_t text = MIPS_KSEG0_TO_PHYS(__text);
-  paddr_t data = MIPS_KSEG0_TO_PHYS(__data);
-  paddr_t ebss = MIPS_KSEG0_TO_PHYS(roundup((vaddr_t)__ebss, PAGESIZE));
+  paddr_t text = MIPS_KSEG2_TO_PHYS(__text);
+  paddr_t data = MIPS_KSEG2_TO_PHYS(__data);
+  paddr_t ebss = MIPS_KSEG2_TO_PHYS(roundup((vaddr_t)__ebss, PAGESIZE));
   vaddr_t va = MIPS_PHYS_TO_KSEG2(text);
 
   /* assume that kernel image will be covered by single PDE (4MiB) */
@@ -91,7 +91,7 @@ __boot_text void mips_init(void) {
   /* User root PDE is NULL */
   mips32_setentrylo0(PTE_GLOBAL);
   /* Kernel root PDE is set to _kernel_pmap_pde */
-  mips32_setentrylo1(PTE_PFN(MIPS_KSEG0_TO_PHYS(_kernel_pmap_pde)) |
+  mips32_setentrylo1(PTE_PFN(MIPS_KSEG2_TO_PHYS(_kernel_pmap_pde)) |
                      PTE_KERNEL);
   mips32_setindex(0);
   mips32_tlbwi();

--- a/sys/mips/malta.c
+++ b/sys/mips/malta.c
@@ -133,7 +133,7 @@ static void malta_physmem(void) {
   /* XXX: workaround - pmap_enter fails to physical page with address 0 */
   paddr_t ram_start = MALTA_PHYS_SDRAM_BASE + PAGESIZE;
   paddr_t ram_end = MALTA_PHYS_SDRAM_BASE + kenv_get_ulong("memsize");
-  paddr_t kern_start = MIPS_KSEG2_TO_PHYS(__boot);
+  paddr_t kern_start = MIPS_KSEG0_TO_PHYS(__boot);
   paddr_t kern_end = align(MIPS_KSEG2_TO_PHYS(__ebss), PAGESIZE);
   paddr_t rd_start = ramdisk_get_start();
   paddr_t rd_end = rd_start + ramdisk_get_size();

--- a/sys/mips/malta.c
+++ b/sys/mips/malta.c
@@ -133,7 +133,7 @@ static void malta_physmem(void) {
   /* XXX: workaround - pmap_enter fails to physical page with address 0 */
   paddr_t ram_start = MALTA_PHYS_SDRAM_BASE + PAGESIZE;
   paddr_t ram_end = MALTA_PHYS_SDRAM_BASE + kenv_get_ulong("memsize");
-  paddr_t kern_start = MIPS_KSEG0_TO_PHYS(__boot);
+  paddr_t kern_start = MIPS_KSEG2_TO_PHYS(__boot);
   paddr_t kern_end = align(MIPS_KSEG2_TO_PHYS(__ebss), PAGESIZE);
   paddr_t rd_start = ramdisk_get_start();
   paddr_t rd_end = rd_start + ramdisk_get_size();


### PR DESCRIPTION
Macro `MIPS_KSEG0_TO_PHYS` is (wrongly) applied to `KSEG2` symbols. This is misleading, though technically correct, as the definition of `MIPS_KSEG0_TO_PHYS` and `MIPS_KSEG2_TO_PHYS` is exactly the same.