### PR TITLE
Rework PID management

### DIFF
--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -398,9 +398,8 @@ __noreturn void run_program(const char *path, char *const *argv,
                             char *const *envv) {
   proc_t *p = proc_self();
 
-  assert(pgrp_enter(p, p->p_pid) == 0);
-
   assert(p != NULL);
+  assert(pgrp_enter(p, p->p_pid) == 0);
 
   klog("Starting program '%s'", path);
 

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -399,7 +399,8 @@ __noreturn void run_program(const char *path, char *const *argv,
   proc_t *p = proc_self();
 
   assert(p != NULL);
-  assert(pgrp_enter(p, p->p_pid) == 0);
+  int stat = pgrp_enter(p, p->p_pid);
+  assert(stat == 0);
 
   klog("Starting program '%s'", path);
 

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -398,7 +398,7 @@ __noreturn void run_program(const char *path, char *const *argv,
                             char *const *envv) {
   proc_t *p = proc_self();
 
-  pgrp_enter(p, 1);
+  assert(pgrp_enter(p, p->p_pid) == 0);
 
   assert(p != NULL);
 

--- a/sys/kern/fork.c
+++ b/sys/kern/fork.c
@@ -11,6 +11,7 @@
 int do_fork(pid_t *cldpidp) {
   thread_t *td = thread_self();
   proc_t *parent = td->td_proc;
+  int rv = 0;
 
   /* Cannot fork non-user threads. */
   assert(parent);
@@ -43,7 +44,8 @@ int do_fork(pid_t *cldpidp) {
 
   /* Now, prepare a new process. */
   proc_t *child = proc_create(newtd, parent);
-  assert(pgrp_enter(child, parent->p_pgrp->pg_id) == 0);
+  rv = pgrp_enter(child, parent->p_pgrp->pg_id);
+  assert(rv == 0);
 
   /* Clone the entire process memory space. */
   child->p_uspace = vm_map_clone(parent->p_uspace);
@@ -71,5 +73,5 @@ int do_fork(pid_t *cldpidp) {
   sched_add(newtd);
 
   *cldpidp = child->p_pid;
-  return 0;
+  return rv;
 }

--- a/sys/kern/fork.c
+++ b/sys/kern/fork.c
@@ -43,7 +43,7 @@ int do_fork(pid_t *cldpidp) {
 
   /* Now, prepare a new process. */
   proc_t *child = proc_create(newtd, parent);
-  pgrp_enter(child, parent->p_pgrp->pg_id);
+  assert(pgrp_enter(child, parent->p_pgrp->pg_id) == 0);
 
   /* Clone the entire process memory space. */
   child->p_uspace = vm_map_clone(parent->p_uspace);

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -29,14 +29,13 @@ static proc_list_t proc_list = TAILQ_HEAD_INITIALIZER(proc_list);
 static proc_list_t zombie_list = TAILQ_HEAD_INITIALIZER(zombie_list);
 static pgrp_list_t pgrp_list = TAILQ_HEAD_INITIALIZER(pgrp_list);
 
-typedef enum id_kind { ID_PID = 0, ID_PGID = 1 } id_kind_t;
+typedef enum id_kind { ID_PID = 0, ID_PGID = 1, ID_NUM_KINDS = 2 } id_kind_t;
 
 /* A PID is taken as long as there's a process with that PID
- * or a pgroup with a PGID equal to that PID. */
-typedef struct pid_slot {
-  proc_t *ps_proc; /* Process with the PID */
-  pgrp_t *ps_pgrp; /* Process group with PGID equal to given PID */
-} pid_slot_t;
+ * or a pgroup with a PGID equal to that PID.
+ * A PID slot contains pointers to structs that use that PID:
+ * A pointer to a `struct proc` and a pointer to a `struct pgrp`. */
+typedef void *pid_slot_t[ID_NUM_KINDS];
 
 static pid_slot_t pid_table[NPROC];
 
@@ -50,33 +49,32 @@ static bool pid_valid(pid_t pid) {
   return (pid > 0 && pid < NPROC);
 }
 
-static pid_slot_t *pid_slot_find(pid_t pid) {
-  if (pid_valid(pid)) {
-    return &pid_table[pid];
-  } else {
-    return NULL;
-  }
+static bool pid_slot_is_free(pid_slot_t ps) {
+  return (ps[ID_PID] == NULL && ps[ID_PGID] == NULL);
 }
 
-static bool pid_slot_is_free(pid_slot_t *ps) {
-  return (ps->ps_proc == NULL && ps->ps_pgrp == NULL);
-}
-
-static bool pid_is_free(pid_t pid) {
+/* Add a new user to a PID that already has a user of a different type. */
+static void pid_add_user(pid_t pid, id_kind_t kind, void *user) {
+  assert(mtx_owned(all_proc_mtx));
   assert(pid_valid(pid));
-  return pid_slot_is_free(&pid_table[pid]);
+
+  void **slot = pid_table[pid];
+  assert(!pid_slot_is_free(slot));
+  assert(slot[kind] == NULL); /* A PID can have at most 1 user of each kind. */
+  slot[kind] = user;
 }
 
-/* NOTE: The caller is responsible for setting ps_proc/ps_pgrp
- * in the corresponding slot in pid_table. */
-static pid_t pid_alloc(void) {
+/* `user` is the struct for which the caller is trying to allocate a PID. */
+static pid_t pid_alloc(id_kind_t kind, void *user) {
   assert(mtx_owned(all_proc_mtx));
 
   pid_t pid;
   bit_ffc(pid_used, NPROC, &pid);
   if (pid < 0)
     panic("Out of PIDs!");
-  assert(pid_is_free(pid));
+  void **slot = pid_table[pid];
+  assert(pid_slot_is_free(slot));
+  slot[kind] = user;
   bit_set(pid_used, pid);
   return pid;
 }
@@ -85,17 +83,11 @@ static void pid_free(pid_t pid, id_kind_t kind) {
   assert(mtx_owned(all_proc_mtx));
   assert(pid_valid(pid));
 
-  pid_slot_t *ps = pid_slot_find(pid);
+  void **slot = pid_table[pid];
+  assert(slot[kind] != NULL); /* Can't free a PID that's not in use. */
+  slot[kind] = NULL;
 
-  if (kind == ID_PID) {
-    ps->ps_proc = NULL;
-  } else if (kind == ID_PGID) {
-    ps->ps_pgrp = NULL;
-  } else {
-    panic("unknown id kind: %d", kind);
-  }
-
-  if (pid_slot_is_free(ps)) {
+  if (pid_slot_is_free(slot)) {
     bit_clear(pid_used, (unsigned)pid);
   }
 }
@@ -105,9 +97,7 @@ static void pid_free(pid_t pid, id_kind_t kind) {
 /* Finds process group with the ID specified by pgid or returns NULL. */
 static pgrp_t *pgrp_lookup(pgid_t pgid) {
   assert(mtx_owned(all_proc_mtx));
-
-  pid_slot_t *ps = pid_slot_find(pgid);
-  return (ps ? ps->ps_pgrp : NULL);
+  return (pid_valid(pgid) ? pid_table[pgid][ID_PGID] : NULL);
 }
 
 /* Make process leaves its process group. */
@@ -151,7 +141,7 @@ int pgrp_enter(proc_t *p, pgid_t pgid) {
     TAILQ_INIT(&target->pg_members);
     target->pg_lock = MTX_INITIALIZER(0);
     target->pg_id = pgid;
-    pid_table[pgid].ps_pgrp = target;
+    pid_add_user(pgid, ID_PGID, target);
 
     TAILQ_INSERT_HEAD(&pgrp_list, target, pg_link);
   }
@@ -204,8 +194,7 @@ proc_t *proc_create(thread_t *td, proc_t *parent) {
 
 void proc_add(proc_t *p) {
   WITH_MTX_LOCK (all_proc_mtx) {
-    p->p_pid = pid_alloc();
-    pid_table[p->p_pid].ps_proc = p;
+    p->p_pid = pid_alloc(ID_PID, p);
     TAILQ_INSERT_TAIL(&proc_list, p, p_all);
     if (p->p_parent)
       TAILQ_INSERT_TAIL(CHILDREN(p->p_parent), p, p_child);
@@ -217,17 +206,15 @@ void proc_add(proc_t *p) {
 proc_t *proc_find(pid_t pid) {
   assert(mtx_owned(all_proc_mtx));
 
-  pid_slot_t *ps = pid_slot_find(pid);
-  if (ps) {
-    proc_t *p = ps->ps_proc;
-    if (p) {
-      proc_lock(p);
-      if (proc_is_alive(p)) {
-        return p;
-      } else {
-        proc_unlock(p);
-      }
-    }
+  if (!pid_valid(pid))
+    return NULL;
+
+  proc_t *p = pid_table[pid][ID_PID];
+  if (p) {
+    proc_lock(p);
+    if (proc_is_alive(p))
+      return p;
+    proc_unlock(p);
   }
 
   return NULL;


### PR DESCRIPTION
It shouldn't be possible to allocate a new PID such that there is a process group with PGID equal to the new PID (that would mean that processes could accidentally become leaders of unrelated process groups). Currently, no such checks are performed on PID allocation. This PR fixes this issue and makes PID lookups faster by using a table instead of a linked list.