### PR TITLE
Handling the lack of a timer in tm_reserve

### DIFF
--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -84,7 +84,8 @@ timer_t *tm_reserve(const char *name, unsigned flags) {
       if (tm->tm_flags & flags)
         break;
     }
-    tm->tm_flags |= TMF_RESERVED;
+    if (tm)
+      tm->tm_flags |= TMF_RESERVED;
   }
   return tm;
 }


### PR DESCRIPTION
Do not dereference NULL address when timer is not found.