### PR TITLE
mtx_init & spin_init should set proper lock type

### DIFF
--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -14,7 +14,7 @@ void mtx_init(mtx_t *m, lock_type_t type) {
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;
-  m->m_type = type;
+  m->m_type = type | LK_SLEEP;
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -14,7 +14,7 @@ void spin_init(spin_t *s, lock_type_t type) {
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;
-  s->s_type = type;
+  s->s_type = type | LK_SPIN;
 }
 
 void _spin_lock(spin_t *s, const void *waitpt) {


### PR DESCRIPTION
Right now `spin_init` does not set spinlock's type to `LK_SPIN`, but it should. Look at `SPIN_INITIALIZER` implementation:
https://github.com/cahirwpz/mimiker/blob/019d2787d696c24e1d6e14b579cd5eaeedbbd92f/include/sys/spinlock.h#L33-L36

`spin_init` is used in `atkbdc` and `ns16550`:
https://github.com/cahirwpz/mimiker/blob/019d2787d696c24e1d6e14b579cd5eaeedbbd92f/sys/drv/ns16550.c#L163

So in fact `ns16550->lock` (of type `spin_t`) is used inside `cv_wait` **as a mutex**.
https://github.com/cahirwpz/mimiker/blob/019d2787d696c24e1d6e14b579cd5eaeedbbd92f/sys/drv/ns16550.c#L56-L60

But **we mustn't use mutexes in the lower half**!