### PR TITLE
Replacing timeval with bintime in kernel.

### DIFF
--- a/include/sys/klog.h
+++ b/include/sys/klog.h
@@ -51,7 +51,7 @@ typedef enum {
 #define KL_SIZE 1024
 
 typedef struct klog_entry {
-  timeval_t kl_timestamp;
+  bintime_t kl_timestamp;
   tid_t kl_tid;
   unsigned kl_line;
   const char *kl_file;

--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -132,10 +132,10 @@ typedef struct thread {
   prio_t td_prio;      /*!< ($) active priority */
   int td_slice;        /*!< ($) time slice length in system ticks */
   /* thread statistics */
-  timeval_t td_rtime;        /*!< (*) time spent running */
-  timeval_t td_last_rtime;   /*!< (*) time of last switch to running state */
-  timeval_t td_slptime;      /*!< (*) time spent sleeping */
-  timeval_t td_last_slptime; /*!< (*) time of last switch to sleep state */
+  bintime_t td_rtime;        /*!< (*) time spent running */
+  bintime_t td_last_rtime;   /*!< (*) time of last switch to running state */
+  bintime_t td_slptime;      /*!< (*) time spent sleeping */
+  bintime_t td_last_slptime; /*!< (*) time of last switch to sleep state */
   unsigned td_nctxsw;        /*!< (*) total number of context switches */
   /* signal handling */
   sigset_t td_sigpend;    /*!< (p) Pending signals for this thread. */

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -46,11 +46,6 @@ typedef struct bintime {
     .frac = (uint64_t)((fp - __builtin_floor(fp)) * (1ULL << 63) * 2)          \
   }
 
-#define BINTIME2(s, fp)                                                        \
-  (bintime_t) {                                                                \
-    .sec = (time_t)s, .frac = (uint64_t)((fp) * (1ULL << 63) * 2)              \
-  }
-
 #define HZ2BT(hz)                                                              \
   (bintime_t) {                                                                \
     .sec = 0, .frac = ((1ULL << 63) / (hz)) << 1                               \

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -46,6 +46,11 @@ typedef struct bintime {
     .frac = (uint64_t)((fp - __builtin_floor(fp)) * (1ULL << 63) * 2)          \
   }
 
+#define BINTIME2(s, fp)                                                    \
+  (bintime_t) {                                                                \
+    .sec = (time_t) s, .frac = (uint64_t)((fp) * (1ULL << 63) * 2)  \
+  }
+
 #define HZ2BT(hz)                                                              \
   (bintime_t) {                                                                \
     .sec = 0, .frac = ((1ULL << 63) / (hz)) << 1                               \

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -46,9 +46,9 @@ typedef struct bintime {
     .frac = (uint64_t)((fp - __builtin_floor(fp)) * (1ULL << 63) * 2)          \
   }
 
-#define BINTIME2(s, fp)                                                    \
+#define BINTIME2(s, fp)                                                        \
   (bintime_t) {                                                                \
-    .sec = (time_t) s, .frac = (uint64_t)((fp) * (1ULL << 63) * 2)  \
+    .sec = (time_t)s, .frac = (uint64_t)((fp) * (1ULL << 63) * 2)              \
   }
 
 #define HZ2BT(hz)                                                              \

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -40,9 +40,8 @@ typedef struct bintime {
     .tv_usec = (long)((fp)*1000000L) % 1000000L                                \
   }
 
-#define _BINTIME_SEC(fp) ((time_t)__builtin_floor(fp))
-#define _BINTIME_FRAC(fp)                                                      \
-  ((uint64_t)((fp - __builtin_floor(fp)) * (1ULL << 63) * 2))
+#define _BINTIME_SEC(fp) ((time_t)(int64_t)(fp))
+#define _BINTIME_FRAC(fp) ((uint64_t)((fp - (int64_t)(fp)) * (1ULL << 63) * 2))
 
 #define BINTIME(fp)                                                            \
   (bintime_t) {                                                                \

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -40,10 +40,13 @@ typedef struct bintime {
     .tv_usec = (long)((fp)*1000000L) % 1000000L                                \
   }
 
+#define _BINTIME_SEC(fp) ((time_t)__builtin_floor(fp))
+#define _BINTIME_FRAC(fp)                                                      \
+  ((uint64_t)((fp - __builtin_floor(fp)) * (1ULL << 63) * 2))
+
 #define BINTIME(fp)                                                            \
   (bintime_t) {                                                                \
-    .sec = (time_t)__builtin_floor(fp),                                        \
-    .frac = (uint64_t)((fp - __builtin_floor(fp)) * (1ULL << 63) * 2)          \
+    .sec = _BINTIME_SEC(fp), .frac = _BINTIME_FRAC(fp)                         \
   }
 
 #define HZ2BT(hz)                                                              \
@@ -62,6 +65,7 @@ static inline timeval_t ts2tv(timespec_t ts) {
 static inline systime_t tv2st(timeval_t tv) {
   return tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
+
 static inline systime_t bt2st(bintime_t *bt) {
   return bt->sec * 1000 + (((uint64_t)1000 * (uint32_t)(bt->frac >> 32)) >> 32);
 }

--- a/sys/debug/__init__.py
+++ b/sys/debug/__init__.py
@@ -5,7 +5,7 @@ from .kdump import Kdump
 from .klog import Klog
 from .ktrace import Ktrace
 from .proc import Kprocess, Process, CurrentProcess
-from .struct import TimeVal
+from .struct import BinTime
 from .sync import CondVar, Mutex
 from .thread import Kthread, Thread, CurrentThread
 from .events import stop_handler
@@ -17,7 +17,7 @@ def addPrettyPrinters():
     pp.add_printer('condvar', 'condvar', CondVar)
     pp.add_printer('thread', 'thread', Thread)
     pp.add_printer('process', 'process', Process)
-    pp.add_printer('timeval', 'timeval', TimeVal)
+    pp.add_printer('bintime', 'bintime', BinTime)
     gdb.printing.register_pretty_printer(gdb.current_objfile(), pp)
 
 

--- a/sys/debug/klog.py
+++ b/sys/debug/klog.py
@@ -2,13 +2,13 @@ import gdb
 import os.path
 
 from .cmd import SimpleCommand
-from .struct import GdbStructMeta, enum, cstr, TimeVal
+from .struct import GdbStructMeta, enum, cstr, BinTime
 from .utils import TextTable, global_var, relpath
 
 
 class LogEntry(metaclass=GdbStructMeta):
     __ctype__ = 'struct klog_entry'
-    __cast__ = {'kl_tid': int, 'kl_timestamp': TimeVal, 'kl_file': cstr,
+    __cast__ = {'kl_tid': int, 'kl_timestamp': BinTime, 'kl_file': cstr,
                 'kl_format': cstr, 'kl_line': int, 'kl_origin': enum}
 
     @property

--- a/sys/debug/struct.py
+++ b/sys/debug/struct.py
@@ -69,7 +69,6 @@ class TimeVal(metaclass=GdbStructMeta):
         return 'timeval{%.6f}' % self.as_float()
 
 
-
 class BinTime(metaclass=GdbStructMeta):
     __ctype__ = 'struct bintime'
     __cast__ = {'sec': int, 'frac': int}

--- a/sys/debug/struct.py
+++ b/sys/debug/struct.py
@@ -69,6 +69,18 @@ class TimeVal(metaclass=GdbStructMeta):
         return 'timeval{%.6f}' % self.as_float()
 
 
+
+class BinTime(metaclass=GdbStructMeta):
+    __ctype__ = 'struct bintime'
+    __cast__ = {'sec': int, 'frac': int}
+
+    def as_float(self):
+        return float(self.sec) + float(self.frac) * 2e-64
+
+    def __str__(self):
+        return 'timeval{%.6f}' % self.as_float()
+
+
 class TailQueue():
     def __init__(self, tq, field):
         self.tq = tq

--- a/sys/kern/klog.c
+++ b/sys/kern/klog.c
@@ -57,7 +57,7 @@ void klog_append(klog_origin_t origin, const char *file, unsigned line,
   tid_t tid = thread_self()->td_tid;
 
   WITH_SPIN_LOCK (&klog_lock) {
-    timeval_t now = get_uptime();
+    bintime_t now = getbintime();
 
     entry = (klog.prev >= 0) ? &klog.array[klog.prev] : NULL;
 

--- a/sys/kern/ktest.c
+++ b/sys/kern/ktest.c
@@ -84,7 +84,7 @@ typedef int (*test_func_t)(unsigned);
 
 /* If the test fails, run_test will not return. */
 static int run_test(test_entry_t *t) {
-  timeval_t start = get_uptime();
+  bintime_t start = getbintime();
 
   /* These are messages to the user, so I intentionally use kprintf instead of
    * log. */
@@ -120,8 +120,10 @@ static int run_test(test_entry_t *t) {
   if (result == KTEST_FAILURE)
     ktest_failure();
 
-  timeval_t end = get_uptime();
-  tv2st(timeval_sub(&end, &start));
+  /* It is not used - end and now */
+  bintime_t end = getbintime();
+  bintime_sub(&end, &start);
+  bt2st(&end);
 
   return result;
 }

--- a/sys/kern/ktest.c
+++ b/sys/kern/ktest.c
@@ -2,7 +2,6 @@
 #include <sys/kenv.h>
 #include <sys/ktest.h>
 #include <sys/libkern.h>
-#include <sys/time.h>
 #include <sys/interrupt.h>
 
 #define KTEST_MAX_NO 1024

--- a/sys/kern/ktest.c
+++ b/sys/kern/ktest.c
@@ -84,8 +84,6 @@ typedef int (*test_func_t)(unsigned);
 
 /* If the test fails, run_test will not return. */
 static int run_test(test_entry_t *t) {
-  bintime_t start = getbintime();
-
   /* These are messages to the user, so I intentionally use kprintf instead of
    * log. */
   kprintf("# Running test \"%s\".\n", t->test_name);
@@ -119,11 +117,6 @@ static int run_test(test_entry_t *t) {
   }
   if (result == KTEST_FAILURE)
     ktest_failure();
-
-  /* It is not used - end and now */
-  bintime_t end = getbintime();
-  bintime_sub(&end, &start);
-  bt2st(&end);
 
   return result;
 }

--- a/sys/kern/sched.c
+++ b/sys/kern/sched.c
@@ -34,9 +34,9 @@ void sched_wakeup(thread_t *td, long reason) {
   assert(!td_is_running(td));
 
   /* Update sleep time. */
-  timeval_t now = get_uptime();
-  now = timeval_sub(&now, &td->td_last_slptime);
-  td->td_slptime = timeval_add(&td->td_slptime, &now);
+  bintime_t now = getbintime();
+  bintime_sub(&now, &td->td_last_slptime);
+  bintime_add(&td->td_slptime, &now);
 
   td->td_state = TDS_READY;
   td->td_slice = SLICE;
@@ -117,7 +117,7 @@ static thread_t *sched_choose(void) {
     return PCPU_GET(idle_thread);
   runq_remove(&runq, td);
   td->td_state = TDS_RUNNING;
-  td->td_last_rtime = get_uptime();
+  td->td_last_rtime = getbintime();
   return td;
 }
 
@@ -133,9 +133,9 @@ long sched_switch(void) {
   td->td_flags &= ~(TDF_SLICEEND | TDF_NEEDSWITCH);
 
   /* Update running time, */
-  timeval_t now = get_uptime();
-  timeval_t diff = timeval_sub(&now, &td->td_last_rtime);
-  td->td_rtime = timeval_add(&td->td_rtime, &diff);
+  bintime_t now = getbintime();
+  bintime_sub(&now, &td->td_last_rtime);
+  bintime_add(&td->td_rtime, &now);
 
   if (td_is_ready(td)) {
     /* Idle threads need not to be inserted into the run queue. */

--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -122,8 +122,8 @@ int tm_start(timer_t *tm, unsigned flags, const bintime_t start,
   if (((tm->tm_flags & flags) & TMF_TYPEMASK) == 0)
     return ENODEV;
   if (flags & TMF_PERIODIC) {
-    if (bintime_cmp(period, tm->tm_min_period, <) ||
-        bintime_cmp(period, tm->tm_max_period, >))
+    if (bintime_cmp(&period, &tm->tm_min_period, <) ||
+        bintime_cmp(&period, &tm->tm_max_period, >))
       return EINVAL;
   }
 

--- a/sys/tests/klog.c
+++ b/sys/tests/klog.c
@@ -13,7 +13,7 @@
 #define NUMBER_OF_ROUNDS 25
 #define MAX_SLEEP_TIME 20
 thread_t *threads[MAX_THREAD_NUM];
-static timeval_t start;
+static bintime_t start;
 
 static uint32_t seed = 0; /* Current seed */
 
@@ -92,9 +92,9 @@ static int multithreads_test(const int number_of_threads) {
 
 /* Function that checks if sleep time is over and assigne new sleep time. */
 static int check_time(systime_t *sleep, const uint32_t freq) {
-  timeval_t now = get_uptime();
-  timeval_t diff = timeval_sub(&now, &start);
-  if (tv2st(diff) < (*sleep))
+  bintime_t now = getbintime();
+  bintime_sub(&now, &start);
+  if (bt2st(&now) < (*sleep))
     return 1;
   (*sleep) += (rand() & freq);
   return 0;
@@ -138,7 +138,7 @@ static int stress_test(void) {
   /* threads[5] = thread_create("Thread dump2", thread_test, &klog_dump); */
 
   int number_of_threads = 5;
-  start = get_uptime();
+  start = getbintime();
   for (int i = 0; i < number_of_threads; i++)
     sched_add(threads[i]);
 

--- a/sys/tests/sched.c
+++ b/sys/tests/sched.c
@@ -9,12 +9,12 @@
 #if 0
 static void demo_thread_1(void) {
   while (true) {
-    timeval_t start = get_uptime();
-    kprintf("[%8zu] Running '%s' thread.\n", (size_t)tv2st(start),
+    bintime_t start = getbintime();
+    kprintf("[%8zu] Running '%s' thread.\n", (size_t)bt2st(start),
             thread_self()->td_name);
-    timeval_t now = get_uptime();
-    while (tv2st(now) < tv2st(start) + 20)
-      now = get_uptime();
+    bintime_t now = getbintime();
+    while (bt2st(now) < bt2st(start) + 20)
+      now = getbintime();
   }
 }
 

--- a/sys/tests/thread_exit.c
+++ b/sys/tests/thread_exit.c
@@ -5,7 +5,8 @@
 #include <sys/sched.h>
 #include <sys/ktest.h>
 
-static bintime_t exit_time[] = {BINTIME(0.100), BINTIME(0.200), BINTIME(0.150)};
+static bintime_t exit_time[] = {BINTIME2(0, 0.100), BINTIME2(0, 0.200),
+                                BINTIME2(0, 0.150)};
 static bintime_t start;
 
 /* TODO: callout + sleepq, once we've implemented callout_schedule. */

--- a/sys/tests/thread_exit.c
+++ b/sys/tests/thread_exit.c
@@ -5,8 +5,6 @@
 #include <sys/sched.h>
 #include <sys/ktest.h>
 
-static bintime_t exit_time[] = {BINTIME2(0, 0.100), BINTIME2(0, 0.200),
-                                BINTIME2(0, 0.150)};
 static bintime_t start;
 
 /* TODO: callout + sleepq, once we've implemented callout_schedule. */
@@ -24,6 +22,8 @@ static void test_thread(void *p) {
 
 /* This tests both thread_join as well as thread_exit. */
 static int test_thread_join(void) {
+  static bintime_t exit_time[] = {BINTIME(0.100), BINTIME(0.200),
+                                  BINTIME(0.150)};
   thread_t *t1 = thread_create("test-thread-exit-1", test_thread, &exit_time[0],
                                prio_kthread(0));
   thread_t *t2 = thread_create("test-thread-exit-2", test_thread, &exit_time[1],

--- a/sys/tests/thread_exit.c
+++ b/sys/tests/thread_exit.c
@@ -22,8 +22,7 @@ static void test_thread(void *p) {
 
 /* This tests both thread_join as well as thread_exit. */
 static int test_thread_join(void) {
-  static bintime_t exit_time[] = {BINTIME(0.100), BINTIME(0.200),
-                                  BINTIME(0.150)};
+  bintime_t exit_time[] = {BINTIME(0.100), BINTIME(0.200), BINTIME(0.150)};
   thread_t *t1 = thread_create("test-thread-exit-1", test_thread, &exit_time[0],
                                prio_kthread(0));
   thread_t *t2 = thread_create("test-thread-exit-2", test_thread, &exit_time[1],

--- a/sys/tests/thread_exit.c
+++ b/sys/tests/thread_exit.c
@@ -5,16 +5,16 @@
 #include <sys/sched.h>
 #include <sys/ktest.h>
 
-static timeval_t exit_time[] = {TIMEVAL(0.100), TIMEVAL(0.200), TIMEVAL(0.150)};
-static timeval_t start;
+static bintime_t exit_time[] = {BINTIME(0.100), BINTIME(0.200), BINTIME(0.150)};
+static bintime_t start;
 
 /* TODO: callout + sleepq, once we've implemented callout_schedule. */
 static void test_thread(void *p) {
-  timeval_t *e = (timeval_t *)p;
+  bintime_t *e = (bintime_t *)p;
   while (1) {
-    timeval_t now = get_uptime();
-    timeval_t diff = timeval_sub(&now, &start);
-    if (timeval_cmp(&diff, e, >))
+    bintime_t now = getbintime();
+    bintime_sub(&now, &start);
+    if (bintime_cmp(&now, e, >))
       thread_exit();
     else
       thread_yield();
@@ -34,7 +34,7 @@ static int test_thread_join(void) {
   tid_t t2_id = t2->td_tid;
   tid_t t3_id = t3->td_tid;
 
-  start = get_uptime();
+  start = getbintime();
   sched_add(t1);
   sched_add(t2);
   sched_add(t3);

--- a/sys/tests/thread_stats.c
+++ b/sys/tests/thread_stats.c
@@ -7,11 +7,12 @@
 
 #define THREADS_NUMBER 10
 
-static bintime_t test_time = BINTIME2(0, 0.2);
+/* 0.2 as a bintime fraction */
+static uint64_t test_time_frac = 3689348814741910528;
 
 static void thread_nop_function(void *arg) {
   bintime_t end = *(bintime_t *)arg;
-  bintime_add(&end, &test_time);
+  bintime_add_frac(&end, test_time_frac);
   bintime_t now = getbintime();
   while (bintime_cmp(&now, &end, <))
     now = getbintime();
@@ -43,8 +44,8 @@ static int test_thread_stats_nop(void) {
 
 static void thread_wake_function(void *arg) {
   bintime_t end = *(bintime_t *)arg;
-  bintime_add(&end, &test_time);
-  bintime_add(&end, &BINTIME2(0, 0.1));
+  bintime_add_frac(&end, test_time_frac);
+  bintime_add(&end, &BINTIME(0.1));
   bintime_t now = getbintime();
   while (bintime_cmp(&now, &end, <)) {
     sleepq_broadcast(arg);
@@ -55,7 +56,7 @@ static void thread_wake_function(void *arg) {
 static void thread_sleep_function(void *arg) {
   sleepq_wait(arg, "Thread stats test sleepq");
   bintime_t end = *(bintime_t *)arg;
-  bintime_add(&end, &test_time);
+  bintime_add_frac(&end, test_time_frac);
   bintime_t now = getbintime();
   while (bintime_cmp(&now, &end, <)) {
     sleepq_wait(arg, "Thread stats test sleepq");

--- a/sys/tests/thread_stats.c
+++ b/sys/tests/thread_stats.c
@@ -7,7 +7,7 @@
 
 #define THREADS_NUMBER 10
 
-static bintime_t test_time = BINTIME(0.2);
+static bintime_t test_time = BINTIME2(0, 0.2);
 
 static void thread_nop_function(void *arg) {
   bintime_t end = *(bintime_t *)arg;
@@ -44,7 +44,7 @@ static int test_thread_stats_nop(void) {
 static void thread_wake_function(void *arg) {
   bintime_t end = *(bintime_t *)arg;
   bintime_add(&end, &test_time);
-  bintime_add(&end, &BINTIME(0.1));
+  bintime_add(&end, &BINTIME2(0, 0.1));
   bintime_t now = getbintime();
   while (bintime_cmp(&now, &end, <)) {
     sleepq_broadcast(arg);

--- a/sys/tests/thread_stats.c
+++ b/sys/tests/thread_stats.c
@@ -7,8 +7,7 @@
 
 #define THREADS_NUMBER 10
 
-/* 0.2 as a bintime fraction */
-static uint64_t test_time_frac = 3689348814741910528;
+static uint64_t test_time_frac = _BINTIME_FRAC(0.2);
 
 static void thread_nop_function(void *arg) {
   bintime_t end = *(bintime_t *)arg;


### PR DESCRIPTION
Changing the representation of how we store time in kernel to more accurate, which give higher precision (2^-64 ≈ 5 * 10^-20 (bintime) instead of 10^-6 (timeval)).