### PR TITLE
Add VOP_GETATTR operation for ns16550 device

### DIFF
--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -12,6 +12,7 @@
 #include <dev/ns16550reg.h>
 #include <sys/interrupt.h>
 #include <sys/sysinit.h>
+#include <sys/stat.h>
 
 #define UART_BUFSIZE 128
 
@@ -104,13 +105,21 @@ static int ns16550_ioctl(vnode_t *v, u_long cmd, void *data) {
   return EPASSTHROUGH;
 }
 
-static vnodeops_t dev_uart_ops = {
-  .v_open = vnode_open_generic,
-  .v_write = ns16550_write,
-  .v_read = ns16550_read,
-  .v_close = ns16550_close,
-  .v_ioctl = ns16550_ioctl,
-};
+static int ns16550_getattr(vnode_t *v, vattr_t *va) {
+  memset(va, 0, sizeof(vattr_t));
+  va->va_mode = S_IFCHR;
+  va->va_nlink = 1;
+  va->va_ino = 0;
+  va->va_size = 0;
+  return 0;
+}
+
+static vnodeops_t dev_uart_ops = {.v_open = vnode_open_generic,
+                                  .v_write = ns16550_write,
+                                  .v_read = ns16550_read,
+                                  .v_close = ns16550_close,
+                                  .v_ioctl = ns16550_ioctl,
+                                  .v_getattr = ns16550_getattr};
 
 static intr_filter_t ns16550_intr(void *data) {
   ns16550_state_t *ns16550 = data;


### PR DESCRIPTION
devfs is missing most of the VOP_* operations and it can cause some errors e.g. when running `stat` without arguments. It seems that implementing these operations will require quite a lot of work. 

This PR introduces simple implementation of `VOP_GETATTR` for ns16550 device.