### PR TITLE
umask syscall

### DIFF
--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -30,6 +30,11 @@
 #endif
 
 /*
+ * Miscellaneous.
+ */
+#define CMASK 022 /* default file mask: S_IWGRP|S_IWOTH */
+
+/*
  * File system parameters and macros.
  *
  * The file system is made out of blocks of at most MAXBSIZE units, with

--- a/include/sys/proc.h
+++ b/include/sys/proc.h
@@ -61,6 +61,7 @@ struct proc {
   condvar_t p_waitcv;             /* (a) processes waiting for this one */
   int p_exitstatus;               /* (@) exit code to be returned to parent */
   vnode_t *p_cwd;                 /* ($) current working directory */
+  mode_t p_cmask;                 /* ($) mask for file creation */
   /* program segments */
   vm_segment_t *p_sbrk; /* ($) The entry where brk segment resides in. */
   vaddr_t p_sbrk_end;   /* ($) Current end of brk segment. */

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -116,6 +116,7 @@ typedef struct stat {
 
 #define S_BLKSIZE 512 /* block size used in the stat struct */
 
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO)
 #define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 #define ALLPERMS (S_ISUID | S_ISGID | S_ISTXT | S_IRWXU | S_IRWXG | S_IRWXO)
 

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -416,6 +416,8 @@ __noreturn void run_program(const char *path, char *const *argv,
   vnode_hold(vfs_root_vnode);
   p->p_cwd = vfs_root_vnode;
 
+  p->p_cmask = CMASK;
+
   /* ... and initialize file descriptors required by the standard library. */
   int _stdin, _stdout, _stderr;
   do_open(p, "/dev/uart", O_RDONLY, 0, &_stdin);

--- a/sys/kern/fork.c
+++ b/sys/kern/fork.c
@@ -60,6 +60,7 @@ int do_fork(pid_t *cldpidp) {
 
   vnode_hold(parent->p_cwd);
   child->p_cwd = parent->p_cwd;
+  child->p_cmask = parent->p_cmask;
 
   /* Copy signal handler dispatch rules. */
   memcpy(child->p_sigactions, parent->p_sigactions,

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -131,10 +131,9 @@ static int sys_kill(proc_t *p, kill_args_t *args, register_t *res) {
  *
  * https://pubs.opengroup.org/onlinepubs/9699919799/functions/umask.html */
 static int sys_umask(proc_t *p, umask_args_t *args, register_t *res) {
+  mode_t newmask = args->newmask;
   klog("umask(%x)", args->newmask);
-
-  /* TODO: not implemented */
-  return ENOTSUP;
+  return do_umask(p, newmask, res);
 }
 
 /* https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html */

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -19,6 +19,9 @@ int do_open(proc_t *p, char *pathname, int flags, mode_t mode, int *fdp) {
   /* Allocate a file structure, but do not install descriptor yet. */
   file_t *f = file_alloc();
 
+  /* According to POSIX, the effect when other than permission bits are set in
+   * mode is unspecified. Our implementation honors these.
+   * https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html */
   mode = (mode & ~p->p_cmask) & ALLPERMS;
 
   /* Try opening file. Fill the file structure. */
@@ -266,6 +269,9 @@ int do_mkdir(proc_t *p, char *path, mode_t mode) {
   }
 
   memset(&va, 0, sizeof(vattr_t));
+  /* We discard all bits but permission bits, since it is
+   * implementation-defined.
+   * https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html */
   va.va_mode = S_IFDIR | ((mode & ACCESSPERMS) & ~p->p_cmask);
 
   error = VOP_MKDIR(dvn, &cn, &va, &vn);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -474,3 +474,9 @@ int do_fchdir(proc_t *p, int fd) {
   file_drop(f);
   return error;
 }
+
+int do_umask(proc_t *p, int newmask, int *oldmaskp) {
+  *oldmaskp = p->p_cmask;
+  p->p_cmask = newmask & ALLPERMS;
+  return 0;
+}

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -18,6 +18,9 @@ int do_open(proc_t *p, char *pathname, int flags, mode_t mode, int *fdp) {
 
   /* Allocate a file structure, but do not install descriptor yet. */
   file_t *f = file_alloc();
+
+  mode = (mode & ~p->p_cmask) & ALLPERMS;
+
   /* Try opening file. Fill the file structure. */
   if ((error = vfs_open(f, pathname, flags, mode)))
     goto fail;
@@ -263,7 +266,7 @@ int do_mkdir(proc_t *p, char *path, mode_t mode) {
   }
 
   memset(&va, 0, sizeof(vattr_t));
-  va.va_mode = S_IFDIR | (mode & ALLPERMS);
+  va.va_mode = S_IFDIR | ((mode & ACCESSPERMS) & ~p->p_cmask);
 
   error = VOP_MKDIR(dvn, &cn, &va, &vn);
   if (!error)


### PR DESCRIPTION
Implemented [umask](https://netbsd.gw.com/cgi-bin/man-cgi?umask+2+NetBSD-current) system call. Access permissions taken as argument by `mkdir(2)` and `open(2)` system calls are now restricted by the `umask`.