### PR TITLE
Fixing clk_tck definition & moving tm2sec to time.c

### DIFF
--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -3,7 +3,7 @@
 
 #include <sys/types.h>
 
-#define CLK_TCK 100 /* system clock ticks per second */
+#define CLK_TCK 1000 /* system clock ticks per second 1[tick] = 1[ms]  */
 
 typedef struct tm {
   int tm_sec;          /* seconds after the minute [0-61] */
@@ -51,7 +51,7 @@ typedef struct bintime {
 time_t tm2sec(tm_t *tm);
 
 static inline systime_t bt2st(bintime_t *bt) {
-  return bt->sec * 1000 + ((1000ULL * (uint32_t)(bt->frac >> 32)) >> 32);
+  return bt->sec * CLK_TCK + (((uint64_t)CLK_TCK * (uint32_t)(bt->frac >> 32)) >> 32);
 }
 
 static inline void bt2ts(bintime_t *bt, timespec_t *ts) {

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -51,7 +51,8 @@ typedef struct bintime {
 time_t tm2sec(tm_t *tm);
 
 static inline systime_t bt2st(bintime_t *bt) {
-  return bt->sec * CLK_TCK + (((uint64_t)CLK_TCK * (uint32_t)(bt->frac >> 32)) >> 32);
+  return bt->sec * CLK_TCK +
+         (((uint64_t)CLK_TCK * (uint32_t)(bt->frac >> 32)) >> 32);
 }
 
 static inline void bt2ts(bintime_t *bt, timespec_t *ts) {

--- a/sys/kern/clock.c
+++ b/sys/kern/clock.c
@@ -6,8 +6,6 @@
 #include <sys/timer.h>
 #include <sys/sysinit.h>
 
-#define SYSTIME_FREQ 1000 /* 1[tick] = 1[ms] */
-
 static systime_t now = 0;
 static timer_t *clock = NULL;
 
@@ -28,7 +26,7 @@ static void clock_init(void) {
     panic("Missing suitable timer for maintenance of system clock!");
   tm_init(clock, clock_cb, NULL);
   if (tm_start(clock, TMF_PERIODIC | TMF_TIMESOURCE, (bintime_t){},
-               HZ2BT(SYSTIME_FREQ)))
+               HZ2BT(CLK_TCK)))
     panic("Failed to start system clock!");
   klog("System clock uses \'%s\' hardware timer.", clock->tm_name);
 }

--- a/sys/kern/time.c
+++ b/sys/kern/time.c
@@ -21,3 +21,30 @@ int do_clock_nanosleep(clockid_t clk, int flags, const timespec_t *rqtp,
                        timespec_t *rmtp) {
   return ENOTSUP;
 }
+
+time_t tm2sec(tm_t *t) {
+  if (t->tm_year < 70)
+    return 0;
+
+  const int32_t year_scale_s = 31536000, day_scale_s = 86400,
+                hour_scale_s = 3600, min_scale_s = 60;
+  time_t res = 0;
+  static const int month_in_days[13] = {0,   31,  59,  90,  120, 151,
+                                        181, 212, 243, 273, 304, 334};
+
+  res += (time_t)month_in_days[t->tm_mon] * day_scale_s;
+  /* Extra days from leap years which already past (EPOCH) */
+  res += (time_t)((t->tm_year + 1900) / 4 - (1970) / 4) * day_scale_s;
+  res -= (time_t)((t->tm_year + 1900) / 100 - (1970) / 100) * day_scale_s;
+  res += (time_t)((t->tm_year + 1900) / 400 - (1970) / 400) * day_scale_s;
+
+  /* If actual year is a leap year and the leap day passed */
+  if (t->tm_mon > 1 && (t->tm_year % 4) == 0 &&
+      ((t->tm_year % 100) != 0 || (t->tm_year + 1900) % 400) == 0)
+    res += day_scale_s;
+
+  /* (t.tm_mday - 1) - cause days are in range [1-31] */
+  return (time_t)(t->tm_year - 70) * year_scale_s +
+         (t->tm_mday - 1) * day_scale_s + t->tm_hour * hour_scale_s +
+         t->tm_min * min_scale_s + t->tm_sec + res;
+}

--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -169,33 +169,6 @@ void tm_select(timer_t *tm) {
   time_source = tm;
 }
 
-time_t tm2sec(tm_t *t) {
-  if (t->tm_year < 70)
-    return 0;
-
-  const int32_t year_scale_s = 31536000, day_scale_s = 86400,
-                hour_scale_s = 3600, min_scale_s = 60;
-  time_t res = 0;
-  static const int month_in_days[13] = {0,   31,  59,  90,  120, 151,
-                                        181, 212, 243, 273, 304, 334};
-
-  res += (time_t)month_in_days[t->tm_mon] * day_scale_s;
-  /* Extra days from leap years which already past (EPOCH) */
-  res += (time_t)((t->tm_year + 1900) / 4 - (1970) / 4) * day_scale_s;
-  res -= (time_t)((t->tm_year + 1900) / 100 - (1970) / 100) * day_scale_s;
-  res += (time_t)((t->tm_year + 1900) / 400 - (1970) / 400) * day_scale_s;
-
-  /* If actual year is a leap year and the leap day passed */
-  if (t->tm_mon > 1 && (t->tm_year % 4) == 0 &&
-      ((t->tm_year % 100) != 0 || (t->tm_year + 1900) % 400) == 0)
-    res += day_scale_s;
-
-  /* (t.tm_mday - 1) - cause days are in range [1-31] */
-  return (time_t)(t->tm_year - 70) * year_scale_s +
-         (t->tm_mday - 1) * day_scale_s + t->tm_hour * hour_scale_s +
-         t->tm_min * min_scale_s + t->tm_sec + res;
-}
-
 bintime_t binuptime(void) {
   /* XXX: probably a race condition here */
   timer_t *tm = time_source;


### PR DESCRIPTION
Changing value  **clk_tck** to 1000, cause our system tick take 1ms.
Moving **tm2sec** to more appropriate file for this type of function.