### PR TITLE
Move callout structures from stack to dynamically or statically allocated memory

### DIFF
--- a/include/sys/callout.h
+++ b/include/sys/callout.h
@@ -39,7 +39,7 @@ void callout_setup_relative(callout_t *handle, systime_t time, timeout_t fn,
  *
  * \return True if the callout was pending and has been stopped, false if the
  * callout has already been delegated to callout thread or executed.
- * 
+ *
  * \warning It's not safe to deallocate callout memory after it has been
  * stopped. You should use \a callout_drain if you need that.
  */

--- a/include/sys/callout.h
+++ b/include/sys/callout.h
@@ -39,6 +39,9 @@ void callout_setup_relative(callout_t *handle, systime_t time, timeout_t fn,
  *
  * \return True if the callout was pending and has been stopped, false if the
  * callout has already been delegated to callout thread or executed.
+ * 
+ * \warning It's not safe to deallocate callout memory after it has been
+ * stopped. You should use \a callout_drain if you need that.
  */
 bool callout_stop(callout_t *handle);
 

--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -4,6 +4,7 @@
 #include <sys/cdefs.h>
 #include <sys/queue.h>
 #include <sys/context.h>
+#include <sys/callout.h>
 #include <sys/exception.h>
 #include <sys/mutex.h>
 #include <sys/condvar.h>
@@ -115,6 +116,7 @@ typedef struct thread {
   /* waiting channel */
   void *td_wchan;            /*!< (*) memory object on which thread awaits */
   const void *td_waitpt;     /*!< (*) PC where program waits */
+  callout_t td_slpcallout;   /*!< (*) callout used to wakeup from sleep */
   sleepq_t *td_sleepqueue;   /*!< ($) thread's sleepqueue */
   turnstile_t *td_blocked;   /*!< (#) turnstile on which thread is blocked */
   turnstile_t *td_turnstile; /*!< (#) thread's turnstile */

--- a/sys/kern/sleepq.c
+++ b/sys/kern/sleepq.c
@@ -370,18 +370,16 @@ static void sq_timeout(thread_t *td) {
 }
 
 int sleepq_wait_timed(void *wchan, const void *waitpt, systime_t timeout) {
-  callout_t co;
-  bzero(&co, sizeof(callout_t));
-
+  thread_t *td = thread_self();
   int status = 0;
   WITH_INTR_DISABLED {
     if (timeout > 0)
-      callout_setup_relative(&co, timeout, (timeout_t)sq_timeout,
+      callout_setup_relative(&td->td_slpcallout, timeout, (timeout_t)sq_timeout,
                              thread_self());
     status = _sleepq_wait(wchan, waitpt, timeout ? SLP_TIMED : SLP_INTR);
   }
   if (timeout > 0)
-    callout_stop(&co);
+    callout_stop(&td->td_slpcallout);
   return status;
 }
 

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -111,6 +111,7 @@ void thread_delete(thread_t *td) {
 
   kmem_free(td->td_kstack.stk_base, PAGESIZE);
 
+  callout_drain(&td->td_slpcallout);
   sleepq_destroy(td->td_sleepqueue);
   turnstile_destroy(td->td_turnstile);
   kfree(M_STR, td->td_name);

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -1,5 +1,6 @@
 #define KL_LOG KL_THREAD
 #include <sys/klog.h>
+#include <sys/libkern.h>
 #include <sys/mimiker.h>
 #include <sys/pool.h>
 #include <sys/malloc.h>
@@ -50,6 +51,7 @@ static void thread_init(thread_t *td, prio_t prio) {
   td->td_lock = MTX_INITIALIZER(0);
   cv_init(&td->td_waitcv, "thread waiters");
   LIST_INIT(&td->td_contested);
+  bzero(&td->td_slpcallout, sizeof(callout_t));
 
   /* From now on, you must use locks on new thread structure. */
   WITH_MTX_LOCK (threads_lock)

--- a/sys/tests/callout.c
+++ b/sys/tests/callout.c
@@ -65,13 +65,16 @@ static void callout_bad(void *arg) {
   panic("%s: should never be called!", __func__);
 }
 
+static callout_t callout;
+
 static int test_callout_stop(void) {
-  callout_t callout;
   bzero(&callout, sizeof(callout_t));
 
   callout_setup_relative(&callout, 2, callout_bad, NULL);
   /* Remove callout, hope that callout_bad won't be called! */
   callout_stop(&callout);
+  /* We don't drain this callout so its memory can still be in use after we
+   * leave the scope of function. Thus the callout is allocated statically. */
 
   return KTEST_SUCCESS;
 }

--- a/sys/tests/sleepq.c
+++ b/sys/tests/sleepq.c
@@ -44,6 +44,8 @@ static int test_sleepq_sync(void) {
   for (int i = 0; i < K; i++)
     thread_join(td[i]);
 
+  /* After callouts are drained we know that their memory is not used
+   * by callout_thread so it's safe to allocate them on stack. */
   for (int i = 0; i < N; i++)
     callout_drain(&callout[i]);
 


### PR DESCRIPTION
* Move thread sleep callout from stack to thread structure.
* Review `tests/sleepq.c`
* Move one callout in `tests/callout.c` to bss section.