### PR TITLE
Basic TTY implementation (raw mode only)

### DIFF
--- a/include/sys/klog.h
+++ b/include/sys/klog.h
@@ -30,6 +30,7 @@ typedef enum {
   KL_TEST,    /* mask for testing purpose */
   KL_FILE,    /* filedesc & file operations */
   KL_FILESYS, /* filesystems */
+  KL_TTY,     /* terminal subsystem */
 } klog_origin_t;
 
 #define KL_NONE 0x00000000 /* don't log anything */

--- a/include/sys/ringbuf.h
+++ b/include/sys/ringbuf.h
@@ -26,5 +26,6 @@ bool ringbuf_putb(ringbuf_t *buf, uint8_t byte);
 bool ringbuf_getb(ringbuf_t *buf, uint8_t *byte_p);
 int ringbuf_read(ringbuf_t *buf, uio_t *uio);
 int ringbuf_write(ringbuf_t *buf, uio_t *uio);
+void ringbuf_reset(ringbuf_t *buf);
 
 #endif /* !_SYS_RINGBUF_H_ */

--- a/include/sys/termios.h
+++ b/include/sys/termios.h
@@ -34,7 +34,6 @@
 #ifndef _SYS_TERMIOS_H_
 #define _SYS_TERMIOS_H_
 
-#include <sys/ttydefaults.h>
 #include <sys/ttycom.h>
 
 /*

--- a/include/sys/termios.h
+++ b/include/sys/termios.h
@@ -34,6 +34,7 @@
 #ifndef _SYS_TERMIOS_H_
 #define _SYS_TERMIOS_H_
 
+#include <sys/ttydefaults.h>
 #include <sys/ttycom.h>
 
 /*

--- a/include/sys/tty.h
+++ b/include/sys/tty.h
@@ -1,0 +1,58 @@
+#ifndef _SYS_TTY_H_
+#define _SYS_TTY_H_
+
+#include <sys/termios.h>
+#include <sys/vnode.h>
+#include <sys/ringbuf.h>
+#include <sys/condvar.h>
+#include <sys/mutex.h>
+
+#define TTY_QUEUE_SIZE 0x400
+#define LINEBUF_SIZE 0x100
+
+struct tty;
+
+typedef void (*t_notify_out_t)(struct tty *);
+
+/* Routines supplied by the serial device driver. */
+typedef struct {
+  /* Called when new characters are added to the tty's output queue.
+   * This routine should make sure that at some point in the future all
+   * characters in the tty's output queue at the time of the call will
+   * be written to the device. */
+  t_notify_out_t t_notify_out;
+} ttyops_t;
+
+typedef struct tty {
+  mtx_t t_lock;
+  ringbuf_t t_inq;  /* Input queue */
+  condvar_t t_incv; /* CV for readers waiting for input */
+  ringbuf_t t_outq; /* Output queue */
+  size_t t_column;  /* Cursor's column position */
+  ttyops_t t_ops;   /* Serial device operations */
+  struct termios t_termios;
+  void *t_data; /* Serial device driver's private data */
+} tty_t;
+
+#define t_cc t_termios.c_cc
+#define t_cflag t_termios.c_cflag
+#define t_iflag t_termios.c_iflag
+#define t_ispeed t_termios.c_ispeed
+#define t_lflag t_termios.c_lflag
+#define t_oflag t_termios.c_oflag
+#define t_ospeed t_termios.c_ospeed
+
+extern vnodeops_t tty_vnodeops;
+
+/*
+ * Allocate and initialize a new `tty` structure.
+ */
+tty_t *tty_alloc(void);
+
+/*
+ * Put a single character into the tty's input queue, provided it's not full.
+ * Must be called with `t_lock` acquired.
+ */
+void tty_input(tty_t *tty, uint8_t c);
+
+#endif /* !_SYS_TTY_H_ */

--- a/include/sys/ttydefaults.h
+++ b/include/sys/ttydefaults.h
@@ -45,9 +45,10 @@
 /*
  * Defaults on "first" open.
  */
-#define TTYDEF_IFLAG (BRKINT | ICRNL | IMAXBEL | IXON | IXANY)
-#define TTYDEF_OFLAG (OPOST | ONLCR | OXTABS)
-#define TTYDEF_LFLAG (ECHO | ICANON | ISIG | IEXTEN | ECHOE | ECHOKE | ECHOCTL)
+#define TTYDEF_IFLAG (/* BRKINT |  */ ICRNL | IMAXBEL | /* IXON |  */ IXANY)
+#define TTYDEF_OFLAG (OPOST | ONLCR /* | OXTABS */)
+#define TTYDEF_LFLAG                                                           \
+  0 /* (ECHO | ICANON | ISIG | IEXTEN | ECHOE | ECHOKE | ECHOCTL) */
 #define TTYDEF_CFLAG (CREAD | CS8 | HUPCL)
 #define TTYDEF_SPEED (B9600)
 
@@ -78,4 +79,28 @@
 #define CRPRNT CREPRINT
 #define CFLUSH CDISCARD
 
+/* PROTECTED INCLUSION ENDS HERE */
 #endif /* !_SYS_TTYDEFAULTS_H_ */
+
+/*
+ * #define TTYDEFCHARS to include an array of default control characters.
+ */
+#ifdef _KERNEL
+#ifdef TTYDEFCHARS
+const cc_t ttydefchars[NCCS] = {
+  [VEOF] = CEOF,         [VEOL] = CEOL,
+  [VEOL2] = CEOL,        [VERASE] = CERASE,
+  [VWERASE] = CWERASE,   [VKILL] = CKILL,
+  [VREPRINT] = CREPRINT, [7] = _POSIX_VDISABLE, /* spare */
+  [VINTR] = CINTR,       [VQUIT] = CQUIT,
+  [VSUSP] = CSUSP,       [VDSUSP] = CDSUSP,
+  [VSTART] = CSTART,     [VSTOP] = CSTOP,
+  [VLNEXT] = CLNEXT,     [VDISCARD] = CDISCARD,
+  [VMIN] = CMIN,         [VTIME] = CTIME,
+  [VSTATUS] = CSTATUS,   [19] = _POSIX_VDISABLE, /* spare */
+};
+#undef TTYDEFCHARS
+#else
+extern const cc_t ttydefchars[NCCS];
+#endif
+#endif /* _KERNEL */

--- a/include/sys/ttydefaults.h
+++ b/include/sys/ttydefaults.h
@@ -79,28 +79,4 @@
 #define CRPRNT CREPRINT
 #define CFLUSH CDISCARD
 
-/* PROTECTED INCLUSION ENDS HERE */
 #endif /* !_SYS_TTYDEFAULTS_H_ */
-
-/*
- * #define TTYDEFCHARS to include an array of default control characters.
- */
-#ifdef _KERNEL
-#ifdef TTYDEFCHARS
-const cc_t ttydefchars[NCCS] = {
-  [VEOF] = CEOF,         [VEOL] = CEOL,
-  [VEOL2] = CEOL,        [VERASE] = CERASE,
-  [VWERASE] = CWERASE,   [VKILL] = CKILL,
-  [VREPRINT] = CREPRINT, [7] = _POSIX_VDISABLE, /* spare */
-  [VINTR] = CINTR,       [VQUIT] = CQUIT,
-  [VSUSP] = CSUSP,       [VDSUSP] = CDSUSP,
-  [VSTART] = CSTART,     [VSTOP] = CSTOP,
-  [VLNEXT] = CLNEXT,     [VDISCARD] = CDISCARD,
-  [VMIN] = CMIN,         [VTIME] = CTIME,
-  [VSTATUS] = CSTATUS,   [19] = _POSIX_VDISABLE, /* spare */
-};
-#undef TTYDEFCHARS
-#else
-extern const cc_t ttydefchars[NCCS];
-#endif
-#endif /* _KERNEL */

--- a/launch
+++ b/launch
@@ -73,8 +73,6 @@ if __name__ == '__main__':
                         help='Enable VGA output.')
     parser.add_argument('-b', '--board', default='malta',
                         choices=['malta', 'rpi3'], help='Emulated board.')
-    parser.add_argument('-r', '--raw', action='store_true',
-                        help='Run socat on /dev/tty1 in raw mode.')
     args = parser.parse_args()
 
     # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
@@ -115,10 +113,8 @@ if __name__ == '__main__':
     else:
         dbg = None
 
-    uarts = []
-    for name, port in getvar('qemu.uarts'):
-        raw = name == '/dev/tty1' and args.raw
-        uarts.append(SOCAT(name, port, raw))
+    uarts = [SOCAT(uart['name'], uart['port'], uart.get('raw', False))
+             for uart in getvar('qemu.uarts')]
 
     if args.test_run:
         TestRun(sim, uarts)

--- a/launch
+++ b/launch
@@ -73,6 +73,8 @@ if __name__ == '__main__':
                         help='Enable VGA output.')
     parser.add_argument('-b', '--board', default='malta',
                         choices=['malta', 'rpi3'], help='Emulated board.')
+    parser.add_argument('-r', '--raw', action='store_true',
+                        help='Run socat on /dev/tty1 in raw mode.')
     args = parser.parse_args()
 
     # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
@@ -113,7 +115,10 @@ if __name__ == '__main__':
     else:
         dbg = None
 
-    uarts = [SOCAT(name, port) for name, port in getvar('qemu.uarts')]
+    uarts = []
+    for name, port in getvar('qemu.uarts'):
+        raw = name == '/dev/tty1' and args.raw
+        uarts.append(SOCAT(name, port, raw))
 
     if args.test_run:
         TestRun(sim, uarts)

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -51,9 +51,9 @@ CONFIG = {
                     '-machine', 'malta',
                     '-cpu', '24Kf'],
                 'uarts': [
-                    ('/dev/tty1', uart_port(0)),
-                    ('/dev/tty2', uart_port(1)),
-                    ('/dev/cons', uart_port(2))
+                    dict(name='/dev/tty1', port=uart_port(0)),
+                    dict(name='/dev/tty2', port=uart_port(1)),
+                    dict(name='/dev/cons', port=uart_port(2))
                 ]
             },
             'rpi3': {
@@ -63,7 +63,7 @@ CONFIG = {
                     '-smp', '4',
                     '-cpu', 'cortex-a53'],
                 'uarts': [
-                    ('/dev/cons', uart_port(0))
+                    dict(name='/dev/cons', port=uart_port(0))
                 ]
             }
         }
@@ -201,7 +201,8 @@ class QEMU(Launchable):
         super().__init__('qemu', getvar('qemu.binary'))
 
         self.options = getopts('qemu.options')
-        for _, port in getvar('qemu.uarts'):
+        for uart in getvar('qemu.uarts'):
+            port = uart['port']
             self.options += ['-serial', f'tcp:127.0.0.1:{port},server,wait']
 
         if getvar('config.args'):

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -237,11 +237,14 @@ class CGDB(GDB):
 
 
 class SOCAT(Launchable):
-    def __init__(self, name, tcp_port):
+    def __init__(self, name, tcp_port, raw=False):
         super().__init__(name, 'socat')
         # The simulator will only open the server after some time has
         # passed.  To minimize the delay, keep reconnecting until success.
-        self.options = ['STDIO', f'tcp:localhost:{tcp_port},retry,forever']
+        stdio_opt = 'STDIO'
+        if raw:
+            stdio_opt += ',cfmakeraw'
+        self.options = [stdio_opt, f'tcp:localhost:{tcp_port},retry,forever']
 
 
 Debuggers = {'gdb': GDB, 'gdbtui': GDBTUI, 'cgdb': CGDB}

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -93,12 +93,11 @@ static intr_filter_t ns16550_intr(void *data) {
 }
 
 static bool ns16550_getb_lock(ns16550_state_t *ns16550, uint8_t *byte_p) {
-  spin_lock(&ns16550->lock);
-  bool ret = ringbuf_getb(&ns16550->rx_buf, byte_p);
-  spin_unlock(&ns16550->lock);
-  return ret;
+  SCOPED_SPIN_LOCK(&ns16550->lock);
+  return ringbuf_getb(&ns16550->rx_buf, byte_p);
 }
 
+/* TODO: revisit after per-intr_event ithreads are implemented. */
 static void ns16550_tty_thread(void *arg) {
   ns16550_state_t *ns16550 = (ns16550_state_t *)arg;
   tty_t *tty = ns16550->tty;
@@ -120,19 +119,17 @@ static void ns16550_tty_thread(void *arg) {
       if (ipend & IIR_TXRDY) {
         /* Move characters from the tty's output queue to tx_buf. */
         while (true) {
-          spin_lock(&ns16550->lock);
+          SCOPED_SPIN_LOCK(&ns16550->lock);
           if (ringbuf_full(&ns16550->tx_buf) ||
               !ringbuf_getb(&tty->t_outq, &byte)) {
             /* Enable TXRDY interrupts if there are characters in tx_buf. */
             if (!ringbuf_empty(&ns16550->tx_buf))
               set(ns16550->regs, IER, IER_ETXRDY);
             ns16550->tty_outq_nonempty = !ringbuf_empty(&tty->t_outq);
-            spin_unlock(&ns16550->lock);
             break;
           }
           ns16550->tty_outq_nonempty = !ringbuf_empty(&tty->t_outq);
           ringbuf_putb(&ns16550->tx_buf, byte);
-          spin_unlock(&ns16550->lock);
         }
       }
     }

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -178,7 +178,7 @@ static int ns16550_attach(device_t *dev) {
 
   cv_init(&ns16550->tty_thread_cv, "NS16550 TTY thread notification");
   thread_t *tty_thread =
-    thread_create("NS16550 TTY worker", ns16550_tty_thread, ns16550,
+    thread_create("ns16550-tty-worker", ns16550_tty_thread, ns16550,
                   prio_ithread(PRIO_ITHRD_QTY - 1));
   sched_add(tty_thread);
 

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -1,5 +1,6 @@
 #define KL_LOG KL_DEV
 #include <sys/libkern.h>
+#include <sys/spinlock.h>
 #include <sys/vnode.h>
 #include <sys/devfs.h>
 #include <sys/klog.h>
@@ -13,15 +14,20 @@
 #include <sys/interrupt.h>
 #include <sys/stat.h>
 #include <sys/devclass.h>
+#include <sys/tty.h>
+#include <sys/priority.h>
+#include <sys/sched.h>
 
 #define UART_BUFSIZE 128
 
 typedef struct ns16550_state {
   spin_t lock;
-  condvar_t tx_nonfull, rx_nonempty;
   ringbuf_t tx_buf, rx_buf;
   intr_handler_t intr_handler;
   resource_t *regs;
+  tty_t *tty;
+  condvar_t tty_thread_cv;
+  uint8_t tty_ipend;
 } ns16550_state_t;
 
 #define in(regs, offset) bus_read_1((regs), (offset))
@@ -46,81 +52,6 @@ static void setup(resource_t *regs) {
   out(regs, LCR, LCR_8BITS); /* 8-bit data, no parity */
 }
 
-static int ns16550_read(vnode_t *v, uio_t *uio, int ioflags) {
-  ns16550_state_t *ns16550 = v->v_data;
-  int error;
-
-  uio->uio_offset = 0; /* This device does not support offsets. */
-
-  uint8_t byte;
-  WITH_SPIN_LOCK (&ns16550->lock) {
-    /* For simplicity, copy to the user space one byte at a time. */
-    while (!ringbuf_getb(&ns16550->rx_buf, &byte))
-      cv_wait(&ns16550->rx_nonempty, &ns16550->lock);
-  }
-  if ((error = uiomove_frombuf(&byte, 1, uio)))
-    return error;
-
-  return 0;
-}
-
-static int ns16550_write(vnode_t *v, uio_t *uio, int ioflags) {
-  ns16550_state_t *ns16550 = v->v_data;
-  resource_t *uart = ns16550->regs;
-  int error;
-
-  uio->uio_offset = 0; /* This device does not support offsets. */
-
-  while (uio->uio_resid > 0) {
-    uint8_t byte;
-    /* For simplicity, copy from the user space one byte at a time. */
-    if ((error = uiomove(&byte, 1, uio)))
-      return error;
-    WITH_SPIN_LOCK (&ns16550->lock) {
-      if (in(uart, LSR) & LSR_THRE) {
-        out(uart, THR, byte);
-      } else {
-        while (!ringbuf_putb(&ns16550->tx_buf, byte))
-          cv_wait(&ns16550->tx_nonfull, &ns16550->lock);
-      }
-    }
-  }
-
-  return 0;
-}
-
-static int ns16550_close(vnode_t *v, file_t *fp) {
-  /* TODO release resources */
-  return 0;
-}
-
-/* XXX: This should be implemented by tty driver, not here. */
-static int ns16550_ioctl(vnode_t *v, u_long cmd, void *data) {
-  if (cmd) {
-    unsigned len = IOCPARM_LEN(cmd);
-    memset(data, 0, len);
-    return 0;
-  }
-
-  return EPASSTHROUGH;
-}
-
-static int ns16550_getattr(vnode_t *v, vattr_t *va) {
-  memset(va, 0, sizeof(vattr_t));
-  va->va_mode = S_IFCHR;
-  va->va_nlink = 1;
-  va->va_ino = 0;
-  va->va_size = 0;
-  return 0;
-}
-
-static vnodeops_t dev_uart_ops = {.v_open = vnode_open_generic,
-                                  .v_write = ns16550_write,
-                                  .v_read = ns16550_read,
-                                  .v_close = ns16550_close,
-                                  .v_ioctl = ns16550_ioctl,
-                                  .v_getattr = ns16550_getattr};
-
 static intr_filter_t ns16550_intr(void *data) {
   ns16550_state_t *ns16550 = data;
   resource_t *uart = ns16550->regs;
@@ -132,7 +63,8 @@ static intr_filter_t ns16550_intr(void *data) {
     /* data ready to be received? */
     if (iir & IIR_RXRDY) {
       (void)ringbuf_putb(&ns16550->rx_buf, in(uart, RBR));
-      cv_signal(&ns16550->rx_nonempty);
+      ns16550->tty_ipend |= IIR_RXRDY;
+      cv_signal(&ns16550->tty_thread_cv);
       res = IF_FILTERED;
     }
 
@@ -141,13 +73,98 @@ static intr_filter_t ns16550_intr(void *data) {
       uint8_t byte;
       if (ringbuf_getb(&ns16550->tx_buf, &byte)) {
         out(uart, THR, byte);
-        cv_signal(&ns16550->tx_nonfull);
+      } else {
+        /* If we're out of characters, signal the tty thread to refill. */
+        ns16550->tty_ipend |= IIR_TXRDY;
+        cv_signal(&ns16550->tty_thread_cv);
+        /* Disable TXRDY interrupts - the tty thread will re-enable them
+         * after filling tx_buf. */
+        clr(uart, IER, IER_ETXRDY);
       }
       res = IF_FILTERED;
     }
   }
 
   return res;
+}
+
+/*
+ * Process incoming characters.
+ * This procedure is run in the interrupt thread's context.
+ */
+static void ns16550_service(void *data) {
+  ns16550_state_t *ns16550 = data;
+  tty_t *tty = ns16550->tty;
+  uint8_t byte;
+  while (true) {
+    WITH_SPIN_LOCK (&ns16550->lock) {
+      if (!ringbuf_getb(&ns16550->rx_buf, &byte))
+        return;
+    }
+    WITH_MTX_LOCK (&tty->t_lock) { tty_input(tty, byte); }
+  }
+}
+
+static bool ns16550_getb_lock(ns16550_state_t *ns16550, uint8_t *byte_p) {
+  spin_lock(&ns16550->lock);
+  bool ret = ringbuf_getb(&ns16550->rx_buf, byte_p);
+  spin_unlock(&ns16550->lock);
+  return ret;
+}
+
+static void ns16550_tty_thread(void *arg) {
+  ns16550_state_t *ns16550 = (ns16550_state_t *)arg;
+  tty_t *tty = ns16550->tty;
+  uint8_t ipend, byte;
+
+  while (true) {
+    WITH_SPIN_LOCK (&ns16550->lock) {
+      /* Sleep until there's work for us to do. */
+      while ((ipend = ns16550->tty_ipend) == 0)
+        cv_wait(&ns16550->tty_thread_cv, &ns16550->lock);
+      ns16550->tty_ipend = 0;
+    }
+    WITH_MTX_LOCK (&tty->t_lock) {
+      if (ipend & IIR_RXRDY) {
+        /* Move characters from rx_buf into the tty's input queue. */
+        while (ns16550_getb_lock(ns16550, &byte))
+          tty_input(tty, byte);
+      }
+      if (ipend & IIR_TXRDY) {
+        /* Move characters from the tty's output queue to tx_buf. */
+        while (true) {
+          spin_lock(&ns16550->lock);
+          if (ringbuf_full(&ns16550->tx_buf) ||
+              !ringbuf_getb(&tty->t_outq, &byte)) {
+            /* Enable TXRDY interrupts if there are characters in tx_buf. */
+            if (!ringbuf_empty(&ns16550->tx_buf))
+              set(ns16550->regs, IER, IER_ETXRDY);
+            spin_unlock(&ns16550->lock);
+            break;
+          }
+          ringbuf_putb(&ns16550->tx_buf, byte);
+          spin_unlock(&ns16550->lock);
+        }
+      }
+    }
+  }
+}
+
+/*
+ * New characters have appeared in the tty's output queue.
+ * Notify the tty thread to do the work.
+ * Called with `tty->t_lock` held.
+ */
+static void ns16550_notify_out(tty_t *tty) {
+  ns16550_state_t *ns16550 = tty->t_data;
+
+  if (ringbuf_empty(&tty->t_outq))
+    return;
+
+  WITH_SPIN_LOCK (&ns16550->lock) {
+    ns16550->tty_ipend |= IIR_TXRDY;
+    cv_signal(&ns16550->tty_thread_cv);
+  }
 }
 
 static int ns16550_attach(device_t *dev) {
@@ -161,15 +178,26 @@ static int ns16550_attach(device_t *dev) {
   ns16550->tx_buf.size = UART_BUFSIZE;
 
   spin_init(&ns16550->lock, 0);
-  cv_init(&ns16550->rx_nonempty, "UART receive buffer not empty");
-  cv_init(&ns16550->tx_nonfull, "UART transmit buffer not full");
+
+  tty_t *tty = tty_alloc();
+  tty->t_termios.c_ispeed = 115200;
+  tty->t_termios.c_ospeed = 115200;
+  tty->t_ops.t_notify_out = ns16550_notify_out;
+  tty->t_data = ns16550;
+  ns16550->tty = tty;
+
+  cv_init(&ns16550->tty_thread_cv, "NS16550 TTY thread notification");
+  thread_t *tty_thread =
+    thread_create("NS16550 TTY worker", ns16550_tty_thread, ns16550,
+                  prio_ithread(PRIO_ITHRD_QTY - 1));
+  sched_add(tty_thread);
 
   /* TODO Small hack to select COM1 UART */
   ns16550->regs = bus_alloc_resource(
     dev, RT_ISA, 0, IO_COM1, IO_COM1 + IO_COMSIZE - 1, IO_COMSIZE, RF_ACTIVE);
   assert(ns16550->regs != NULL);
-  ns16550->intr_handler =
-    INTR_HANDLER_INIT(ns16550_intr, NULL, ns16550, "NS16550 UART", 0);
+  ns16550->intr_handler = INTR_HANDLER_INIT(ns16550_intr, ns16550_service,
+                                            ns16550, "NS16550 UART", 0);
   /* TODO Do not use magic number "4" here! */
   bus_intr_setup(dev, 4, &ns16550->intr_handler);
 
@@ -178,7 +206,7 @@ static int ns16550_attach(device_t *dev) {
   out(ns16550->regs, IER, IER_ERXRDY | IER_ETXRDY);
 
   /* Prepare /dev/uart interface. */
-  devfs_makedev(NULL, "uart", &dev_uart_ops, ns16550);
+  devfs_makedev(NULL, "uart", &tty_vnodeops, ns16550->tty);
 
   return 0;
 }

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -198,10 +198,10 @@ static int ns16550_attach(device_t *dev) {
 
   ns16550_state_t *ns16550 = dev->state;
 
-  ns16550->rx_buf.data = kmalloc(M_DEV, UART_BUFSIZE, M_ZERO);
-  ns16550->rx_buf.size = UART_BUFSIZE;
-  ns16550->tx_buf.data = kmalloc(M_DEV, UART_BUFSIZE, M_ZERO);
-  ns16550->tx_buf.size = UART_BUFSIZE;
+  ringbuf_init(&ns16550->rx_buf, kmalloc(M_DEV, UART_BUFSIZE, M_ZERO),
+               UART_BUFSIZE);
+  ringbuf_init(&ns16550->tx_buf, kmalloc(M_DEV, UART_BUFSIZE, M_ZERO),
+               UART_BUFSIZE);
 
   spin_init(&ns16550->lock, 0);
 

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -104,18 +104,28 @@ static intr_filter_t ns16550_intr(void *data) {
 /*
  * If tx_buf is empty, we can try to write characters directly from tty->t_outq.
  * This routine attempts to do just that.
- * Must be called with both tty->t_lock and ns16550->lock held.
+ * Must be called with tty->t_lock held. Acquires ns16550->lock.
  */
 static void ns16550_try_bypass_txbuf(ns16550_state_t *ns16550, tty_t *tty) {
   resource_t *uart = ns16550->regs;
+  uint32_t count = 0;
   uint8_t byte;
 
   if (!ringbuf_empty(&ns16550->tx_buf))
     return;
 
+  spin_lock(&ns16550->lock);
   while ((in(uart, LSR) & LSR_THRE) && ringbuf_getb(&tty->t_outq, &byte)) {
     out(uart, THR, byte);
+    /* Avoid holding ns16550->lock for too long, since interrupts are disabled
+     * while we're holding it. */
+    if (++count >= 20) {
+      count = 0;
+      spin_unlock(&ns16550->lock);
+      spin_lock(&ns16550->lock);
+    }
   }
+  spin_unlock(&ns16550->lock);
 }
 
 static void ns16550_set_tty_outq_nonempty_flag(ns16550_state_t *ns16550,
@@ -133,9 +143,9 @@ static void ns16550_set_tty_outq_nonempty_flag(ns16550_state_t *ns16550,
 static void ns16550_fill_txbuf(ns16550_state_t *ns16550, tty_t *tty) {
   uint8_t byte;
 
+  ns16550_try_bypass_txbuf(ns16550, tty);
   while (true) {
     SCOPED_SPIN_LOCK(&ns16550->lock);
-    ns16550_try_bypass_txbuf(ns16550, tty);
     if (ringbuf_full(&ns16550->tx_buf) || !ringbuf_getb(&tty->t_outq, &byte)) {
       /* Enable TXRDY interrupts if there are characters in tx_buf. */
       if (!ringbuf_empty(&ns16550->tx_buf))

--- a/sys/kern/Makefile
+++ b/sys/kern/Makefile
@@ -59,6 +59,7 @@ SOURCES = \
 	time.c \
 	timer.c \
 	tmpfs.c \
+	tty.c \
 	uio.c \
 	ustack.c \
 	vfs.c \

--- a/sys/kern/klog.c
+++ b/sys/kern/klog.c
@@ -19,7 +19,8 @@ static const char *subsystems[] = {
   [KL_DEV] = "dev",     [KL_VFS] = "vfs",         [KL_VNODE] = "vnode",
   [KL_PROC] = "proc",   [KL_SYSCALL] = "syscall", [KL_USER] = "user",
   [KL_TEST] = "test",   [KL_SIGNAL] = "signal",   [KL_FILESYS] = "filesys",
-  [KL_TIME] = "time",   [KL_FILE] = "file",       [KL_UNDEF] = "???"};
+  [KL_TIME] = "time",   [KL_FILE] = "file",       [KL_TTY] = "tty",
+  [KL_UNDEF] = "???"};
 
 void init_klog(void) {
   const char *mask = kenv_get("klog-mask");

--- a/sys/kern/ringbuf.c
+++ b/sys/kern/ringbuf.c
@@ -77,3 +77,7 @@ int ringbuf_write(ringbuf_t *buf, uio_t *uio) {
   }
   return 0;
 }
+
+void ringbuf_reset(ringbuf_t *buf) {
+  ringbuf_init(buf, buf->data, buf->size);
+}

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -17,6 +17,7 @@
 #include <sys/param.h>
 #include <sys/uio.h>
 #include <sys/vm_map.h>
+#include <sys/device.h>
 
 /*
  * Table with character classes and parity. The 8th bit indicates parity,
@@ -122,13 +123,12 @@ static void tty_init_termios(struct termios *tio) {
 }
 
 tty_t *tty_alloc(void) {
-  /* XXX: What pool should we use here? */
-  tty_t *tty = kmalloc(M_TEMP, sizeof(tty_t), M_WAITOK);
+  tty_t *tty = kmalloc(M_DEV, sizeof(tty_t), M_WAITOK);
   mtx_init(&tty->t_lock, 0);
-  ringbuf_init(&tty->t_inq, kmalloc(M_TEMP, TTY_QUEUE_SIZE, M_WAITOK),
+  ringbuf_init(&tty->t_inq, kmalloc(M_DEV, TTY_QUEUE_SIZE, M_WAITOK),
                TTY_QUEUE_SIZE);
   cv_init(&tty->t_incv, "t_incv");
-  ringbuf_init(&tty->t_outq, kmalloc(M_TEMP, TTY_QUEUE_SIZE, M_WAITOK),
+  ringbuf_init(&tty->t_outq, kmalloc(M_DEV, TTY_QUEUE_SIZE, M_WAITOK),
                TTY_QUEUE_SIZE);
   tty_init_termios(&tty->t_termios);
   tty->t_ops.t_notify_out = NULL;

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -223,7 +223,7 @@ static void tty_discard_input(tty_t *tty) {
  * the characters that should be transmitted. The return value
  * is the number of characters that should be transmitted.
  */
-static int tty_process_out(tty_t *tty, int oflag, uint8_t *cb) {
+static int tty_process_out(tty_t *tty, int oflag, uint8_t cb[2]) {
   uint8_t c = cb[0];
   /* Newline translation: if ONLCR is set, translate newline into "\r\n". */
   if (c == '\n' && (oflag & ONLCR)) {

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -171,7 +171,7 @@ void tty_input(tty_t *tty, uint8_t c) {
 
   if (c == '\r') {
     if (iflag & IGNCR)
-      goto end;
+      return;
     else if (iflag & ICRNL)
       c = '\n';
   } else if (c == '\n' && (iflag & INLCR)) {
@@ -179,15 +179,15 @@ void tty_input(tty_t *tty, uint8_t c) {
   }
 
   if (tty->t_inq.count >= TTY_QUEUE_SIZE) {
-    if (iflag & IMAXBEL)
+    if (iflag & IMAXBEL) {
       tty_output(tty, CTRL('g'));
-    goto end;
+      tty_notify_out(tty);
+    }
+    return;
   }
 
   ringbuf_putb(&tty->t_inq, c);
   tty_wakeup(tty);
-end:
-  tty_notify_out(tty);
 }
 
 static int tty_read(vnode_t *v, uio_t *uio, int ioflags) {

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -123,7 +123,7 @@ static void tty_init_termios(struct termios *tio) {
   tio->c_oflag = TTYDEF_OFLAG;
   tio->c_ispeed = TTYDEF_SPEED;
   tio->c_ospeed = TTYDEF_SPEED;
-  memcpy(&tio->c_cc, ttydefchars, sizeof ttydefchars);
+  memcpy(&tio->c_cc, ttydefchars, sizeof(ttydefchars));
 }
 
 tty_t *tty_alloc(void) {

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -19,6 +19,8 @@
 #include <sys/vm_map.h>
 #include <sys/device.h>
 
+/* START OF FreeBSD CODE */
+
 /*
  * Table with character classes and parity. The 8th bit indicates parity,
  * the 7th bit indicates the character is an alphameric or underscore (for
@@ -103,6 +105,8 @@ unsigned char const char_type[] = {
 #undef NO
 #undef TB
 #undef VT
+
+/* END OF FreeBSD CODE */
 
 /* termios flags that can be changed using TIOCSETA{,W,F}. */
 #define TTYSUP_IFLAG_CHANGE (INLCR | IGNCR | ICRNL | IMAXBEL)

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -1,0 +1,380 @@
+#define KL_LOG KL_TTY
+#include <sys/klog.h>
+#include <sys/libkern.h>
+#include <sys/termios.h>
+#include <sys/tty.h>
+#define TTYDEFCHARS
+#include <sys/ttydefaults.h>
+#undef TTYDEFCHARS
+#include <sys/malloc.h>
+#include <sys/kmem_flags.h>
+#include <sys/mutex.h>
+#include <sys/condvar.h>
+#include <sys/ringbuf.h>
+#include <sys/vnode.h>
+#include <sys/stat.h>
+#include <sys/mimiker.h>
+#include <sys/param.h>
+#include <sys/uio.h>
+#include <sys/vm_map.h>
+
+/*
+ * Table with character classes and parity. The 8th bit indicates parity,
+ * the 7th bit indicates the character is an alphameric or underscore (for
+ * ALTWERASE), and the low 6 bits indicate delay type.  If the low 6 bits
+ * are 0 then the character needs no special processing on output; classes
+ * other than 0 might be translated or (not currently) require delays.
+ */
+#define E 0x00 /* Even parity. */
+#define O 0x80 /* Odd parity. */
+#define PARITY(c) (char_type[c] & O)
+
+#define ALPHA 0x40 /* Alpha or underscore. */
+#define ISALPHA(c) (char_type[(c)&TTY_CHARMASK] & ALPHA)
+
+#define CCLASSMASK 0x3f
+#define CCLASS(c) (char_type[c] & CCLASSMASK)
+
+typedef enum {
+  ORDINARY = 0,
+  CONTROL = 1,
+  BACKSPACE = 2,
+  NEWLINE = 3,
+  TAB = 4,
+  VTAB = 5,
+  RETURN = 6,
+} cclass_t;
+
+#define BS BACKSPACE
+#define CC CONTROL
+#define CR RETURN
+#define NA ORDINARY | ALPHA
+#define NL NEWLINE
+#define NO ORDINARY
+#define TB TAB
+#define VT VTAB
+
+/* clang-format off */
+unsigned char const char_type[] = {
+	E|CC, O|CC, O|CC, E|CC, O|CC, E|CC, E|CC, O|CC,	/* nul - bel */
+	O|BS, E|TB, E|NL, O|CC, E|VT, O|CR, O|CC, E|CC,	/* bs - si */
+	O|CC, E|CC, E|CC, O|CC, E|CC, O|CC, O|CC, E|CC,	/* dle - etb */
+	E|CC, O|CC, O|CC, E|CC, O|CC, E|CC, E|CC, O|CC,	/* can - us */
+	O|NO, E|NO, E|NO, O|NO, E|NO, O|NO, O|NO, E|NO,	/* sp - ' */
+	E|NO, O|NO, O|NO, E|NO, O|NO, E|NO, E|NO, O|NO,	/* ( - / */
+	E|NA, O|NA, O|NA, E|NA, O|NA, E|NA, E|NA, O|NA,	/* 0 - 7 */
+	O|NA, E|NA, E|NO, O|NO, E|NO, O|NO, O|NO, E|NO,	/* 8 - ? */
+	O|NO, E|NA, E|NA, O|NA, E|NA, O|NA, O|NA, E|NA,	/* @ - G */
+	E|NA, O|NA, O|NA, E|NA, O|NA, E|NA, E|NA, O|NA,	/* H - O */
+	E|NA, O|NA, O|NA, E|NA, O|NA, E|NA, E|NA, O|NA,	/* P - W */
+	O|NA, E|NA, E|NA, O|NO, E|NO, O|NO, O|NO, O|NA,	/* X - _ */
+	E|NO, O|NA, O|NA, E|NA, O|NA, E|NA, E|NA, O|NA,	/* ` - g */
+	O|NA, E|NA, E|NA, O|NA, E|NA, O|NA, O|NA, E|NA,	/* h - o */
+	O|NA, E|NA, E|NA, O|NA, E|NA, O|NA, O|NA, E|NA,	/* p - w */
+	E|NA, O|NA, O|NA, E|NO, O|NO, E|NO, E|NO, O|CC,	/* x - del */
+	/*
+	 * Meta chars; should be settable per character set;
+	 * for now, treat them all as normal characters.
+	 */
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+	NA,   NA,   NA,   NA,   NA,   NA,   NA,   NA,
+};
+/* clang-format on */
+#undef BS
+#undef CC
+#undef CR
+#undef NA
+#undef NL
+#undef NO
+#undef TB
+#undef VT
+
+/* termios flags that can be changed using TIOCSETA{,W,F}. */
+#define TTYSUP_IFLAG_CHANGE (INLCR | IGNCR | ICRNL | IMAXBEL)
+#define TTYSUP_OFLAG_CHANGE (OPOST | ONLCR | OCRNL | ONOCR | ONLRET)
+#define TTYSUP_LFLAG_CHANGE 0
+
+static void tty_output(tty_t *tty, uint8_t c);
+
+/* Initialize termios with sane defaults. */
+static void tty_init_termios(struct termios *tio) {
+  tio->c_cflag = TTYDEF_CFLAG;
+  tio->c_iflag = TTYDEF_IFLAG;
+  tio->c_lflag = TTYDEF_LFLAG;
+  tio->c_oflag = TTYDEF_OFLAG;
+  tio->c_ispeed = TTYDEF_SPEED;
+  tio->c_ospeed = TTYDEF_SPEED;
+  memcpy(&tio->c_cc, ttydefchars, sizeof ttydefchars);
+}
+
+tty_t *tty_alloc(void) {
+  /* XXX: What pool should we use here? */
+  tty_t *tty = kmalloc(M_TEMP, sizeof(tty_t), M_WAITOK);
+  mtx_init(&tty->t_lock, 0);
+  ringbuf_init(&tty->t_inq, kmalloc(M_TEMP, TTY_QUEUE_SIZE, M_WAITOK),
+               TTY_QUEUE_SIZE);
+  cv_init(&tty->t_incv, "t_incv");
+  ringbuf_init(&tty->t_outq, kmalloc(M_TEMP, TTY_QUEUE_SIZE, M_WAITOK),
+               TTY_QUEUE_SIZE);
+  tty_init_termios(&tty->t_termios);
+  tty->t_ops.t_notify_out = NULL;
+  tty->t_data = NULL;
+  tty->t_column = 0;
+  return tty;
+}
+
+/* Notify the serial device driver that there are characters
+ * in the output queue. */
+static void tty_notify_out(tty_t *tty) {
+  assert(mtx_owned(&tty->t_lock));
+  if (tty->t_outq.count > 0) {
+    tty->t_ops.t_notify_out(tty);
+  }
+}
+
+/*
+ * Put a character directly in the output queue.
+ * TODO: what to do when the queue is full?
+ */
+static void tty_outq_putc(tty_t *tty, uint8_t c) {
+  if (!(tty->t_lflag & FLUSHO) && !ringbuf_putb(&tty->t_outq, c)) {
+    klog("tty_outq_putc: outq full, dropping character 0x%hhx");
+  }
+}
+
+/* Wake up readers waiting for input. */
+static void tty_wakeup(tty_t *tty) {
+  cv_broadcast(&tty->t_incv);
+}
+
+void tty_input(tty_t *tty, uint8_t c) {
+  /* TODO: Canonical mode, character processing. */
+  int iflag = tty->t_iflag;
+
+  if (c == '\r') {
+    if (iflag & IGNCR)
+      goto end;
+    else if (iflag & ICRNL)
+      c = '\n';
+  } else if (c == '\n' && (iflag & INLCR)) {
+    c = '\r';
+  }
+
+  if (tty->t_inq.count >= TTY_QUEUE_SIZE) {
+    if (iflag & IMAXBEL)
+      tty_output(tty, CTRL('g'));
+    goto end;
+  }
+
+  ringbuf_putb(&tty->t_inq, c);
+  tty_wakeup(tty);
+end:
+  tty_notify_out(tty);
+}
+
+static int tty_read(vnode_t *v, uio_t *uio, int ioflags) {
+  tty_t *tty = v->v_data;
+  int error = 0;
+
+  uio->uio_offset = 0; /* This device does not support offsets. */
+
+  uint8_t c;
+  WITH_MTX_LOCK (&tty->t_lock) {
+    while (tty->t_inq.count == 0)
+      cv_wait(&tty->t_incv, &tty->t_lock);
+
+    /* In raw mode, read a single character.
+     * In theory we should respect things such as VMIN and VTIME, but most
+     * programs don't use them. */
+    ringbuf_getb(&tty->t_inq, &c);
+    error = uiomove(&c, 1, uio);
+  }
+
+  return error;
+}
+
+static void tty_discard_input(tty_t *tty) {
+  assert(mtx_owned(&tty->t_lock));
+  ringbuf_reset(&tty->t_inq);
+}
+
+/*
+ * Do output processing on a character.
+ * `cb` points to a character buffer, where the first element
+ * is the character to process. Upon return, the buffer contains
+ * the characters that should be transmitted. The return value
+ * is the number of characters that should be transmitted.
+ */
+static int tty_process_out(tty_t *tty, int oflag, uint8_t *cb) {
+  uint8_t c = cb[0];
+  /* Newline translation: if ONLCR is set, translate newline into "\r\n". */
+  if (c == '\n' && (oflag & ONLCR)) {
+    cb[0] = '\r';
+    cb[1] = '\n';
+    return 2;
+  }
+  if (c == '\r') {
+    /* If OCRNL is set, translate "\r" into "\n". */
+    if (oflag & OCRNL) {
+      cb[0] = '\n';
+      return 1;
+    }
+    /* If ONOCR is set, don't transmit CRs when on column 0. */
+    if ((oflag & ONOCR) && tty->t_column == 0)
+      return 0;
+  }
+  return 1;
+}
+
+/*
+ * Add a single character to the output queue.
+ * Output processing (e.g. turning NL into CR-NL pairs) happens here.
+ */
+static void tty_output(tty_t *tty, uint8_t c) {
+  assert(mtx_owned(&tty->t_lock));
+
+  int oflag = tty->t_oflag;
+  /* Check if output processing is enabled. */
+  if (!(oflag & OPOST)) {
+    tty_outq_putc(tty, c);
+    return;
+  }
+
+  uint8_t cb[2];
+  cb[0] = c;
+  int ccount = tty_process_out(tty, oflag, cb);
+  int col = tty->t_column;
+
+  for (int i = 0; i < ccount; i++) {
+    tty_outq_putc(tty, cb[i]);
+    switch (CCLASS(cb[i])) {
+      case BACKSPACE:
+        if (col > 0)
+          col--;
+        break;
+      case CONTROL:
+        break;
+      case NEWLINE:
+        if (oflag & ONLRET)
+          col = 0;
+        break;
+      case RETURN:
+        col = 0;
+        break;
+      case ORDINARY:
+        col++;
+        break;
+      case TAB:
+        col = roundup2(col + 1, 8);
+        break;
+    }
+  }
+  tty->t_column = col;
+}
+
+static int tty_write(vnode_t *v, uio_t *uio, int ioflags) {
+  tty_t *tty = v->v_data;
+  int error = 0;
+
+  uio->uio_offset = 0; /* This device does not support offsets. */
+
+  uint8_t c;
+  WITH_MTX_LOCK (&tty->t_lock) {
+    while (uio->uio_resid > 0) {
+      error = uiomove(&c, 1, uio);
+      if (error)
+        break;
+      tty_output(tty, c);
+    }
+    tty_notify_out(tty);
+  }
+
+  return error;
+}
+
+static int tty_close(vnode_t *v, file_t *fp) {
+  /* TODO implement. */
+  return 0;
+}
+
+static int tty_ioctl(vnode_t *v, u_long cmd, void *data) {
+  tty_t *tty = v->v_data;
+  int ret = 0;
+
+  mtx_lock(&tty->t_lock);
+  switch (cmd) {
+    case TIOCGETA: { /* Get termios */
+      struct termios *t = (struct termios *)data;
+      memcpy(t, &tty->t_termios, sizeof(struct termios));
+      break;
+    }
+    case TIOCSETA:    /* Set termios immediately */
+    case TIOCSETAW:   /* Set termios after waiting for output to drain */
+    case TIOCSETAF: { /* Like TIOCSETAW, but also discard all pending input */
+      struct termios *t = (struct termios *)data;
+
+      if (cmd == TIOCSETAW || cmd == TIOCSETAF) {
+        /* TODO Drain all output. */
+        if (cmd == TIOCSETAF) {
+          /* Discard all pending input. */
+          tty_discard_input(tty);
+        }
+      }
+
+#define SET_MASKED_BITS(lhs, rhs, mask)                                        \
+  (lhs) = ((lhs) & ~(mask)) | ((rhs) & (mask))
+      SET_MASKED_BITS(tty->t_iflag, t->c_iflag, TTYSUP_IFLAG_CHANGE);
+      SET_MASKED_BITS(tty->t_oflag, t->c_oflag, TTYSUP_OFLAG_CHANGE);
+      SET_MASKED_BITS(tty->t_lflag, t->c_lflag, TTYSUP_LFLAG_CHANGE);
+      /* Changing `t_cflag` is completely unsupported right now. */
+#undef SET_MASKED_BITS
+      memcpy(tty->t_cc, t->c_cc, sizeof(tty->t_cc));
+
+      break;
+    }
+    case 0:
+      ret = EPASSTHROUGH;
+      break;
+    default: {
+      char buf[32];
+      IOCSNPRINTF(buf, sizeof(buf), cmd);
+      klog("Unsupported tty ioctl: %s", buf);
+      unsigned len = IOCPARM_LEN(cmd);
+      memset(data, 0, len);
+      break;
+    }
+  }
+  mtx_unlock(&tty->t_lock);
+
+  return ret;
+}
+
+static int tty_getattr(vnode_t *v, vattr_t *va) {
+  memset(va, 0, sizeof(vattr_t));
+  va->va_mode = S_IFCHR;
+  va->va_nlink = 1;
+  va->va_ino = 0;
+  va->va_size = 0;
+  return 0;
+}
+
+vnodeops_t tty_vnodeops = {.v_open = vnode_open_generic,
+                           .v_write = tty_write,
+                           .v_read = tty_read,
+                           .v_close = tty_close,
+                           .v_ioctl = tty_ioctl,
+                           .v_getattr = tty_getattr};

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -283,6 +283,9 @@ static void tty_output(tty_t *tty, uint8_t c) {
         col++;
         break;
       case TAB:
+        /* XXX We assume that the terminal device has tabs of width 8.
+         * This can be remediated by implementing the OXTABS option
+         * which expands tabs into spaces. */
         col = roundup2(col + 1, 8);
         break;
     }

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -3,9 +3,7 @@
 #include <sys/libkern.h>
 #include <sys/termios.h>
 #include <sys/tty.h>
-#define TTYDEFCHARS
 #include <sys/ttydefaults.h>
-#undef TTYDEFCHARS
 #include <sys/malloc.h>
 #include <sys/kmem_flags.h>
 #include <sys/mutex.h>
@@ -117,6 +115,21 @@ static void tty_output(tty_t *tty, uint8_t c);
 
 /* Initialize termios with sane defaults. */
 static void tty_init_termios(struct termios *tio) {
+
+  /* Default control characters from FreeBSD */
+  static const cc_t ttydefchars[NCCS] = {
+    [VEOF] = CEOF,         [VEOL] = CEOL,
+    [VEOL2] = CEOL,        [VERASE] = CERASE,
+    [VWERASE] = CWERASE,   [VKILL] = CKILL,
+    [VREPRINT] = CREPRINT, [7] = _POSIX_VDISABLE, /* spare */
+    [VINTR] = CINTR,       [VQUIT] = CQUIT,
+    [VSUSP] = CSUSP,       [VDSUSP] = CDSUSP,
+    [VSTART] = CSTART,     [VSTOP] = CSTOP,
+    [VLNEXT] = CLNEXT,     [VDISCARD] = CDISCARD,
+    [VMIN] = CMIN,         [VTIME] = CTIME,
+    [VSTATUS] = CSTATUS,   [19] = _POSIX_VDISABLE, /* spare */
+  };
+
   tio->c_cflag = TTYDEF_CFLAG;
   tio->c_iflag = TTYDEF_IFLAG;
   tio->c_lflag = TTYDEF_LFLAG;

--- a/sys/mips/timer.c
+++ b/sys/mips/timer.c
@@ -61,13 +61,19 @@ static uint64_t read_count(mips_timer_state_t *state) {
   return state->count.val;
 }
 
-static void set_next_tick(mips_timer_state_t *state) {
+static int set_next_tick(mips_timer_state_t *state) {
   SCOPED_INTR_DISABLED();
+  int ticks = 0;
+
   /* calculate next value of compare register based on timer period */
-  state->compare.val += state->period_cntr;
-  (void)read_count(state);
-  assert(state->compare.val > state->count.val);
-  mips32_set_c0(C0_COMPARE, state->compare.lo);
+  do {
+    state->compare.val += state->period_cntr;
+    mips32_set_c0(C0_COMPARE, state->compare.lo);
+    (void)read_count(state);
+    ticks++;
+  } while (state->compare.val <= state->count.val);
+
+  return ticks;
 }
 
 static mips_timer_state_t *state_of(timer_t *tm) {
@@ -76,6 +82,7 @@ static mips_timer_state_t *state_of(timer_t *tm) {
 
 static intr_filter_t mips_timer_intr(void *data) {
   mips_timer_state_t *state = state_of(data);
+  /* TODO(cahir): can we tell scheduler that clock ticked more that once? */
   set_next_tick(state);
   tm_trigger(data);
   return IF_FILTERED;


### PR DESCRIPTION
- Add default control characters to `ttydefaults.h`
- Add `ringbuf_reset()` function
- Add launcher option to run `socat` in raw mode
- Replace `/dev/uart` with a terminal device
- Remove unneeded NS16550 UART code
- Implement basic TTY device with an asynchronous serial device driver interface