### PR TITLE
Fix race between kmem_free() and kmem_alloc().

### DIFF
--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -63,7 +63,6 @@ void kmem_free(void *ptr, size_t size) {
   klog("%s: free %p of size %ld", __func__, ptr, size);
 
   assert(page_aligned_p(ptr) && page_aligned_p(size));
-  vmem_free(kvspace, (vmem_addr_t)ptr, size);
 
   /* Mark the entire block as invalid */
   kasan_mark((void *)ptr, 0, size, KASAN_CODE_KMEM_USE_AFTER_FREE);
@@ -80,6 +79,8 @@ void kmem_free(void *ptr, size_t size) {
   }
 
   pmap_kremove((vaddr_t)ptr, end);
+
+  vmem_free(kvspace, (vmem_addr_t)ptr, size);
 }
 
 void *kmem_map(paddr_t pa, size_t size) {


### PR DESCRIPTION
A race is possible where thread 1 call `kmem_free()` and is preemted
right after `vmem_free()`. Then, thread 2 calls `kmem_alloc()` and
allocates the piece of address space just freed. Then, thread 1
marks the allocated addresses as invalid and unmaps them from the
kernel pmap.
By moving the call to `vmem_free()` to the very end, we make sure
that we 'own' the piece of address space until we're done with the
bookkeeping.