### PR TITLE
Fix tmux overrides.

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -26,7 +26,7 @@ set -g status-keys vi # Use vi-style key bindings in the status line.
 set -g mode-keys vi #  Use vi-style key bindings in copy mode.
 
 # toggle mouse
-bind m run "cut -c3- $(git rev-parse --show-toplevel)/.tmux.conf | sh -s _toggle_mouse"
+bind m run "cut -c3- $MIMIKER_REPO/.tmux.conf | sh -s _toggle_mouse"
 
 
 # -- copy mode -----------------------------------------------------------------
@@ -56,9 +56,7 @@ bind-key B command-prompt -p 'save last selection to:' -I 'tmux_dump' \
 
 # -- user defined overrides ----------------------------------------------------
 
-if-shell '[ -f $(git rev-parse --show-toplevel)/.tmux.conf.local ]' \
-    'source $(git rev-parse --show-toplevel)/.tmux.conf.local'
-
+source-file $MIMIKER_REPO/.tmux.conf.local
 
 # EOF
 # # Shell script begin

--- a/launch
+++ b/launch
@@ -4,6 +4,7 @@ import argparse
 import os
 import os.path
 import subprocess
+import sys
 
 from launcher import *
 
@@ -29,11 +30,7 @@ def TestRun(sim, uarts):
 def DevelRun(sim, dbg, uarts):
     from libtmux import Server, Session
 
-    # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
-    tmux_env = os.environ.copy()
-    tmux_env["MIMIKER_REPO"] = os.getcwd()
-    subprocess.run(['tmux', '-f', TMUX_CONF, '-L', 'mimiker', 'start-server'],
-                   env=tmux_env)
+    subprocess.run(['tmux', '-f', TMUX_CONF, '-L', 'mimiker', 'start-server'])
 
     server = Server(config_file=TMUX_CONF, socket_name='mimiker')
 
@@ -85,6 +82,9 @@ if __name__ == '__main__':
     # Check if the kernel file is available
     if not os.path.isfile(args.kernel):
         raise SystemExit('%s: file does not exist!' % args.kernel)
+
+    # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
+    os.environ['MIMIKER_REPO'] = os.path.dirname(os.path.realpath(sys.argv[0]))
 
     sim = QEMU()
     sim.configure(debug=args.debug, graphics=args.graphics, kernel=args.kernel,

--- a/launch
+++ b/launch
@@ -29,7 +29,11 @@ def TestRun(sim, uarts):
 def DevelRun(sim, dbg, uarts):
     from libtmux import Server, Session
 
-    subprocess.run(['tmux', '-f', TMUX_CONF, '-L', 'mimiker', 'start-server'])
+    # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
+    tmux_env = os.environ.copy()
+    tmux_env["MIMIKER_REPO"] = os.getcwd()
+    subprocess.run(['tmux', '-f', TMUX_CONF, '-L', 'mimiker', 'start-server'],
+                   env=tmux_env)
 
     server = Server(config_file=TMUX_CONF, socket_name='mimiker')
 


### PR DESCRIPTION
This seems to be the simplest solution. There is an env var `MIMIKER_REPO` set by `./launch`.
It is set to `./launch`'s cwd, and then it is used in `.tmux.conf` to source `/.tmux.conf.local`.