### PR TITLE
KASAN: rename PTE to PDE in boot code

### DIFF
--- a/include/mips/kasan.h
+++ b/include/mips/kasan.h
@@ -10,7 +10,7 @@
 #define KASAN_MD_SHADOW_START 0xF0000000
 #define KASAN_MD_SHADOW_SIZE (1 << 24) /* 16 MB */
 static_assert(KASAN_MD_SHADOW_SIZE % SUPERPAGESIZE == 0,
-              "Shadow memory is described by several full PTEs");
+              "Shadow memory is described by several full PDEs");
 #define KASAN_MD_SHADOW_END (KASAN_MD_SHADOW_START + KASAN_MD_SHADOW_SIZE)
 
 /* Sanitized memory (accesses within this range are checked) */

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -104,10 +104,10 @@ __boot_text void *mips_init(void) {
   va = KASAN_MD_SHADOW_START;
   /* Allocate physical memory for shadow area */
   paddr_t pa = (paddr_t)bootmem_alloc(KASAN_MD_SHADOW_SIZE);
-  /* How many PTEs should we use? */
-  int num_pte = KASAN_MD_SHADOW_SIZE / SUPERPAGESIZE;
-  for (int i = 0; i < num_pte; i++) {
-    /* Allocate a new PTE */
+  /* How many PDEs should we use? */
+  int num_pde = KASAN_MD_SHADOW_SIZE / SUPERPAGESIZE;
+  for (int i = 0; i < num_pde; i++) {
+    /* Allocate a new PT */
     pte = bootmem_alloc(PAGESIZE);
     pde[PDE_INDEX(va)] = PTE_PFN((intptr_t)pte) | PTE_KERNEL;
     for (int j = 0; j < PT_ENTRIES; j++) {


### PR DESCRIPTION
There is a mistake that PDE (page directory entry) is described as PTE (page table entry) in KASAN's code.