### PR TITLE
Remove resource from device before deallocation

### DIFF
--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -58,6 +58,8 @@ device_t *make_device(device_t *parent, driver_t *driver);
  * \note Mostly used in bus drivers. */
 void device_add_resource(device_t *dev, resource_t *r, int rid);
 
+void device_remove_resource(device_t *dev, resource_t *r);
+
 /* A universal memory pool to be used by all drivers. */
 KMALLOC_DECLARE(M_DEV);
 

--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -58,6 +58,7 @@ device_t *make_device(device_t *parent, driver_t *driver);
  * \note Mostly used in bus drivers. */
 void device_add_resource(device_t *dev, resource_t *r, int rid);
 
+/*! \brief Remove a resource from a device. */
 void device_remove_resource(device_t *dev, resource_t *r);
 
 /* A universal memory pool to be used by all drivers. */

--- a/sys/kern/device.c
+++ b/sys/kern/device.c
@@ -8,6 +8,7 @@ KMALLOC_DEFINE(M_DEV, "devices & drivers", PAGESIZE * 1024);
 
 static device_t *device_alloc(void) {
   device_t *dev = kmalloc(M_DEV, sizeof(device_t), M_ZERO);
+  TAILQ_INIT(&dev->resources);
   TAILQ_INIT(&dev->children);
   return dev;
 }

--- a/sys/kern/device.c
+++ b/sys/kern/device.c
@@ -59,3 +59,7 @@ void device_add_resource(device_t *dev, resource_t *r, int rid) {
   r->r_id = rid;
   TAILQ_INSERT_HEAD(&dev->resources, r, r_device);
 }
+
+void device_remove_resource(device_t *dev, resource_t *r) {
+  TAILQ_REMOVE(&dev->resources, r, r_device);
+}

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -365,6 +365,7 @@ static resource_t *gt_pci_alloc_resource(device_t *pcib, device_t *dev,
 
 static void gt_pci_release_resource(device_t *pcib, device_t *dev,
                                     res_type_t type, int rid, resource_t *r) {
+  device_remove_resource(dev, r);
   rman_release_resource(r);
 }
 


### PR DESCRIPTION
* `gt_pci_release_resource` now calls `device_remove_resource`, so deallocated resource does not stay on `dev->resources` tail queue (note that `gt_pci_alloc_resource` calls `device_add_resource`, which adds a newly allocated resource to `dev->resources`)
* `device_alloc` now calls `TAILQ_INIT(&dev->resources)` (another bug fixed?)

Fixes #685 