### PR TITLE
Fix two bugs related to file modes

### DIFF
--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -288,9 +288,9 @@ static int tmpfs_vop_setattr(vnode_t *v, vattr_t *va) {
 
   if (va->va_size != (size_t)VNOVAL)
     tmpfs_reg_resize(tfm, node, va->va_size);
-  if (va->va_mode != (mode_t)VNOVAL) {
+  if (va->va_mode != (mode_t)VNOVAL)
     node->tfn_mode = (node->tfn_mode & ~ALLPERMS) | (va->va_mode & ALLPERMS);
-  }
+
   return 0;
 }
 

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -288,8 +288,9 @@ static int tmpfs_vop_setattr(vnode_t *v, vattr_t *va) {
 
   if (va->va_size != (size_t)VNOVAL)
     tmpfs_reg_resize(tfm, node, va->va_size);
-  if (va->va_mode != (mode_t)VNOVAL)
-    node->tfn_mode = va->va_mode;
+  if (va->va_mode != (mode_t)VNOVAL) {
+    node->tfn_mode = (node->tfn_mode & ~ALLPERMS) | (va->va_mode & ALLPERMS);
+  }
   return 0;
 }
 

--- a/sys/kern/vfs_vnode.c
+++ b/sys/kern/vfs_vnode.c
@@ -138,8 +138,7 @@ void vattr_convert(vattr_t *va, stat_t *sb) {
 }
 
 void vattr_null(vattr_t *va) {
-  va->va_mode = V_NONE;
-
+  va->va_mode = VNOVAL;
   va->va_nlink = VNOVAL;
   va->va_ino = VNOVAL;
   va->va_uid = VNOVAL;


### PR DESCRIPTION
When a file had been truncated (e.g. while opening a file with `O_TRUNC` flag) its mode was also removed. Invalid setting in `vattr_t` was the cause.
The second problem was that file type was omitted while changing permissions. 