### PR TITLE
Fix ioctl buffer overflow.

### DIFF
--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -96,7 +96,8 @@ static int ns16550_close(vnode_t *v, file_t *fp) {
 /* XXX: This should be implemented by tty driver, not here. */
 static int ns16550_ioctl(vnode_t *v, u_long cmd, void *data) {
   if (cmd) {
-    memset(data, 0, sizeof(struct termios));
+    unsigned len = IOCPARM_LEN(cmd);
+    memset(data, 0, len);
     return 0;
   }
 


### PR DESCRIPTION
Fix ioctl buffer overflow.

For `bin/ls` we call `ioctl` with command `TIOCGWINSZ` which invokes `ns16550_ioctl` where we always clear 44 bytes of memory. But buffer length returned by `IOCPARM_LEN` in `sys_ioctl` is 8 so we have overflow.

After the change we clean exactly as many bytes as we have allocated.