### PR TITLE
Revert almost the greatest idea in MIPS pmap

### DIFF
--- a/include/mips/pmap.h
+++ b/include/mips/pmap.h
@@ -15,8 +15,6 @@ typedef uint32_t pde_t;
 
 #include <mips/vm_param.h>
 
-#define PT_BASE ((pte_t *)0xffc00000)
-
 /* MIPS pmap implements standard two-level hierarchical page table
  * stored in physical addresses. Indices are 10-bits wide. */
 #define PTE_INDEX_MASK 0x003ff000

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -9,8 +9,8 @@
 
 /* Last address in kseg0 used by kernel for boot allocation. */
 __boot_data void *_bootmem_end;
-/* Kernel page directory entries allocated in kseg0. */
-extern pte_t _kernel_pmap_pde[PT_ENTRIES];
+/* Pointer to kernel page directory allocated in kseg0. */
+extern pde_t *_kernel_pmap_pde;
 /* The boot stack is used before we switch out to thread0. */
 static alignas(PAGESIZE) uint8_t _boot_stack[PAGESIZE];
 
@@ -75,7 +75,7 @@ __boot_text void *mips_init(void) {
   }
 
   /* Prepare 1:1 mapping between kseg2 and physical memory for kernel image. */
-  pde_t *pde = (pde_t *)MIPS_KSEG2_TO_KSEG0(_kernel_pmap_pde);
+  pde_t *pde = (pde_t *)bootmem_alloc(PAGESIZE);
   for (int i = 0; i < PT_ENTRIES; i++)
     pde[i] = PTE_GLOBAL;
 
@@ -89,10 +89,7 @@ __boot_text void *mips_init(void) {
   vaddr_t va = MIPS_PHYS_TO_KSEG2(text);
 
   /* assume that kernel image will be covered by single PDE (4MiB) */
-  pde[PDE_INDEX(va)] = PTE_PFN(MIPS_KSEG0_TO_PHYS(pte)) | PTE_KERNEL;
-
-  /* auto-mapping? */
-  pde[PDE_INDEX(PT_BASE)] = PTE_PFN(MIPS_KSEG0_TO_PHYS(pde)) | PTE_KERNEL;
+  pde[PDE_INDEX(va)] = PTE_PFN((paddr_t)pte) | PTE_KERNEL;
 
   /* read-only segment - sections: .text, .rodata, etc. */
   for (paddr_t pa = text; pa < data; va += PAGESIZE, pa += PAGESIZE)
@@ -111,7 +108,7 @@ __boot_text void *mips_init(void) {
   for (int i = 0; i < num_pde; i++) {
     /* Allocate a new PT */
     pte = bootmem_alloc(PAGESIZE);
-    pde[PDE_INDEX(va)] = PTE_PFN((intptr_t)pte) | PTE_KERNEL;
+    pde[PDE_INDEX(va)] = PTE_PFN((paddr_t)pte) | PTE_KERNEL;
     for (int j = 0; j < PT_ENTRIES; j++) {
       pte[PTE_INDEX(va)] = PTE_PFN(pa) | PTE_KERNEL;
       va += PAGESIZE;
@@ -130,6 +127,9 @@ __boot_text void *mips_init(void) {
   mips32_setentrylo1(PTE_PFN(MIPS_KSEG0_TO_PHYS(pde)) | PTE_KERNEL);
   mips32_setindex(0);
   mips32_tlbwi();
+
+  /* Since the variable is in kseg2 we cannot initialize it earlier. */
+  _kernel_pmap_pde = pde;
 
   /* Return the end of boot stack (grows downwards on MIPS) as new sp.
    * This is done in order to move kernel boot process to kseg2, since

--- a/sys/mips/ebase.S
+++ b/sys/mips/ebase.S
@@ -222,7 +222,7 @@ _ebase:
 # i.e. it exposes 1:1 mapping between effective and physical addresses.
 #
 # Page directory entries are not stored in TLB but are processed by TLB refill
-# handler, hence they may store kseg0 addresses (instead of physical).
+# handler, hence they contain kseg0 addresses instead of physical one.
 
 # useg: [0000.0000, 8000.0000) -> ffff.e000 UPD (ASID = x)
 # kseg: [c000.0000, ffff.e000) -> ffff.f000 KPD (GLOBAL)

--- a/sys/mips/ebase.S
+++ b/sys/mips/ebase.S
@@ -218,23 +218,21 @@ _ebase:
 # EHB has to be put between a producer and a consumer - preferably just before
 # the consumer, not just after the producer.
 
+# MIPS kseg0 plays role of direct map from other architectures,
+# i.e. it exposes 1:1 mapping between effective and physical addresses.
+#
+# Page directory entries are not stored in TLB but are processed by TLB refill
+# handler, hence they may store kseg0 addresses (instead of physical).
+
 # useg: [0000.0000, 8000.0000) -> ffff.e000 UPD (ASID = x)
-# kseg: [c000.0000, ffc0.0000) -> ffff.f000 KPD (GLOBAL)
-# upte: [ffc0.0000, ffe0.0000) -> ffff.e000 UPD (ASID = x)
-# kpte: [ffe0.0000, ffff.e000) -> ffff.f000 KPD (GLOBAL)
+# kseg: [c000.0000, ffff.e000) -> ffff.f000 KPD (GLOBAL)
 
 # |uuuuuuuu________|________....kkkk|
 # ^                ^
 # fffe.0000        ffff.0000
 
-# useg: [000, 800) -> 0000.0000 - 0000.07ff
-#                     -> 0000.0000 - 0000.07fc
-# kseg: [c00, ffc) -> ffff.fc00 - ffff.fffb
-#                     -> 0000.1c00 - 0000.1ff8
-# upte: [ffc, ffe) -> ffff.fffc - ffff.fffd (x \in {-3, -4})
-#                     -> 0000.0ffc - 0000.0ffc
-# kpte: [ffe, fff) -> ffff.fffe - ffff.ffff (x \in {-1, -2})
-#                     -> 0000.1ffc - 0000.1ffc
+# useg: [000x.xxxx, 800x.xxxx) -> 0000.0000 - 0000.07ff -> 0000 - 07fc
+# kseg: [c00x.xxxx, fffx.xxxx) -> ffff.fc00 - ffff.ffff -> 1c00 - 1ffc
 
 SLEAF(tlb_refill)
         # Read PDE associated with bad virtual address.
@@ -242,12 +240,6 @@ SLEAF(tlb_refill)
         # so it's copied into 12th position with arithmetic shift.
         mfc0    k1, C0_BADVADDR
         sra     k1, 20
-
-        addiu   k0, k1, 4
-        sltiu   k0, k0, 2
-        sll     k0, 12
-        xor     k1, k0
-
         andi    k1, 0x1ffc
         lw      k1, -0x2000(k1)         # [k1] PDE of bad virtual address
 
@@ -257,9 +249,8 @@ SLEAF(tlb_refill)
         /* branch delay slot */
 
         # Calculate page table address from PDE
-        lui     k0, 0x8000
         srl     k1, 6
-        ins     k0, k1, 12, 19          # [k0] PTE address in kseg0
+        sll     k0, k1, 12              # [k0] PTE address in kseg0
         # ... and index of even entry corresponding to bad virtual address.
         mfc0    k1, C0_BADVADDR
         srl     k1, 13                  # [k1] PTE index (lower 10 bits)


### PR DESCRIPTION
 * Treat kseg0 as direct map for free.
 * Remove workarounds.