### PR TITLE
Fix off-by-one error in vm_physmem.

### DIFF
--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -101,9 +101,9 @@ void init_vm_page(void) {
     for (unsigned i = 0; i < seg->npages; i++) {
       vm_page_t *page = &pages[i];
       paddr_t pa = seg->start + i * PAGESIZE;
-      unsigned size = 1 << min(PM_NQUEUES, ctz(pa / PAGESIZE));
+      unsigned size = 1 << min(PM_NQUEUES - 1, ctz(pa / PAGESIZE));
       if (pa + size * PAGESIZE > seg->end)
-        size = 1 << min(PM_NQUEUES, log2((seg->end ^ pa) / PAGESIZE));
+        size = 1 << min(PM_NQUEUES - 1, log2((seg->end ^ pa) / PAGESIZE));
       page->paddr = pa;
       page->size = size;
       page->flags = seg->used ? PG_ALLOCATED : 0;


### PR DESCRIPTION
Fix off-by-one error in `vm_physmem` found in #743.