### PR TITLE
Adjustments to lock_type_t

### DIFF
--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -6,8 +6,8 @@
 
 /* Union type of locks that may be passed to `cv_wait` */
 typedef union cv_lock {
-  /*! `mtx_t` and `spin_t` must begin with `lock_attrs_t` */
-  lock_attrs_t *attrs;
+  /*! `mtx_t` and `spin_t` must begin with `lk_attr_t` */
+  lk_attr_t *attrs;
   mtx_t *mtx;   /*!< sleep mutex to use with `cv_wait` */
   spin_t *spin; /*!< spin lock to use with `cv_wait`*/
 } __transparent_union cv_lock_t;

--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -6,8 +6,8 @@
 
 /* Union type of locks that may be passed to `cv_wait` */
 typedef union cv_lock {
-  lock_attrs_t
-    *attrs;     /*!< `mtx_t` and `spin_t` must begin with `lock_attrs_t` */
+  /*! `mtx_t` and `spin_t` must begin with `lock_attrs_t` */
+  lock_attrs_t *attrs;
   mtx_t *mtx;   /*!< sleep mutex to use with `cv_wait` */
   spin_t *spin; /*!< spin lock to use with `cv_wait`*/
 } __transparent_union cv_lock_t;

--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -6,9 +6,10 @@
 
 /* Union type of locks that may be passed to `cv_wait` */
 typedef union cv_lock {
-  lock_type_t *type; /*!< `mtx_t` and `spin_t` must begin with `lock_type_t` */
-  mtx_t *mtx;        /*!< sleep mutex to use with `cv_wait` */
-  spin_t *spin;      /*!< spin lock to use with `cv_wait`*/
+  lock_attrs_t
+    *attrs;     /*!< `mtx_t` and `spin_t` must begin with `lock_attrs_t` */
+  mtx_t *mtx;   /*!< sleep mutex to use with `cv_wait` */
+  spin_t *spin; /*!< spin lock to use with `cv_wait`*/
 } __transparent_union cv_lock_t;
 
 typedef struct condvar {

--- a/include/sys/condvar.h
+++ b/include/sys/condvar.h
@@ -4,14 +4,6 @@
 #include <sys/types.h>
 #include <sys/lock.h>
 
-/* Union type of locks that may be passed to `cv_wait` */
-typedef union cv_lock {
-  /*! `mtx_t` and `spin_t` must begin with `lk_attr_t` */
-  lk_attr_t *attrs;
-  mtx_t *mtx;   /*!< sleep mutex to use with `cv_wait` */
-  spin_t *spin; /*!< spin lock to use with `cv_wait`*/
-} __transparent_union cv_lock_t;
-
 typedef struct condvar {
   const char *name;     /*!< name for debugging purpose */
   volatile int waiters; /*!< # of threads sleeping in associated sleep queue */
@@ -32,7 +24,7 @@ void cv_init(condvar_t *cv, const char *name);
 #define cv_destroy(m)
 
 /*! \brief Wait on a conditional variable. */
-void cv_wait(condvar_t *cv, cv_lock_t m);
+void cv_wait(condvar_t *cv, lock_t m);
 
 /*! \brief Wait on a conditional variable with possiblity of being interrupted.
  *
@@ -49,7 +41,7 @@ void cv_wait(condvar_t *cv, cv_lock_t m);
  * \returns EINTR if the thread was interrupted during the sleep
  * \returns ETIMEDOUT if the sleep timed out
  */
-int cv_wait_timed(condvar_t *cv, cv_lock_t m, systime_t timeout);
+int cv_wait_timed(condvar_t *cv, lock_t m, systime_t timeout);
 
 /*! \brief Wake a single thread waiting on a conditional variable.
  *

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -26,12 +26,12 @@ typedef enum {
    * When a thread tries to acquire a sleeping lock that is owned by another
    * thread, it will go to sleep on a sleepqueue. */
   LK_TYPE_SLEEP = 3,
-  /*!\var LK_RECURSE
+  /*!\var LK_RECURSIVE
    * \brief Flag indicating a recursive lock.
    *
    * The lock may be acquired by the owner multiple times, and must
    * be released exactly as many times. */
-  LK_RECURSE = 4
+  LK_RECURSIVE = 4
 } lk_attr_t;
 
 typedef struct spin spin_t;
@@ -66,7 +66,7 @@ static inline bool lk_sleep_p(lock_t l) {
 
 /* !\brief Predicates checking flags of a lock */
 static inline bool lk_recursive_p(lock_t l) {
-  return lk_attr(l) & LK_RECURSE;
+  return lk_attr(l) & LK_RECURSIVE;
 }
 
 #endif /* !_SYS_LOCK_H_ */

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -1,7 +1,11 @@
 #ifndef _SYS_LOCK_H_
 #define _SYS_LOCK_H_
 
-/*! \enum Kind of lock. */
+/*!\brief Lock attributes.
+ *
+ * Non-mutually-exclusive members may be bitwise-ORed together.
+ * \note Members that have any set bits in common with #LK_TYPE_MASK
+ * are mutually exclusive and denote the lock's type. */
 typedef enum {
   /*!\var LK_BLOCK
    * \brief Type of blocking locks.

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -32,7 +32,7 @@ typedef enum {
    * The lock may be acquired by the owner multiple times, and must
    * be released exactly as many times. */
   LK_RECURSE = 0x4
-} lock_attrs_t;
+} lk_attr_t;
 
 typedef struct spin spin_t;
 typedef struct mtx mtx_t;
@@ -41,23 +41,23 @@ typedef struct mtx mtx_t;
 #define LK_TYPE_MASK 0x3
 
 /* !\brief Get lock type from attributes */
-#define lock_attrs_type(attrs) ((attrs)&LK_TYPE_MASK)
+#define lk_attr_type(attrs) ((attrs)&LK_TYPE_MASK)
 
 /* !\brief Getters for attributes' type */
-static inline bool lock_attrs_blocking(lock_attrs_t attrs) {
-  return lock_attrs_type(attrs) == LK_TYPE_BLOCK;
+static inline bool lk_attr_blocking(lk_attr_t attrs) {
+  return lk_attr_type(attrs) == LK_TYPE_BLOCK;
 }
 
-static inline bool lock_attrs_spinning(lock_attrs_t attrs) {
-  return lock_attrs_type(attrs) == LK_TYPE_SPIN;
+static inline bool lk_attr_spinning(lk_attr_t attrs) {
+  return lk_attr_type(attrs) == LK_TYPE_SPIN;
 }
 
-static inline bool lock_attrs_sleeping(lock_attrs_t attrs) {
-  return lock_attrs_type(attrs) == LK_TYPE_SLEEP;
+static inline bool lk_attr_sleeping(lk_attr_t attrs) {
+  return lk_attr_type(attrs) == LK_TYPE_SLEEP;
 }
 
 /* !\brief Getters for attributes' flags */
-static inline bool lock_attrs_recursive(lock_attrs_t attrs) {
+static inline bool lk_attr_recursive(lk_attr_t attrs) {
   return attrs & LK_RECURSE;
 }
 

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -1,25 +1,35 @@
 #ifndef _SYS_LOCK_H_
 #define _SYS_LOCK_H_
 
-/* Lock flags */
-typedef int lock_type_t;
+/*! \enum Kind of lock. */
+typedef enum {
+  /*!\var LK_BLOCK
+   * \brief Type of blocking locks.
+   *
+   * When a thread tries to acquire a blocking lock that is owned by another
+   * thread, it will block and switch out to another thread. */
+  LK_BLOCK = 0x1,
+  /*!\var LK_SPIN
+   * \brief Type of spin locks.
+   *
+   * Interrupts are disabled upon acquiring a spin lock. */
+  LK_SPIN = 0x2,
+  /*!\var LK_SLEEP
+   * \brief Type of sleeping locks.
+   *
+   * When a thread tries to acquire a sleeping lock that is owned by another
+   * thread, it will go to sleep on a sleepqueue. */
+  LK_SLEEP = 0x3,
+  /*!\var LK_RECURSE
+   * \brief Flag indicating a recursive lock.
+   *
+   * The lock may be acquired by the owner multiple times, and must
+   * be released exactly as many times. */
+  LK_RECURSE = 0x4
+} lock_type_t;
 
-/*!\brief Type of blocking locks.
- *
- * When a thread tries to acquire a blocking lock that is owned by another
- * thread, it will block and switch out to another thread. */
-#define LK_BLOCKING 0x1
-/*!\brief Type of spin locks.
- *
- * Interrupts are disabled upon acquiring a spin lock. */
-#define LK_SPIN 0x2
-/*!\brief Mask used to extract a lock's type (blocking/spin). */
-#define LK_TYPE 0x3
-/*!\brief Flag indicating a recursive lock.
- *
- * The lock may be acquired by the owner multiple times, and must
- * be released exactly as many times. */
-#define LK_RECURSE 0x4
+/*!\brief Mask used to extract a lock's type (blocking/spin/...). */
+#define LK_TYPE_MASK 0x3
 
 typedef struct spin spin_t;
 typedef struct mtx mtx_t;

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -1,27 +1,25 @@
 #ifndef _SYS_LOCK_H_
 #define _SYS_LOCK_H_
 
-/*! \enum Kind of lock. */
-typedef enum {
-  /*!\var LK_SLEEP
-   * \brief Type of sleeping lock.
-   *
-   * When a thread acquires sleeping lock that is owned by another thread it
-   * will be suspended and put on a sleep queue. */
-  LK_SLEEP = 0,
-  /*!\var LK_SPIN
-   * \brief Type of spinning lock.
-   *
-   * When a thread acquires spinning lock interrupts will be disabled.
-   */
-  LK_SPIN = 1,
-  /*!\var MTX_RECURSE
-   * \brief Type of recursive lock.
-   *
-   * The owner may lock it multiple times, but must release it as many times as
-   * she acquired it. */
-  LK_RECURSE = 2,
-} lock_type_t;
+/* Lock flags */
+typedef int lock_type_t;
+
+/*!\brief Type of blocking locks.
+ *
+ * When a thread tries to acquire a blocking lock that is owned by another
+ * thread, it will block and switch out to another thread. */
+#define LK_BLOCKING 0x1
+/*!\brief Type of spin locks.
+ *
+ * Interrupts are disabled upon acquiring a spin lock. */
+#define LK_SPIN 0x2
+/*!\brief Mask used to extract a lock's type (blocking/spin). */
+#define LK_TYPE 0x3
+/*!\brief Flag indicating a recursive lock.
+ *
+ * The lock may be acquired by the owner multiple times, and must
+ * be released exactly as many times. */
+#define LK_RECURSE 0x4
 
 typedef struct spin spin_t;
 typedef struct mtx mtx_t;

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -1,6 +1,8 @@
 #ifndef _SYS_LOCK_H_
 #define _SYS_LOCK_H_
 
+#include <stdbool.h>
+
 /*!\brief Lock attributes.
  *
  * Non-mutually-exclusive members may be bitwise-ORed together.
@@ -32,10 +34,31 @@ typedef enum {
   LK_RECURSE = 0x4
 } lock_attrs_t;
 
+typedef struct spin spin_t;
+typedef struct mtx mtx_t;
+
 /*!\brief Mask used to extract a lock's type (blocking/spin/...). */
 #define LK_TYPE_MASK 0x3
 
-typedef struct spin spin_t;
-typedef struct mtx mtx_t;
+/* !\brief Get lock type from attributes */
+#define lock_attrs_type(attrs) ((attrs)&LK_TYPE_MASK)
+
+/* !\brief Getters for attributes' type */
+static inline bool lock_attrs_blocking(lock_attrs_t attrs) {
+  return lock_attrs_type(attrs) == LK_BLOCK;
+}
+
+static inline bool lock_attrs_spinning(lock_attrs_t attrs) {
+  return lock_attrs_type(attrs) == LK_SPIN;
+}
+
+static inline bool lock_attrs_sleeping(lock_attrs_t attrs) {
+  return lock_attrs_type(attrs) == LK_SLEEP;
+}
+
+/* !\brief Getters for attributes' flags */
+static inline bool lock_attrs_recursive(lock_attrs_t attrs) {
+  return attrs & LK_RECURSE;
+}
 
 #endif /* !_SYS_LOCK_H_ */

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -26,7 +26,7 @@ typedef enum {
    * The lock may be acquired by the owner multiple times, and must
    * be released exactly as many times. */
   LK_RECURSE = 0x4
-} lock_type_t;
+} lock_attrs_t;
 
 /*!\brief Mask used to extract a lock's type (blocking/spin/...). */
 #define LK_TYPE_MASK 0x3

--- a/include/sys/lock.h
+++ b/include/sys/lock.h
@@ -9,23 +9,23 @@
  * \note Members that have any set bits in common with #LK_TYPE_MASK
  * are mutually exclusive and denote the lock's type. */
 typedef enum {
-  /*!\var LK_BLOCK
+  /*!\var LK_TYPE_BLOCK
    * \brief Type of blocking locks.
    *
    * When a thread tries to acquire a blocking lock that is owned by another
    * thread, it will block and switch out to another thread. */
-  LK_BLOCK = 0x1,
-  /*!\var LK_SPIN
+  LK_TYPE_BLOCK = 0x1,
+  /*!\var LK_TYPE_SPIN
    * \brief Type of spin locks.
    *
    * Interrupts are disabled upon acquiring a spin lock. */
-  LK_SPIN = 0x2,
-  /*!\var LK_SLEEP
+  LK_TYPE_SPIN = 0x2,
+  /*!\var LK_TYPE_SLEEP
    * \brief Type of sleeping locks.
    *
    * When a thread tries to acquire a sleeping lock that is owned by another
    * thread, it will go to sleep on a sleepqueue. */
-  LK_SLEEP = 0x3,
+  LK_TYPE_SLEEP = 0x3,
   /*!\var LK_RECURSE
    * \brief Flag indicating a recursive lock.
    *
@@ -45,15 +45,15 @@ typedef struct mtx mtx_t;
 
 /* !\brief Getters for attributes' type */
 static inline bool lock_attrs_blocking(lock_attrs_t attrs) {
-  return lock_attrs_type(attrs) == LK_BLOCK;
+  return lock_attrs_type(attrs) == LK_TYPE_BLOCK;
 }
 
 static inline bool lock_attrs_spinning(lock_attrs_t attrs) {
-  return lock_attrs_type(attrs) == LK_SPIN;
+  return lock_attrs_type(attrs) == LK_TYPE_SPIN;
 }
 
 static inline bool lock_attrs_sleeping(lock_attrs_t attrs) {
-  return lock_attrs_type(attrs) == LK_SLEEP;
+  return lock_attrs_type(attrs) == LK_TYPE_SLEEP;
 }
 
 /* !\brief Getters for attributes' flags */

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -25,7 +25,7 @@ typedef struct mtx {
 
 #define MTX_INITIALIZER(recurse)                                               \
   (mtx_t) {                                                                    \
-    .m_attrs = (recurse) | LK_BLOCK                                            \
+    .m_attrs = (recurse) | LK_TYPE_BLOCK                                       \
   }
 
 /*! \brief Initializes mutex.

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -25,7 +25,7 @@ typedef struct mtx {
 
 #define MTX_INITIALIZER(recurse)                                               \
   (mtx_t) {                                                                    \
-    .m_type = (recurse) | LK_SLEEP                                             \
+    .m_type = (recurse) | LK_BLOCKING                                          \
   }
 
 /*! \brief Initializes mutex.

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -23,9 +23,9 @@ typedef struct mtx {
   const void *m_lockpt;       /*!< place where the lock was acquired */
 } mtx_t;
 
-#define MTX_INITIALIZER(recurse)                                               \
+#define MTX_INITIALIZER(recursive)                                             \
   (mtx_t) {                                                                    \
-    .m_attr = (recurse) | LK_TYPE_BLOCK                                        \
+    .m_attr = (recursive) | LK_TYPE_BLOCK                                      \
   }
 
 /*! \brief Initializes mutex.

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -25,7 +25,7 @@ typedef struct mtx {
 
 #define MTX_INITIALIZER(recurse)                                               \
   (mtx_t) {                                                                    \
-    .m_type = (recurse) | LK_BLOCKING                                          \
+    .m_type = (recurse) | LK_BLOCK                                             \
   }
 
 /*! \brief Initializes mutex.

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -31,7 +31,7 @@ typedef struct mtx {
 /*! \brief Initializes mutex.
  *
  * \note Every mutex has to be initialized before it is used. */
-void mtx_init(mtx_t *m, lk_attr_t attrs);
+void mtx_init(mtx_t *m, lk_attr_t attr);
 
 /*! \brief Makes mutex unusable for further locking.
  *

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -17,7 +17,7 @@ typedef struct thread thread_t;
  * \note Mutex must be released by its owner!
  */
 typedef struct mtx {
-  lk_attr_t m_attrs;       /*!< lock attributes */
+  lk_attr_t m_attrs;          /*!< lock attributes */
   volatile unsigned m_count;  /*!< counter for recursive mutexes */
   volatile thread_t *m_owner; /*!< stores address of the owner */
   const void *m_lockpt;       /*!< place where the lock was acquired */

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -17,7 +17,7 @@ typedef struct thread thread_t;
  * \note Mutex must be released by its owner!
  */
 typedef struct mtx {
-  lk_attr_t m_attrs;          /*!< lock attributes */
+  lk_attr_t m_attr;           /*!< lock attributes */
   volatile unsigned m_count;  /*!< counter for recursive mutexes */
   volatile thread_t *m_owner; /*!< stores address of the owner */
   const void *m_lockpt;       /*!< place where the lock was acquired */
@@ -25,7 +25,7 @@ typedef struct mtx {
 
 #define MTX_INITIALIZER(recurse)                                               \
   (mtx_t) {                                                                    \
-    .m_attrs = (recurse) | LK_TYPE_BLOCK                                       \
+    .m_attr = (recurse) | LK_TYPE_BLOCK                                        \
   }
 
 /*! \brief Initializes mutex.

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -17,7 +17,7 @@ typedef struct thread thread_t;
  * \note Mutex must be released by its owner!
  */
 typedef struct mtx {
-  lock_type_t m_type;         /*!< type of lock */
+  lock_attrs_t m_attrs;       /*!< lock attributes */
   volatile unsigned m_count;  /*!< counter for recursive mutexes */
   volatile thread_t *m_owner; /*!< stores address of the owner */
   const void *m_lockpt;       /*!< place where the lock was acquired */
@@ -25,13 +25,13 @@ typedef struct mtx {
 
 #define MTX_INITIALIZER(recurse)                                               \
   (mtx_t) {                                                                    \
-    .m_type = (recurse) | LK_BLOCK                                             \
+    .m_attrs = (recurse) | LK_BLOCK                                            \
   }
 
 /*! \brief Initializes mutex.
  *
  * \note Every mutex has to be initialized before it is used. */
-void mtx_init(mtx_t *m, lock_type_t type);
+void mtx_init(mtx_t *m, lock_attrs_t attrs);
 
 /*! \brief Makes mutex unusable for further locking.
  *

--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -17,7 +17,7 @@ typedef struct thread thread_t;
  * \note Mutex must be released by its owner!
  */
 typedef struct mtx {
-  lock_attrs_t m_attrs;       /*!< lock attributes */
+  lk_attr_t m_attrs;       /*!< lock attributes */
   volatile unsigned m_count;  /*!< counter for recursive mutexes */
   volatile thread_t *m_owner; /*!< stores address of the owner */
   const void *m_lockpt;       /*!< place where the lock was acquired */
@@ -31,7 +31,7 @@ typedef struct mtx {
 /*! \brief Initializes mutex.
  *
  * \note Every mutex has to be initialized before it is used. */
-void mtx_init(mtx_t *m, lock_attrs_t attrs);
+void mtx_init(mtx_t *m, lk_attr_t attrs);
 
 /*! \brief Makes mutex unusable for further locking.
  *

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -30,9 +30,9 @@ typedef struct spin {
   const void *s_lockpt;       /*!< place where the lock was acquired */
 } spin_t;
 
-#define SPIN_INITIALIZER(recurse)                                              \
+#define SPIN_INITIALIZER(recursive)                                            \
   (spin_t) {                                                                   \
-    .s_attr = (recurse) | LK_TYPE_SPIN                                         \
+    .s_attr = (recursive) | LK_TYPE_SPIN                                       \
   }
 
 /*! \brief Initializes spin lock.

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -24,21 +24,21 @@ typedef struct thread thread_t;
  *       will be used for interprocessor synchronization as well.
  */
 typedef struct spin {
-  lock_type_t s_type;         /*!< type of lock */
+  lock_attrs_t s_attrs;       /*!< lock attributes */
   volatile unsigned s_count;  /*!< counter for recursive spinlock */
   volatile thread_t *s_owner; /*!< stores address of the owner */
   const void *s_lockpt;       /*!< place where the lock was acquired */
 } spin_t;
 
-#define SPIN_INITIALIZER(type)                                                 \
+#define SPIN_INITIALIZER(attrs)                                                \
   (spin_t) {                                                                   \
-    .s_type = (type) | LK_SPIN                                                 \
+    .s_attrs = (attrs) | LK_SPIN                                               \
   }
 
 /*! \brief Initializes spin lock.
  *
  * \note Every spin lock has to be initialized before it is used. */
-void spin_init(spin_t *s, lock_type_t type);
+void spin_init(spin_t *s, lock_attrs_t attrs);
 
 /*! \brief Makes spin lock unusable for further locking.
  *

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -32,7 +32,7 @@ typedef struct spin {
 
 #define SPIN_INITIALIZER(attrs)                                                \
   (spin_t) {                                                                   \
-    .s_attrs = (attrs) | LK_SPIN                                               \
+    .s_attrs = (attrs) | LK_TYPE_SPIN                                          \
   }
 
 /*! \brief Initializes spin lock.

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -24,15 +24,15 @@ typedef struct thread thread_t;
  *       will be used for interprocessor synchronization as well.
  */
 typedef struct spin {
-  lk_attr_t s_attrs;          /*!< lock attributes */
+  lk_attr_t s_attr;           /*!< lock attributes */
   volatile unsigned s_count;  /*!< counter for recursive spinlock */
   volatile thread_t *s_owner; /*!< stores address of the owner */
   const void *s_lockpt;       /*!< place where the lock was acquired */
 } spin_t;
 
-#define SPIN_INITIALIZER(attrs)                                                \
+#define SPIN_INITIALIZER(recurse)                                              \
   (spin_t) {                                                                   \
-    .s_attrs = (attrs) | LK_TYPE_SPIN                                          \
+    .s_attr = (recurse) | LK_TYPE_SPIN                                         \
   }
 
 /*! \brief Initializes spin lock.

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -24,7 +24,7 @@ typedef struct thread thread_t;
  *       will be used for interprocessor synchronization as well.
  */
 typedef struct spin {
-  lk_attr_t s_attrs;       /*!< lock attributes */
+  lk_attr_t s_attrs;          /*!< lock attributes */
   volatile unsigned s_count;  /*!< counter for recursive spinlock */
   volatile thread_t *s_owner; /*!< stores address of the owner */
   const void *s_lockpt;       /*!< place where the lock was acquired */

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -24,7 +24,7 @@ typedef struct thread thread_t;
  *       will be used for interprocessor synchronization as well.
  */
 typedef struct spin {
-  lock_attrs_t s_attrs;       /*!< lock attributes */
+  lk_attr_t s_attrs;       /*!< lock attributes */
   volatile unsigned s_count;  /*!< counter for recursive spinlock */
   volatile thread_t *s_owner; /*!< stores address of the owner */
   const void *s_lockpt;       /*!< place where the lock was acquired */
@@ -38,7 +38,7 @@ typedef struct spin {
 /*! \brief Initializes spin lock.
  *
  * \note Every spin lock has to be initialized before it is used. */
-void spin_init(spin_t *s, lock_attrs_t attrs);
+void spin_init(spin_t *s, lk_attr_t attrs);
 
 /*! \brief Makes spin lock unusable for further locking.
  *

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -38,7 +38,7 @@ typedef struct spin {
 /*! \brief Initializes spin lock.
  *
  * \note Every spin lock has to be initialized before it is used. */
-void spin_init(spin_t *s, lk_attr_t attrs);
+void spin_init(spin_t *s, lk_attr_t attr);
 
 /*! \brief Makes spin lock unusable for further locking.
  *

--- a/sys/kern/condvar.c
+++ b/sys/kern/condvar.c
@@ -3,7 +3,7 @@
 #include <sys/sched.h>
 #include <sys/mutex.h>
 
-#define spin_lock_p(m) (*(m).attrs & LK_SPIN)
+#define spin_lock_p(m) lock_attrs_spinning(*(m).attrs)
 
 static void mutex_lock(cv_lock_t m, const void *waitpt) {
   if (spin_lock_p(m))

--- a/sys/kern/condvar.c
+++ b/sys/kern/condvar.c
@@ -3,7 +3,7 @@
 #include <sys/sched.h>
 #include <sys/mutex.h>
 
-#define spin_lock_p(m) (*(m).type & LK_SPIN)
+#define spin_lock_p(m) (*(m).attrs & LK_SPIN)
 
 static void mutex_lock(cv_lock_t m, const void *waitpt) {
   if (spin_lock_p(m))

--- a/sys/kern/condvar.c
+++ b/sys/kern/condvar.c
@@ -3,17 +3,15 @@
 #include <sys/sched.h>
 #include <sys/mutex.h>
 
-#define spin_lock_p(m) lk_attr_spinning(*(m).attrs)
-
-static void mutex_lock(cv_lock_t m, const void *waitpt) {
-  if (spin_lock_p(m))
+static inline void lk_acquire(lock_t m, const void *waitpt) {
+  if (lk_spin_p(m))
     _spin_lock(m.spin, waitpt);
   else
     _mtx_lock(m.mtx, waitpt);
 }
 
-static void mutex_unlock(cv_lock_t m) {
-  if (spin_lock_p(m))
+static void lk_release(lock_t m) {
+  if (lk_spin_p(m))
     spin_unlock(m.spin);
   else
     mtx_unlock(m.mtx);
@@ -24,23 +22,23 @@ void cv_init(condvar_t *cv, const char *name) {
   cv->waiters = 0;
 }
 
-void cv_wait(condvar_t *cv, cv_lock_t m) {
+void cv_wait(condvar_t *cv, lock_t m) {
   WITH_NO_PREEMPTION {
     cv->waiters++;
-    mutex_unlock(m);
+    lk_release(m);
     sleepq_wait(cv, __caller(0));
   }
-  mutex_lock(m, __caller(0));
+  lk_acquire(m, __caller(0));
 }
 
-int cv_wait_timed(condvar_t *cv, cv_lock_t m, systime_t timeout) {
+int cv_wait_timed(condvar_t *cv, lock_t m, systime_t timeout) {
   int status;
   WITH_NO_PREEMPTION {
     cv->waiters++;
-    mutex_unlock(m);
+    lk_release(m);
     status = sleepq_wait_timed(cv, __caller(0), timeout);
   }
-  mutex_lock(m, __caller(0));
+  lk_acquire(m, __caller(0));
   return status;
 }
 

--- a/sys/kern/condvar.c
+++ b/sys/kern/condvar.c
@@ -3,7 +3,7 @@
 #include <sys/sched.h>
 #include <sys/mutex.h>
 
-#define spin_lock_p(m) lock_attrs_spinning(*(m).attrs)
+#define spin_lock_p(m) lk_attr_spinning(*(m).attrs)
 
 static void mutex_lock(cv_lock_t m, const void *waitpt) {
   if (spin_lock_p(m))

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -32,7 +32,7 @@ void intr_event_init(intr_event_t *ie, unsigned irq, const char *name,
                      ie_action_t *disable, ie_action_t *enable, void *source) {
   ie->ie_irq = irq;
   ie->ie_name = name;
-  ie->ie_lock = SPIN_INITIALIZER(LK_RECURSE);
+  ie->ie_lock = SPIN_INITIALIZER(LK_RECURSIVE);
   ie->ie_enable = enable;
   ie->ie_disable = disable;
   ie->ie_source = source;

--- a/sys/kern/klog.c
+++ b/sys/kern/klog.c
@@ -9,7 +9,7 @@
 
 klog_t klog;
 
-static spin_t klog_lock = SPIN_INITIALIZER(LK_RECURSE);
+static spin_t klog_lock = SPIN_INITIALIZER(LK_RECURSIVE);
 
 static const char *subsystems[] = {
   [KL_RUNQ] = "runq",   [KL_SLEEPQ] = "sleepq",   [KL_CALLOUT] = "callout",

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -4,19 +4,19 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define mtx_recurse_p(m) ((m)->m_type & LK_RECURSE)
+#define mtx_recurse_p(m) ((m)->m_attrs & LK_RECURSE)
 
 bool mtx_owned(mtx_t *m) {
   return (m->m_owner == thread_self());
 }
 
-void mtx_init(mtx_t *m, lock_type_t type) {
+void mtx_init(mtx_t *m, lock_attrs_t attrs) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert((type & LK_TYPE_MASK) == 0);
+  assert((attrs & LK_TYPE_MASK) == 0);
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;
-  m->m_type = type | LK_BLOCK;
+  m->m_attrs = attrs | LK_BLOCK;
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -11,10 +11,12 @@ bool mtx_owned(mtx_t *m) {
 }
 
 void mtx_init(mtx_t *m, lock_type_t type) {
+  /* The caller must not attempt to set the lock's type, only flags. */
+  assert((type & LK_TYPE) == 0);
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;
-  m->m_type = type | LK_SLEEP;
+  m->m_type = type | LK_BLOCKING;
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -16,7 +16,7 @@ void mtx_init(mtx_t *m, lock_attrs_t attrs) {
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;
-  m->m_attrs = attrs | LK_BLOCK;
+  m->m_attrs = attrs | LK_TYPE_BLOCK;
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -4,24 +4,22 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define mtx_recurse_p(m) lk_attr_recursive((m)->m_attrs)
-
 bool mtx_owned(mtx_t *m) {
   return (m->m_owner == thread_self());
 }
 
-void mtx_init(mtx_t *m, lk_attr_t attrs) {
+void mtx_init(mtx_t *m, lk_attr_t la) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert(lk_attr_type(attrs) == 0);
+  assert((la & LK_TYPE_MASK) == 0);
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;
-  m->m_attrs = attrs | LK_TYPE_BLOCK;
+  m->m_attr = la | LK_TYPE_BLOCK;
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {
   if (mtx_owned(m)) {
-    if (!mtx_recurse_p(m))
+    if (!lk_recursive_p(m))
       panic("Sleeping mutex %p is not recursive!", m);
     m->m_count++;
     return;
@@ -40,7 +38,7 @@ void mtx_unlock(mtx_t *m) {
   assert(mtx_owned(m));
 
   if (m->m_count > 0) {
-    assert(mtx_recurse_p(m));
+    assert(lk_recursive_p(m));
     m->m_count--;
     return;
   }

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -4,7 +4,7 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define mtx_recurse_p(m) ((m)->m_attrs & LK_RECURSE)
+#define mtx_recurse_p(m) lock_attrs_recursive((m)->m_attrs)
 
 bool mtx_owned(mtx_t *m) {
   return (m->m_owner == thread_self());
@@ -12,7 +12,7 @@ bool mtx_owned(mtx_t *m) {
 
 void mtx_init(mtx_t *m, lock_attrs_t attrs) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert((attrs & LK_TYPE_MASK) == 0);
+  assert(lock_attrs_type(attrs) == 0);
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -12,11 +12,11 @@ bool mtx_owned(mtx_t *m) {
 
 void mtx_init(mtx_t *m, lock_type_t type) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert((type & LK_TYPE) == 0);
+  assert((type & LK_TYPE_MASK) == 0);
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;
-  m->m_type = type | LK_BLOCKING;
+  m->m_type = type | LK_BLOCK;
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -4,15 +4,15 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define mtx_recurse_p(m) lock_attrs_recursive((m)->m_attrs)
+#define mtx_recurse_p(m) lk_attr_recursive((m)->m_attrs)
 
 bool mtx_owned(mtx_t *m) {
   return (m->m_owner == thread_self());
 }
 
-void mtx_init(mtx_t *m, lock_attrs_t attrs) {
+void mtx_init(mtx_t *m, lk_attr_t attrs) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert(lock_attrs_type(attrs) == 0);
+  assert(lk_attr_type(attrs) == 0);
   m->m_owner = NULL;
   m->m_count = 0;
   m->m_lockpt = NULL;

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -4,19 +4,19 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define spin_recurse_p(s) ((s)->s_type & LK_RECURSE)
+#define spin_recurse_p(s) ((s)->s_attrs & LK_RECURSE)
 
 bool spin_owned(spin_t *s) {
   return (s->s_owner == thread_self());
 }
 
-void spin_init(spin_t *s, lock_type_t type) {
+void spin_init(spin_t *s, lock_attrs_t attrs) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert((type & LK_TYPE_MASK) == 0);
+  assert((attrs & LK_TYPE_MASK) == 0);
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;
-  s->s_type = type | LK_SPIN;
+  s->s_attrs = attrs | LK_SPIN;
 }
 
 void _spin_lock(spin_t *s, const void *waitpt) {

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -16,7 +16,7 @@ void spin_init(spin_t *s, lock_attrs_t attrs) {
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;
-  s->s_attrs = attrs | LK_SPIN;
+  s->s_attrs = attrs | LK_TYPE_SPIN;
 }
 
 void _spin_lock(spin_t *s, const void *waitpt) {

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -4,26 +4,24 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define spin_recurse_p(s) lk_attr_recursive((s)->s_attrs)
-
 bool spin_owned(spin_t *s) {
   return (s->s_owner == thread_self());
 }
 
-void spin_init(spin_t *s, lk_attr_t attrs) {
+void spin_init(spin_t *s, lk_attr_t la) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert(lk_attr_type(attrs) == 0);
+  assert((la & LK_TYPE_MASK) == 0);
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;
-  s->s_attrs = attrs | LK_TYPE_SPIN;
+  s->s_attr = la | LK_TYPE_SPIN;
 }
 
 void _spin_lock(spin_t *s, const void *waitpt) {
   intr_disable();
 
   if (spin_owned(s)) {
-    if (!spin_recurse_p(s))
+    if (!lk_recursive_p(s))
       panic("Spin lock %p is not recursive!", s);
     s->s_count++;
     return;
@@ -38,7 +36,7 @@ void spin_unlock(spin_t *s) {
   assert(spin_owned(s));
 
   if (s->s_count > 0) {
-    assert(spin_recurse_p(s));
+    assert(lk_recursive_p(s));
     s->s_count--;
   } else {
     s->s_owner = NULL;

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -12,7 +12,7 @@ bool spin_owned(spin_t *s) {
 
 void spin_init(spin_t *s, lock_type_t type) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert((type & LK_TYPE) == 0);
+  assert((type & LK_TYPE_MASK) == 0);
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -4,7 +4,7 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define spin_recurse_p(s) ((s)->s_attrs & LK_RECURSE)
+#define spin_recurse_p(s) lock_attrs_recursive((s)->s_attrs)
 
 bool spin_owned(spin_t *s) {
   return (s->s_owner == thread_self());
@@ -12,7 +12,7 @@ bool spin_owned(spin_t *s) {
 
 void spin_init(spin_t *s, lock_attrs_t attrs) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert((attrs & LK_TYPE_MASK) == 0);
+  assert(lock_attrs_type(attrs) == 0);
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -4,15 +4,15 @@
 #include <sys/sched.h>
 #include <sys/thread.h>
 
-#define spin_recurse_p(s) lock_attrs_recursive((s)->s_attrs)
+#define spin_recurse_p(s) lk_attr_recursive((s)->s_attrs)
 
 bool spin_owned(spin_t *s) {
   return (s->s_owner == thread_self());
 }
 
-void spin_init(spin_t *s, lock_attrs_t attrs) {
+void spin_init(spin_t *s, lk_attr_t attrs) {
   /* The caller must not attempt to set the lock's type, only flags. */
-  assert(lock_attrs_type(attrs) == 0);
+  assert(lk_attr_type(attrs) == 0);
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;

--- a/sys/kern/spinlock.c
+++ b/sys/kern/spinlock.c
@@ -11,6 +11,8 @@ bool spin_owned(spin_t *s) {
 }
 
 void spin_init(spin_t *s, lock_type_t type) {
+  /* The caller must not attempt to set the lock's type, only flags. */
+  assert((type & LK_TYPE) == 0);
   s->s_owner = NULL;
   s->s_count = 0;
   s->s_lockpt = NULL;

--- a/sys/kern/taskqueue.c
+++ b/sys/kern/taskqueue.c
@@ -5,7 +5,7 @@
 
 void taskqueue_init(taskqueue_t *tq) {
   STAILQ_INIT(&tq->tq_list);
-  mtx_init(&tq->tq_mutex, LK_RECURSE);
+  mtx_init(&tq->tq_mutex, LK_RECURSIVE);
   cv_init(&tq->tq_nonempty, "taskqueue nonempty");
 }
 

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -731,7 +731,7 @@ static int tmpfs_mount(mount_t *mp) {
   /* Allocate the tmpfs mount structure and fill it. */
   tmpfs_mount_t *tfm = &tmpfs;
 
-  tfm->tfm_lock = MTX_INITIALIZER(LK_RECURSE);
+  tfm->tfm_lock = MTX_INITIALIZER(LK_RECURSIVE);
   tfm->tfm_next_ino = 2;
   mp->mnt_data = tfm;
 


### PR DESCRIPTION
- Add a new lock type (`LK_BLOCK`) that represents ordinary mutexes that use turnstiles
- Adjust lock type values so that it is possible to check that the caller doesn't try to set the lock type themselves in `mtx_init` and `spin_init`