### PR TITLE
Use devclasses for device initialization

### DIFF
--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -27,8 +27,6 @@ struct driver {
   d_detach_t detach;     /* detach device from system */
 };
 
-#define DRIVER_ADD(name) SET_ENTRY(driver_table, name)
-
 typedef enum { DEV_BUS_NONE, DEV_BUS_PCI, DEV_BUS_ISA } device_bus_t;
 
 struct device {

--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -6,6 +6,7 @@
 #include <sys/linker_set.h>
 #include <sys/rman.h>
 
+typedef struct devclass devclass_t;
 typedef struct device device_t;
 typedef struct driver driver_t;
 typedef struct resource resource_t;
@@ -41,6 +42,7 @@ struct device {
   /* Device information and state. */
   device_bus_t bus;
   driver_t *driver;
+  devclass_t *devclass;
   void *instance; /* used by bus driver to store data in children */
   void *state;    /* memory requested by driver for its state*/
 };

--- a/sys/drv/atkbdc.c
+++ b/sys/drv/atkbdc.c
@@ -152,6 +152,8 @@ static int atkbdc_probe(device_t *dev) {
 static int atkbdc_attach(device_t *dev) {
   assert(dev->parent->bus == DEV_BUS_PCI);
 
+  vnodeops_init(&scancode_vnodeops);
+
   atkbdc_state_t *atkbdc = dev->state;
 
   atkbdc->scancodes.data = kmalloc(M_DEV, KBD_BUFSIZE, M_ZERO);
@@ -184,12 +186,5 @@ static driver_t atkbdc_driver = {
   .attach = atkbdc_attach,
 };
 
-extern device_t *gt_pci;
-
-static void atkbdc_init(void) {
-  vnodeops_init(&scancode_vnodeops);
-  (void)make_device(gt_pci, &atkbdc_driver);
-}
-
-SYSINIT_ADD(atkbdc, atkbdc_init, DEPS("rootdev"));
+DRIVER_ADD(atkbdc_driver);
 DEVCLASS_ENTRY(pci, atkbdc_driver);

--- a/sys/drv/atkbdc.c
+++ b/sys/drv/atkbdc.c
@@ -186,5 +186,4 @@ static driver_t atkbdc_driver = {
   .attach = atkbdc_attach,
 };
 
-DRIVER_ADD(atkbdc_driver);
 DEVCLASS_ENTRY(pci, atkbdc_driver);

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -13,6 +13,7 @@
 #include <sys/interrupt.h>
 #include <sys/sysinit.h>
 #include <sys/stat.h>
+#include <sys/devclass.h>
 
 #define UART_BUFSIZE 128
 
@@ -189,10 +190,5 @@ static driver_t ns16550_driver = {
   .attach = ns16550_attach,
 };
 
-extern device_t *gt_pci;
-
-static void ns16550_init(void) {
-  (void)make_device(gt_pci, &ns16550_driver);
-}
-
-SYSINIT_ADD(ns16550, ns16550_init, DEPS("rootdev"));
+DRIVER_ADD(ns16550_driver);
+DEVCLASS_ENTRY(pci, ns16550_driver);

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -190,5 +190,4 @@ static driver_t ns16550_driver = {
   .attach = ns16550_attach,
 };
 
-DRIVER_ADD(ns16550_driver);
 DEVCLASS_ENTRY(pci, ns16550_driver);

--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -145,4 +145,4 @@ static driver_t pit_driver = {
 };
 
 DRIVER_ADD(pit_driver);
-DEVCLASS_ENTRY(root, pit_driver);
+DEVCLASS_ENTRY(pci, pit_driver);

--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -144,11 +144,5 @@ static driver_t pit_driver = {
   .attach = pit_attach,
 };
 
-extern device_t *gt_pci;
-
-static void pit_init(void) {
-  (void)make_device(gt_pci, &pit_driver);
-}
-
-SYSINIT_ADD(pit, pit_init, DEPS("rootdev"));
+DRIVER_ADD(pit_driver);
 DEVCLASS_ENTRY(root, pit_driver);

--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -144,5 +144,4 @@ static driver_t pit_driver = {
   .attach = pit_attach,
 };
 
-DRIVER_ADD(pit_driver);
 DEVCLASS_ENTRY(pci, pit_driver);

--- a/sys/drv/rtc.c
+++ b/sys/drv/rtc.c
@@ -97,6 +97,8 @@ static vnodeops_t rtc_time_vnodeops = {.v_open = vnode_open_generic,
 static int rtc_attach(device_t *dev) {
   assert(dev->parent->bus == DEV_BUS_PCI);
 
+  vnodeops_init(&rtc_time_vnodeops);
+
   rtc_state_t *rtc = dev->state;
 
   rtc->regs = bus_alloc_resource(
@@ -131,12 +133,5 @@ static driver_t rtc_driver = {
   .attach = rtc_attach,
 };
 
-extern device_t *gt_pci;
-
-static void rtc_init(void) {
-  vnodeops_init(&rtc_time_vnodeops);
-  (void)make_device(gt_pci, &rtc_driver);
-}
-
-SYSINIT_ADD(rtc, rtc_init, DEPS("rootdev"));
-DEVCLASS_ENTRY(root, rtc_driver);
+DRIVER_ADD(rtc_driver);
+DEVCLASS_ENTRY(pci, rtc_driver);

--- a/sys/drv/rtc.c
+++ b/sys/drv/rtc.c
@@ -133,5 +133,4 @@ static driver_t rtc_driver = {
   .attach = rtc_attach,
 };
 
-DRIVER_ADD(rtc_driver);
 DEVCLASS_ENTRY(pci, rtc_driver);

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -213,5 +213,4 @@ static driver_t stdvga = {
   .attach = stdvga_attach,
 };
 
-DRIVER_ADD(stdvga);
 DEVCLASS_ENTRY(pci, stdvga);

--- a/sys/kern/bus.c
+++ b/sys/kern/bus.c
@@ -5,6 +5,7 @@
 #include <sys/kmem.h>
 #include <sys/pmap.h>
 #include <sys/rman.h>
+#include <sys/devclass.h>
 
 int generic_bs_map(bus_addr_t addr, bus_size_t size,
                    bus_space_handle_t *handle_p) {
@@ -105,21 +106,21 @@ bus_space_t *generic_bus_space = &(bus_space_t){
 /* clang-format on */
 
 int bus_generic_probe(device_t *bus) {
-  device_t *dev;
-  SET_DECLARE(driver_table, driver_t);
-  klog("Scanning %s for known devices.", bus->driver->desc);
-  TAILQ_FOREACH (dev, &bus->children, link) {
-    driver_t **drv_p;
-    SET_FOREACH (drv_p, driver_table) {
-      driver_t *drv = *drv_p;
-      dev->driver = drv;
-      if (device_probe(dev)) {
-        klog("%s detected!", drv->desc);
-        device_attach(dev);
-        break;
-      }
-      dev->driver = NULL;
+  int error = 0;
+  devclass_t *dc = bus->devclass;
+  if (!dc)
+    return error;
+  driver_t **drv_p;
+  DEVCLASS_FOREACH(drv_p, dc) {
+    driver_t *drv = *drv_p;
+    device_t *dev = device_add_child(bus);
+    dev->driver = drv;
+    if (device_probe(dev)) {
+      klog("%s detected!", drv->desc);
+      error = device_attach(dev);
+      if (error)
+        return error;
     }
   }
-  return 0;
+  return error;
 }

--- a/sys/kern/clock.c
+++ b/sys/kern/clock.c
@@ -33,4 +33,4 @@ static void clock_init(void) {
   klog("System clock uses \'%s\' hardware timer.", clock->tm_name);
 }
 
-SYSINIT_ADD(clock, clock_init, DEPS("sched", "callout", "pit"));
+SYSINIT_ADD(clock, clock_init, DEPS("sched", "callout", "rootdev"));

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -240,6 +240,8 @@ static inline void gt_pci_intr_event_init(gt_pci_state_t *gtpci, unsigned irq,
 DEVCLASS_CREATE(pci);
 
 static int gt_pci_attach(device_t *pcib) {
+  /* TODO(pj) This should be done in other place. Fix it after done with drivers
+   * infrastructure. */
   pcib->devclass = &pci_devclass;
   gt_pci_state_t *gtpci = pcib->state;
 

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -431,4 +431,5 @@ pci_bus_driver_t gt_pci_bus = {
 /* clang-format on */
 
 DEVCLASS_CREATE(pci);
+DRIVER_ADD(gt_pci_bus);
 DEVCLASS_ENTRY(root, gt_pci_bus);

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -414,5 +414,4 @@ pci_bus_driver_t gt_pci_bus = {
 };
 /* clang-format on */
 
-DRIVER_ADD(gt_pci_bus);
 DEVCLASS_ENTRY(root, gt_pci_bus);

--- a/sys/mips/rootdev.c
+++ b/sys/mips/rootdev.c
@@ -15,7 +15,7 @@ typedef struct rootdev {
 
 /* TODO: remove following lines when devclasses are implemented */
 extern pci_bus_driver_t gt_pci_bus;
-device_t *gt_pci;
+static device_t *gt_pci;
 
 static rman_t rm_mem; /* stores all resources of root bus children */
 

--- a/sys/mips/rootdev.c
+++ b/sys/mips/rootdev.c
@@ -15,7 +15,6 @@ typedef struct rootdev {
 
 /* TODO: remove following lines when devclasses are implemented */
 extern pci_bus_driver_t gt_pci_bus;
-static device_t *gt_pci;
 
 static rman_t rm_mem; /* stores all resources of root bus children */
 
@@ -32,7 +31,7 @@ static int rootdev_attach(device_t *dev) {
   /* Manages space occupied by I/O devices: PCI, FPGA, system controler, ... */
   rman_init(&rm_mem, "Malta I/O space", 0x10000000, 0x1fffffff, RT_MEMORY);
 
-  gt_pci = device_add_child(dev);
+  device_t *gt_pci = device_add_child(dev);
   gt_pci->driver = &gt_pci_bus.driver;
   if (device_probe(gt_pci))
     device_attach(gt_pci);


### PR DESCRIPTION
* fix `bus_generic_probe` -- now it initializes only devices in correct _devclass_
* use _devclass_ interface for device initialization
* introduce new member of `device_t` for access to _devclass_
* remove `gt_pci_bus` and `gt_pci` global references
* stop using `SYSINIT_ADD` for device initialization
* use `bus_generic_probe` everywhere where it is possible
 