### PR TITLE
Use LINUX_BOOT_ABI for AArch64.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 *.uelf
 *.test
 
+# Kernel blobs
+*.img
+*.img.gz
+
 # Ramdisk
 *.cpio
 

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -3,3 +3,7 @@ GCC_ABIFLAGS := -DELFSIZE=64
 CLANG_ABIFLAGS := -target aarch64-elf -DELFSIZE=64
 ELFTYPE := elf64-littleaarch64
 ELFARCH := aarch64
+
+ifeq ($(BOARD), rpi3)
+KERNEL-IMAGE := mimiker.img.gz
+endif

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -49,4 +49,4 @@ GIT     = git
 PATCH   = patch
 GENASSYM = $(TOPDIR)/sys/script/genassym.sh
 YACC	= byacc
-GZIP	= gzip
+GZIP	= gzip -9

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -49,3 +49,4 @@ GIT     = git
 PATCH   = patch
 GENASSYM = $(TOPDIR)/sys/script/genassym.sh
 YACC	= byacc
+GZIP	= gzip

--- a/launch
+++ b/launch
@@ -60,6 +60,9 @@ if __name__ == '__main__':
         description='Launch kernel in Malta board simulator.')
     parser.add_argument('-k', '--kernel', metavar='KERNEL', type=str,
                         default='sys/mimiker.elf',
+                        help='Kernel image file.')
+    parser.add_argument('-e', '--elf', metavar='ELF', type=str,
+                        default='sys/mimiker.elf',
                         help='Kernel image file in ELF format.')
     parser.add_argument('--initrd', metavar='INITRD', type=str,
                         default='initrd.cpio',
@@ -92,6 +95,7 @@ if __name__ == '__main__':
     setvar('config.debug', args.debug)
     setvar('config.graphics', args.graphics)
     setvar('config.kernel', args.kernel)
+    setvar('config.elf', args.elf)
     setvar('config.initrd', args.initrd)
     setvar('config.args', args.args)
 

--- a/launch
+++ b/launch
@@ -78,8 +78,7 @@ if __name__ == '__main__':
     # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
     os.environ['MIMIKER_REPO'] = os.path.dirname(os.path.realpath(sys.argv[0]))
 
-    setvar('board', args.board)
-    setvar('config.kernel', getvar('config.{BOARD}.kernel'))
+    setboard(args.board)
     setvar('config.debug', args.debug)
     setvar('config.graphics', args.graphics)
     setvar('config.args', args.args)
@@ -108,7 +107,7 @@ if __name__ == '__main__':
     else:
         dbg = None
 
-    uarts = [SOCAT(name, port) for name, port in getvar('qemu.{BOARD}.uarts')]
+    uarts = [SOCAT(name, port) for name, port in getvar('qemu.uarts')]
 
     if args.test_run:
         TestRun(sim, uarts)

--- a/launch
+++ b/launch
@@ -58,15 +58,6 @@ def DevelRun(sim, dbg, uarts):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Launch kernel in Malta board simulator.')
-    parser.add_argument('-k', '--kernel', metavar='KERNEL', type=str,
-                        default='sys/mimiker.elf',
-                        help='Kernel image file.')
-    parser.add_argument('-e', '--elf', metavar='ELF', type=str,
-                        default='sys/mimiker.elf',
-                        help='Kernel image file in ELF format.')
-    parser.add_argument('--initrd', metavar='INITRD', type=str,
-                        default='initrd.cpio',
-                        help='Initial RAM disk in CPIO format.')
     parser.add_argument('args', metavar='ARGS', type=str,
                         nargs=argparse.REMAINDER, help='Kernel arguments.')
     parser.add_argument('-D', '--debugger', metavar='DEBUGGER', type=str,
@@ -84,20 +75,18 @@ if __name__ == '__main__':
                         choices=['malta', 'rpi3'], help='Emulated board.')
     args = parser.parse_args()
 
-    # Check if the kernel file is available
-    if not os.path.isfile(args.kernel):
-        raise SystemExit('%s: file does not exist!' % args.kernel)
-
     # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
     os.environ['MIMIKER_REPO'] = os.path.dirname(os.path.realpath(sys.argv[0]))
 
     setvar('board', args.board)
+    setvar('config.kernel', getvar('config.{BOARD}.kernel'))
     setvar('config.debug', args.debug)
     setvar('config.graphics', args.graphics)
-    setvar('config.kernel', args.kernel)
-    setvar('config.elf', args.elf)
-    setvar('config.initrd', args.initrd)
     setvar('config.args', args.args)
+
+    # Check if the kernel file is available
+    if not os.path.isfile(getvar('config.kernel')):
+        raise SystemExit('%s: file does not exist!' % getvar('config.kernel'))
 
     sim = QEMU()
 

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -23,10 +23,17 @@ CONFIG = {
     'config': {
         'debug': False,
         'graphics': False,
-        'kernel': 'sys/mimiker.elf',
         'elf': 'sys/mimiker.elf',
         'initrd': 'initrd.cpio',
-        'args': []
+        'args': [],
+        'board': {
+            'malta' : {
+                'kernel': 'sys/mimiker.elf',
+            },
+            'rpi3': {
+                'kernel': 'sys/mimiker.img.gz',
+            },
+        },
     },
     'qemu': {
         'options': [

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -200,7 +200,7 @@ class QEMU(Launchable):
     def __init__(self):
         super().__init__('qemu', getvar('qemu.binary'))
 
-        self.options = getvar('qemu.options')
+        self.options = getopts('qemu.options')
         for _, port in getvar('qemu.uarts'):
             self.options += ['-serial', f'tcp:127.0.0.1:{port},server,wait']
 

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -52,7 +52,6 @@ CONFIG = {
             'rpi3': {
                 'binary': 'qemu-mimiker-aarch64',
                 'options': [
-                    '-d', 'mmu,int',
                     '-machine', 'raspi3',
                     '-smp', '4',
                     '-cpu', 'cortex-a53'],

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -24,6 +24,7 @@ CONFIG = {
         'debug': False,
         'graphics': False,
         'kernel': 'sys/mimiker.elf',
+        'elf': 'sys/mimiker.elf',
         'initrd': 'initrd.cpio',
         'args': []
     },
@@ -51,6 +52,7 @@ CONFIG = {
             'rpi3': {
                 'binary': 'qemu-mimiker-aarch64',
                 'options': [
+                    '-d', 'mmu,int',
                     '-machine', 'raspi3',
                     '-smp', '4',
                     '-cpu', 'cortex-a53'],
@@ -74,7 +76,7 @@ CONFIG = {
             '-ex=set confirm yes',
             '-ex=source .gdbinit',
             '-ex=continue',
-            '{kernel}'
+            '{elf}'
         ],
         'board': {
             'malta': {

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -5,7 +5,7 @@ TOPDIR = $(realpath ..)
 SUBDIR = $(ARCH) drv kern libkern tests
 KLIB = no
 
-BUILD-FILES += mimiker.img.gz mimiker.img mimiker.elf cscope.out etags tags
+BUILD-FILES += $(KERNEL-IMAGE) mimiker.elf cscope.out etags tags
 CLEAN-FILES += mimiker.elf.map
 
 include $(TOPDIR)/build/build.kern.mk
@@ -21,12 +21,12 @@ mimiker.elf: $(KLIBDEPS)
 	$(LD) $(LDFLAGS) -Wl,-Map=$@.map $(LDLIBS) -o $@
 
 mimiker.img: mimiker.elf
-	@echo "[OBJCOPY] Translate kernel image: $@"
-	$(OBJCOPY) $^ -O binary $@
+	@echo "[OBJCOPY] Prepare kernel image: $@"
+	$(OBJCOPY) -O binary $^ $@
 
 mimiker.img.gz: mimiker.img
 	@echo "[GZIP] Compress kernel image: $@"
-	$(GZIP) --keep -f $^ > $@
+	$(GZIP) -f $^ > $@
 
 # Lists of all files that we consider operating system kernel sources.
 SRCDIRS = $(TOPDIR)/include $(TOPDIR)/sys

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -5,7 +5,7 @@ TOPDIR = $(realpath ..)
 SUBDIR = $(ARCH) drv kern libkern tests
 KLIB = no
 
-BUILD-FILES += mimiker.elf cscope.out etags tags
+BUILD-FILES += mimiker.img.gz mimiker.img mimiker.elf cscope.out etags tags
 CLEAN-FILES += mimiker.elf.map
 
 include $(TOPDIR)/build/build.kern.mk
@@ -19,6 +19,14 @@ LDLIBS	= -Wl,--start-group \
 mimiker.elf: $(KLIBDEPS)
 	@echo "[LD] Linking kernel image: $@"
 	$(LD) $(LDFLAGS) -Wl,-Map=$@.map $(LDLIBS) -o $@
+
+mimiker.img: mimiker.elf
+	@echo "[OBJCOPY] Translate kernel image: $@"
+	$(OBJCOPY) $^ -O binary $@
+
+mimiker.img.gz: mimiker.img
+	@echo "[GZIP] Compress kernel image: $@"
+	$(GZIP) --keep -f $^ > $@
 
 # Lists of all files that we consider operating system kernel sources.
 SRCDIRS = $(TOPDIR)/include $(TOPDIR)/sys

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -103,7 +103,6 @@ el1_entry:
   return;
 }
 
-extern char _kernel[];
 extern char __boot[];
 extern char __text[];
 extern char __data[];
@@ -139,7 +138,7 @@ __boot_text static void build_page_table(void) {
   paddr_t text = AARCH64_PHYSADDR(__text);
   paddr_t data = AARCH64_PHYSADDR(__data);
   paddr_t ebss = AARCH64_PHYSADDR(roundup((vaddr_t)__ebss, PAGESIZE));
-  vaddr_t va = (vaddr_t)__boot + (vaddr_t)_kernel;
+  vaddr_t va = KERNEL_SPACE_BEGIN + (vaddr_t)__boot;
 
   l0[L0_INDEX(va)] = (pde_t)l1 | L0_TABLE;
   l1[L1_INDEX(va)] = (pde_t)l2 | L1_TABLE;
@@ -226,7 +225,7 @@ __boot_text static void enable_mmu(void) {
   __isb();
 }
 
-__boot_text void *aarch64_init(void) {
+__boot_text void *aarch64_init(__unused void *atags) {
   drop_to_el1();
   enable_cache_coherency();
   clear_bss();

--- a/sys/aarch64/rpi3.ld
+++ b/sys/aarch64/rpi3.ld
@@ -12,7 +12,6 @@ PHDRS
   data   PT_LOAD FLAGS(6); /* read-write */
 }
 
-PROVIDE(_kernel = 0xffff000000000000);
 
 SECTIONS
 {
@@ -25,6 +24,8 @@ SECTIONS
     . = ALIGN (4096);
     __eboot = ABSOLUTE(.);
   } : boot
+
+  HIDDEN(_kernel = 0xffff000000000000);
 
   .text _kernel + __eboot : AT(__eboot) ALIGN(4096)
   {

--- a/sys/aarch64/rpi3.ld
+++ b/sys/aarch64/rpi3.ld
@@ -12,10 +12,11 @@ PHDRS
   data   PT_LOAD FLAGS(6); /* read-write */
 }
 
+PROVIDE(__kernel_size = (__kernel_end - __kernel_start) + (__eboot - __boot));
 
 SECTIONS
 {
-  .boot 0x80000 : AT(0x80000) ALIGN(4096)
+  .boot 0x200000 : AT(0x200000) ALIGN(4096)
   {
     __boot = ABSOLUTE(.);
     KEEP(*(.boot))

--- a/sys/aarch64/start.S
+++ b/sys/aarch64/start.S
@@ -1,8 +1,11 @@
 #include <aarch64/asm.h>
 
-#define IMAGE_OFFSET 0
-#define IMAGE_SIZE 0
-#define IMAGE_FLAGS 0
+/* Initial boot environment is described in detail 
+ * at Documentation/arm64/booting.rst from Linux source tree. */
+
+#define IMAGE_OFFSET 0 /* Image offset from start of 2 MiB page */
+#define IMAGE_SIZE __kernel_size
+#define IMAGE_FLAGS 2 /* Kernel is little endian, page size is 4KiB */
 
         .section .boot, "ax"
         .extern _boot_stack

--- a/sys/aarch64/start.S
+++ b/sys/aarch64/start.S
@@ -1,9 +1,25 @@
 #include <aarch64/asm.h>
 
+#define IMAGE_OFFSET 0
+#define IMAGE_SIZE 0
+#define IMAGE_FLAGS 0
+
         .section .boot, "ax"
         .extern _boot_stack
 
 ASENTRY(_start)
+        /* Based on  locore.S from FreeBSD. */
+        b       1f
+        .long   0
+        .quad   IMAGE_OFFSET
+        .quad   IMAGE_SIZE
+        .quad   IMAGE_FLAGS
+        .quad   0
+        .quad   0
+        .quad   0
+        .long   0x644d5241
+        .long   0
+1:
         /* Save atags. */
         MOV     x27, x0
 

--- a/sys/aarch64/start.S
+++ b/sys/aarch64/start.S
@@ -8,7 +8,7 @@
         .extern _boot_stack
 
 ASENTRY(_start)
-        /* Based on  locore.S from FreeBSD. */
+        /* Based on locore.S from FreeBSD. */
         b       1f
         .long   0
         .quad   IMAGE_OFFSET
@@ -17,7 +17,7 @@ ASENTRY(_start)
         .quad   0
         .quad   0
         .quad   0
-        .long   0x644d5241
+        .long   0x644d5241 /* Magic "ARM\x64" */
         .long   0
 1:
         /* Save atags. */


### PR DESCRIPTION
Use `LINUX_BOOT_ABI` for AArch64.

QEMU assumes the .img files are the Linux. We need `LINUX_BOOT_ABI` for RPI3 support.