### PR TITLE
Add void to function signatures in utest

### DIFF
--- a/bin/utest/fd.c
+++ b/bin/utest/fd.c
@@ -18,7 +18,7 @@ static int n;
 #include "utest_fd.h"
 
 /* Just the basic, correct operations on a single /dev/null */
-int test_fd_devnull() {
+int test_fd_devnull(void) {
   assert_open_ok(0, "/dev/null", 0, O_RDWR);
   assert_read_ok(0, buf, 100);
   assert_write_ok(0, str, strlen(str));
@@ -28,7 +28,7 @@ int test_fd_devnull() {
 
 /* Opens and closes multiple descriptors, checks if descriptor numbers are
    correctly reused */
-int test_fd_multidesc() {
+int test_fd_multidesc(void) {
   assert_open_ok(0, "/dev/null", 0, O_RDWR);
   assert_open_ok(1, "/dev/null", 0, O_RDWR);
   assert_open_ok(2, "/dev/null", 0, O_RDWR);
@@ -49,7 +49,7 @@ int test_fd_multidesc() {
 }
 
 /* Tests whether READ/WRITE flags are checked correctly */
-int test_fd_readwrite() {
+int test_fd_readwrite(void) {
   assert_open_ok(0, "/dev/null", 0, O_RDONLY);
   assert_open_ok(1, "/dev/null", 0, O_WRONLY);
   assert_open_ok(2, "/dev/null", 0, O_RDWR);
@@ -68,7 +68,7 @@ int test_fd_readwrite() {
   return 0;
 }
 
-int test_fd_read() {
+int test_fd_read(void) {
   /* Read all at once */
   const char *contents =
     "This is the content of file \"fd_test_file\" in directory \"/tests\"!";
@@ -97,7 +97,7 @@ int test_fd_read() {
 }
 
 /* Try passing invalid pointers as arguments to open,read,write. */
-int test_fd_copy() {
+int test_fd_copy(void) {
   /* /dev/null does not copy any data, so passing an invalid pointer will not
    * cause any errors - thus we use /dev/zero for this test. However, /dev/zero
    * might also skip copying data, and in that case this test would also fail -
@@ -121,7 +121,7 @@ int test_fd_copy() {
 }
 
 /* Tries accessing some invalid descriptor numbers */
-int test_fd_bad_desc() {
+int test_fd_bad_desc(void) {
   assert_write_fail(0, buf, 100, EBADF);
   assert_write_fail(42, buf, 100, EBADF);
   assert_write_fail(-10, buf, 100, EBADF);
@@ -134,7 +134,7 @@ int test_fd_bad_desc() {
   return 0;
 }
 
-int test_fd_open_path() {
+int test_fd_open_path(void) {
   assert_open_fail("/etc/shadow", 0, O_RDONLY, ENOENT);
   assert_open_fail("123456", 0, O_RDONLY, ENOENT);
   assert_open_fail("", 0, O_RDONLY, ENOENT);
@@ -150,7 +150,7 @@ int test_fd_open_path() {
   return 0;
 }
 
-int test_fd_dup() {
+int test_fd_dup(void) {
   int x = open("/tests/dup_test_file", O_RDONLY, 0);
   int y = dup(0);
   dup2(x, 0);
@@ -165,7 +165,7 @@ int test_fd_dup() {
 #undef FD_OFFSET
 #include "utest_fd.h"
 
-int test_fd_pipe() {
+int test_fd_pipe(void) {
   int fd[2];
   assert_pipe_ok(fd);
 
@@ -191,7 +191,7 @@ int test_fd_pipe() {
   return 0;
 }
 
-int test_fd_all() {
+int test_fd_all(void) {
   /* Call all fd-related tests one by one to see how they impact the process
    * file descriptor table. */
   test_fd_read();

--- a/bin/utest/fpu_ctx.c
+++ b/bin/utest/fpu_ctx.c
@@ -181,7 +181,7 @@ static void signal_handler_usr1(int signo) {
   check_fpu_all_gpr((void *)1337);
 }
 
-int test_fpu_ctx_signals() {
+int test_fpu_ctx_signals(void) {
   MTC1_all_gpr((void *)0xc0de);
 
   signal(SIGUSR1, signal_handler_usr1);

--- a/bin/utest/misbehave.c
+++ b/bin/utest/misbehave.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-int test_misbehave() {
+int test_misbehave(void) {
   const char str[] = "Hello world from a user program!\n";
 
   /* XXX: Currently kernel does not sigsegv offending programs, but in future it

--- a/bin/utest/mmap.c
+++ b/bin/utest/mmap.c
@@ -85,7 +85,7 @@ int test_munmap_sigsegv(void) {
   return 1;
 }
 
-int test_mmap() {
+int test_mmap(void) {
   mmap_no_hint();
   mmap_with_hint();
   mmap_bad();

--- a/bin/utest/pgrp.c
+++ b/bin/utest/pgrp.c
@@ -213,7 +213,7 @@ int test_pgrp_orphan() {
 
 static volatile pid_t parent_sid;
 
-int test_session_basic() {
+int test_session_basic(void) {
   signal(SIGUSR1, sa_handler);
   parent_sid = getsid(getpid());
   assert(parent_sid != -1);

--- a/bin/utest/sbrk.c
+++ b/bin/utest/sbrk.c
@@ -73,7 +73,7 @@ int test_sbrk_sigsegv(void) {
   return 1;
 }
 
-int test_sbrk() {
+int test_sbrk(void) {
   sbrk_orig = sbrk(0);
   assert(sbrk_orig != NULL);
 

--- a/bin/utest/signal.c
+++ b/bin/utest/signal.c
@@ -17,7 +17,7 @@ static void sigint_handler(int signo) {
   printf("sigint handled!\n");
   raise(SIGUSR1); /* Recursive signals! */
 }
-int test_signal_basic() {
+int test_signal_basic(void) {
   signal(SIGINT, sigint_handler);
   signal(SIGUSR1, sigusr1_handler);
   raise(SIGINT);
@@ -36,7 +36,7 @@ static void sigusr2_handler(int signo) {
   raise(SIGABRT); /* Terminate self. */
 }
 /* Test sending a signal to a different thread. */
-int test_signal_send() {
+int test_signal_send(void) {
   /* The child should inherit signal handler configuration. */
   signal(SIGUSR2, sigusr2_handler);
   int pid = fork();
@@ -61,7 +61,7 @@ int test_signal_send() {
 /* ======= signal_abort ======= */
 /* This test shall be considered success if the process gets terminated with
    SIGABRT */
-int test_signal_abort() {
+int test_signal_abort(void) {
   raise(SIGABRT);
   return 0;
 }
@@ -69,7 +69,7 @@ int test_signal_abort() {
 /* ======= signal_segfault ======= */
 /* This test shall be considered success if the process gets terminated with
    SIGABRT */
-int test_signal_segfault() {
+int test_signal_segfault(void) {
   volatile struct { int x; } *ptr = 0x0;
   ptr->x = 42;
   return 0;
@@ -86,7 +86,7 @@ static void signal_parent(int signo) {
   kill(ppid, SIGCONT);
 }
 
-int test_signal_stop() {
+int test_signal_stop(void) {
   ppid = getpid();
   signal(SIGUSR1, SIG_IGN);
   signal(SIGCONT, sigcont_handler);
@@ -138,7 +138,7 @@ int test_signal_stop() {
 }
 
 /* ======= signal_cont_masked ======= */
-int test_signal_cont_masked() {
+int test_signal_cont_masked(void) {
   ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   int pid = fork();
@@ -172,7 +172,7 @@ int test_signal_cont_masked() {
 }
 
 /* ======= signal_mask ======= */
-int test_signal_mask() {
+int test_signal_mask(void) {
   ppid = getpid();
   signal(SIGUSR1, signal_parent);
   signal(SIGCONT, sigcont_handler);
@@ -219,7 +219,7 @@ int test_signal_mask() {
 }
 
 /* ======= signal_mask_nonmaskable ======= */
-int test_signal_mask_nonmaskable() {
+int test_signal_mask_nonmaskable(void) {
   sigset_t set, old;
   __sigemptyset(&set);
   __sigaddset(&set, SIGSTOP);
@@ -234,7 +234,7 @@ int test_signal_mask_nonmaskable() {
 }
 
 /* ======= signal_sigsuspend ======= */
-int test_signal_sigsuspend() {
+int test_signal_sigsuspend(void) {
   pid_t ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   signal(SIGUSR1, sigusr1_handler);
@@ -287,7 +287,7 @@ static void yield_handler(int signo) {
     handler_success = 1;
 }
 
-int test_signal_handler_mask() {
+int test_signal_handler_mask(void) {
   pid_t ppid = getpid();
   struct sigaction sa = {.sa_handler = yield_handler, .sa_flags = 0};
   /* Block SIGUSR1 when executing handler for SIGUSR2. */

--- a/bin/utest/wait.c
+++ b/bin/utest/wait.c
@@ -18,7 +18,7 @@ static void sigcont_handler(int signo) {
   sigcont_handled = 1;
 }
 
-int test_wait_basic() {
+int test_wait_basic(void) {
   ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   int pid = fork();
@@ -60,7 +60,7 @@ int test_wait_basic() {
 }
 
 /* ======= wait_nohang ======= */
-int test_wait_nohang() {
+int test_wait_nohang(void) {
   ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   int pid = fork();


### PR DESCRIPTION
Add void to function without arguments in `utest`.

In C `foo(void)` is different than `foo()`. Second variant could take any number of parameters of unknown types.