### PR TITLE
Fix cpu_intr_disabled

### DIFF
--- a/sys/aarch64/interrupt.c
+++ b/sys/aarch64/interrupt.c
@@ -14,5 +14,5 @@ void cpu_intr_enable(void) {
 
 bool cpu_intr_disabled(void) {
   uint32_t daif = READ_SPECIALREG(daif);
-  return (daif & DAIF_I_MASKED) == 0;
+  return (daif & DAIF_I_MASKED) != 0;
 }


### PR DESCRIPTION
When I bit is set then exceptions are masked.