### PR TITLE
Auto-reap fixes

### DIFF
--- a/bin/utest/fork.c
+++ b/bin/utest/fork.c
@@ -55,8 +55,7 @@ int test_fork_sigchld_ignored(void) {
   if (n == 0)
     exit(0);
 
-  /* TODO: Use a timeout here, because otherwise the parent process exits
-     first... Which is also a useful test, but doesn't really verify an ignored
-     SIGCHILD. */
+  /* wait() should fail, since the child reaps itself. */
+  assert(wait(NULL) == -1);
   return 0;
 }

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -218,6 +218,11 @@ static void proc_reparent(proc_t *old_parent, proc_t *new_parent) {
     if (new_parent)
       TAILQ_INSERT_TAIL(CHILDREN(new_parent), child, p_child);
   }
+
+  /* The new parent might be waiting for its children to change state,
+   * so notify the parent so that they check again. */
+  if (new_parent)
+    cv_broadcast(&new_parent->p_waitcv);
 }
 
 __noreturn void proc_exit(int exitstatus) {


### PR DESCRIPTION
Currently, if a process that ignores `SIGCHLD` forks and waits for the child to exit, it will wait forever, but it can happen for 2 different reasons:
- If the child exits before the parent calls `wait()`, `do_waitpid` will fail to find a child process matching the criteria (because there are no children at all) and will wait until a child changes state, which will never happen.
What should happen: `do_waitpid` should notice that there are not child processes matching the criteria and return immediately with `ECHILD`.
- If the call to `wait()` happens before the child exits, the parent will wait until a child changes state, but the child will not notify the parent in `proc_exit`, because `auto_reap` will be true.
What should happen: the child should notify the parent unconditionally in `proc_exit`. The parent will then check that it has no children matching the criteria and return with `ECHILD`.

Both cases are bugs. This PR fixes both of them.