### PR TITLE
Don't unlock the process in sig_kill.

### DIFF
--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -79,7 +79,7 @@ typedef struct exc_frame exc_frame_t;
  * usually performed in the context of target process.
  *
  * \sa sig_post
- * \note must be called with p::p_lock held
+ * \note Must be called with p::p_lock held. Returns with p::p_lock held.
  */
 void sig_kill(proc_t *p, signo_t sig);
 

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -267,8 +267,8 @@ __noreturn void proc_exit(int exitstatus) {
     klog("Wakeup PID(%d) because child PID(%d) died", parent->p_pid, p->p_pid);
 
     cv_broadcast(&parent->p_waitcv);
-    proc_lock(parent);
-    sig_kill(parent, SIGCHLD);
+    WITH_MTX_LOCK (&parent->p_lock)
+      sig_kill(parent, SIGCHLD);
 
     klog("Turning PID(%d) into zombie!", p->p_pid);
 
@@ -295,6 +295,7 @@ int proc_sendsig(pid_t pid, signo_t sig) {
     if (target == NULL)
       return EINVAL;
     sig_kill(target, sig);
+    proc_unlock(target);
     return 0;
   }
 
@@ -316,8 +317,8 @@ int proc_sendsig(pid_t pid, signo_t sig) {
 
   WITH_MTX_LOCK (&pgrp->pg_lock) {
     TAILQ_FOREACH (target, &pgrp->pg_members, p_pglist) {
-      proc_lock(target);
-      sig_kill(target, sig);
+      WITH_MTX_LOCK (&target->p_lock)
+        sig_kill(target, sig);
     }
   }
 

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -104,7 +104,6 @@ void sig_kill(proc_t *proc, signo_t sig) {
     proc->p_state = PS_NORMAL;
   } else if (handler == SIG_IGN ||
              (defact(sig) == SA_IGNORE && handler == SIG_DFL)) {
-    proc_unlock(proc);
     return;
   }
 
@@ -134,8 +133,6 @@ void sig_kill(proc_t *proc, signo_t sig) {
       sched_wakeup(td, 0);
     }
   }
-
-  proc_unlock(proc);
 }
 
 int sig_check(thread_t *td) {

--- a/sys/mips/signal.c
+++ b/sys/mips/signal.c
@@ -100,6 +100,6 @@ int sig_return(void) {
 
 void sig_trap(exc_frame_t *frame, signo_t sig) {
   proc_t *proc = proc_self();
-  proc_lock(proc);
-  sig_kill(proc, sig);
+  WITH_MTX_LOCK (&proc->p_lock)
+    sig_kill(proc, sig);
 }


### PR DESCRIPTION
This only led to errors in sig_kill where we forgot to unlock it.