### PR TITLE
Increase P_VMEM pool size for vmem_t

### DIFF
--- a/sys/kern/pool.c
+++ b/sys/kern/pool.c
@@ -102,6 +102,8 @@ static void add_slab(pool_t *pool, slab_t *slab, size_t slabsize) {
   slab->ph_ntotal = (usable * 8 + 7) / (8 * slab->ph_itemsize + 1);
   slab->ph_nused = 0;
 
+  assert(slab->ph_ntotal > 0);
+
   size_t header = sizeof(slab_t) + bitstr_size(slab->ph_ntotal);
   slab->ph_items = (void *)slab + align(header, PI_ALIGNMENT);
   memset(slab->ph_bitmap, 0, bitstr_size(slab->ph_ntotal));

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -75,7 +75,7 @@ typedef struct bt {
 
 static POOL_DEFINE(P_VMEM, "vmem", sizeof(vmem_t));
 static POOL_DEFINE(P_BT, "vmem boundary tag", sizeof(bt_t));
-static alignas(PAGESIZE) uint8_t P_VMEM_BOOTPAGE[PAGESIZE];
+static alignas(PAGESIZE) uint8_t P_VMEM_BOOTPAGE[2 * PAGESIZE];
 /* Note: in the future, the amount of static memory for boundary tags should
  * be reduced by more clever tag allocation technique that always keeps some
  * number of free tags. For more information, please see bt_alloc and bt_refill


### PR DESCRIPTION
On _AArch64_ `vmem_t` doesn't fit on one page.