### PR TITLE
Don't copyin user sigaction if the pointer is NULL.

### DIFF
--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -69,8 +69,8 @@ int do_sigaction(signo_t sig, const sigaction_t *act, sigaction_t *oldact) {
   WITH_PROC_LOCK(p) {
     if (oldact != NULL)
       memcpy(oldact, &p->p_sigactions[sig], sizeof(sigaction_t));
-
-    memcpy(&p->p_sigactions[sig], act, sizeof(sigaction_t));
+    if (act != NULL)
+      memcpy(&p->p_sigactions[sig], act, sizeof(sigaction_t));
   }
 
   return 0;

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -137,24 +137,23 @@ static int sys_umask(proc_t *p, umask_args_t *args, register_t *res) {
 /* https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html */
 static int sys_sigaction(proc_t *p, sigaction_args_t *args, register_t *res) {
   int signo = args->signum;
-  const void *p_newact = args->nsa;
-  void *p_oldact = args->osa;
+  const void *u_newact = args->nsa;
+  void *u_oldact = args->osa;
 
-  klog("sigaction(%d, %p, %p)", signo, p_newact, p_oldact);
+  klog("sigaction(%d, %p, %p)", signo, u_newact, u_oldact);
 
   sigaction_t newact;
   sigaction_t oldact;
   int error;
 
-  if ((error = copyin_s(p_newact, newact)))
+  if (u_newact && (error = copyin_s(u_newact, newact)))
     return error;
 
-  if ((error = do_sigaction(signo, &newact, &oldact)))
+  if ((error = do_sigaction(signo, u_newact ? &newact : NULL, &oldact)))
     return error;
 
-  if (p_oldact != NULL)
-    if ((error = copyout_s(oldact, p_oldact)))
-      return error;
+  if (u_oldact != NULL)
+    error = copyout_s(oldact, u_oldact);
 
   return error;
 }


### PR DESCRIPTION
The user might want to only read a signal's disposition, in which case the input sigaction pointer will be `NULL`.
This is not an error, and we shouldn't try to `copyin` the sigaction in that case.