### PR TITLE
Fix arguments passing to open system call wrapper

### DIFF
--- a/lib/libc/sys/open.c
+++ b/lib/libc/sys/open.c
@@ -2,10 +2,12 @@
 #include <stdarg.h>
 
 int open(const char *path, int flags, ...) {
-  int ret;
-  va_list args;
-  va_start(args, flags);
-  ret = openat(AT_FDCWD, path, flags, args);
-  va_end(args);
-  return ret;
+  mode_t mode = 0;
+  if (flags & O_CREAT) {
+    va_list args;
+    va_start(args, flags);
+    mode = va_arg(args, mode_t);
+    va_end(args);
+  }
+  return openat(AT_FDCWD, path, flags, mode);
 }


### PR DESCRIPTION
There was a problem with passing arguments that are variable. Now it should be OK.