### PR TITLE
Remove yield(), use thread_yield() instead.

### DIFF
--- a/include/sys/sched.h
+++ b/include/sys/sched.h
@@ -107,12 +107,6 @@ long sched_switch(void);
  */
 void sched_maybe_preempt(void);
 
-/*! \brief Unconditionally yield the CPU to another thread.
- *
- * \note Panics if interrupts or preemption are disabled.
- */
-void yield(void);
-
 /*! \brief Turns calling thread into idle thread. */
 __noreturn void sched_run(void);
 

--- a/sys/kern/sched.c
+++ b/sys/kern/sched.c
@@ -211,16 +211,6 @@ void sched_maybe_preempt(void) {
   }
 }
 
-void yield(void) {
-  assert(!preempt_disabled() && !intr_disabled());
-  thread_t *td = thread_self();
-
-  WITH_SPIN_LOCK (&td->td_spin) {
-    td->td_state = TDS_READY;
-    sched_switch();
-  }
-}
-
 bool preempt_disabled(void) {
   thread_t *td = thread_self();
   return td->td_pdnest > 0;

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -20,7 +20,7 @@
 #include <sys/libkern.h>
 #include <sys/syslimits.h>
 #include <sys/context.h>
-#include <sys/sched.h>
+#include <sys/thread.h>
 
 #include "sysent.h"
 
@@ -819,6 +819,6 @@ end:
 
 static int sys_sched_yield(proc_t *p, void *args, register_t *res) {
   klog("sched_yield()");
-  yield();
+  thread_yield();
   return 0;
 }


### PR DESCRIPTION
For some reason I thought that we didn't have a yield function in the kernel. Turns out we did.