### PR TITLE
Fix use-after-free bug inside thread_reap

### DIFF
--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -34,8 +34,8 @@ void thread_reap(void) {
     TAILQ_INIT(&zombie_threads);
   }
 
-  thread_t *td;
-  TAILQ_FOREACH (td, &zombies, td_zombieq)
+  thread_t *td, *next;
+  TAILQ_FOREACH_SAFE (td, &zombies, td_zombieq, next)
     thread_delete(td);
 }
 


### PR DESCRIPTION
Currently inside `thread_reap` we have a `TAILQ_FOREACH` loop which basically translates to:
```
for (... ; ... ; td = td->td_zombieq.tqe_next) {
  thread_delete(td);
}
```
The access to `td->td_zombieq` after calling `thread_delete` is obviously a use-after-free.

The bug has been found by KASAN:
```
======================================
ERROR: KernelAddressSanitizer:
invalid access to addr 0xc000b640
READ of size 4
code 0xfc
======================================
```
```
Breakpoint 3, panic_fail () at /home/jpszczolowski/mimiker/sys/kern/assert.c:6
6       __noreturn void panic_fail(void) {
(gdb) bt
#0  panic_fail () at /home/jpszczolowski/mimiker/sys/kern/assert.c:6
#1  0xc0132520 in kasan_shadow_check (read=0x1, size=0x4, addr=0xc000b640) at /home/jpszczolowski/mimiker/sys/kern/kasan.c:143
#2  __asan_load4_noabort (addr=addr@entry=0xc000b640) at /home/jpszczolowski/mimiker/sys/kern/kasan.c:246
#3  0xc011d74c in thread_reap () at /home/jpszczolowski/mimiker/sys/kern/thread.c:38
#4  0xc011d7bc in thread_create (name=name@entry=0xc016c0c0 "test-mutex", fn=fn@entry=0xc0150864 <simple_routine>, arg=arg@entry=0x0, prio=prio@entry=0x20) at /home/jpszczolowski/mimiker/sys/kern/thread.c:83
#5  0xc0150734 in test_mutex_simple () at /home/jpszczolowski/mimiker/include/sys/priority.h:28
#6  0xc012f6f0 in run_test (t=0xc017de40 <mutex_simple_test>) at /home/jpszczolowski/mimiker/sys/kern/ktest.c:117
#7  0xc012fae0 in run_all_tests () at /home/jpszczolowski/mimiker/sys/kern/ktest.c:193
#8  0xc012fd50 in ktest_main (test=test@entry=0xc0188f64 <_stack0+3940> "all") at /home/jpszczolowski/mimiker/sys/kern/ktest.c:251
#9  0xc012f128 in kmain () at /home/jpszczolowski/mimiker/sys/kern/main.c:20
#10 0xc011d958 in thread_self () at /home/jpszczolowski/mimiker/sys/kern/thread.c:120
```

