### PR TITLE
Implement auto-reap.

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -266,9 +266,14 @@ __noreturn void proc_exit(int exitstatus) {
 
     klog("Wakeup PID(%d) because child PID(%d) died", parent->p_pid, p->p_pid);
 
-    cv_broadcast(&parent->p_waitcv);
     proc_lock(parent);
-    sig_kill(parent, SIGCHLD);
+    bool auto_reap = parent->p_sigactions[SIGCHLD].sa_handler == SIG_IGN;
+    if (!auto_reap) {
+      cv_broadcast(&parent->p_waitcv);
+      sig_kill(parent, SIGCHLD);
+    } else {
+      proc_unlock(parent);
+    }
 
     klog("Turning PID(%d) into zombie!", p->p_pid);
 
@@ -278,6 +283,11 @@ __noreturn void proc_exit(int exitstatus) {
     }
 
     klog("Process PID(%d) {%p} is dead!", p->p_pid, p);
+
+    if (auto_reap) {
+      klog("Auto-reaping process PID(%d)!", p->p_pid);
+      proc_reap(p);
+    }
   }
 
   /* Can't call [noreturn] thread_exit() from within a WITH scope. */

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -122,7 +122,9 @@ thread_t *thread_self(void) {
   return PCPU_GET(curthread);
 }
 
-/* For now this is only a stub */
+/* For now this is only a stub
+ * NOTE: this procedure must NOT access the thread's process state
+ * in ANY way, as the process might have already been reaped. */
 __noreturn void thread_exit(void) {
   thread_t *td = thread_self();
 


### PR DESCRIPTION
If the parent of an exiting child ignores SIGCHLD, the child shouldn't leave any state for the parent to reap.