### PR TITLE
Improve interrupt handling framework

### DIFF
--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -51,7 +51,7 @@ typedef struct intr_handler intr_handler_t;
 typedef enum {
   IF_STRAY = 0,    /* this device did not trigger the interrupt */
   IF_FILTERED = 1, /* the interrupt has been handled and can be EOId */
-  IF_DELEGATE = 2, /* the handler should be run in private thread */
+  IF_DELEGATE = 2  /* the handler should be run in private thread */
 } intr_filter_t;
 
 /*
@@ -70,7 +70,7 @@ struct intr_handler {
   ih_service_t *ih_service; /* interrupt service routine (run in thread ctx) */
   intr_event_t *ih_event;   /* event we are connected to */
   void *ih_argument;        /* argument to pass to filter/service routines */
-  char *ih_name;            /* name of the handler */
+  const char *ih_name;      /* name of the handler */
   prio_t ih_prio;           /* handler's priority (sort key for ie_handlers) */
 };
 

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -106,6 +106,9 @@ void intr_event_run_handlers(intr_event_t *ie) {
       assert(ih->ih_service);
       ithread = true;
 
+      if (ie->ie_disable)
+        ie->ie_disable(ie);
+
       TAILQ_REMOVE(&ie->ie_handlers, ih, ih_link);
       ie->ie_count--;
       /* Note that this will order our handlers nicely,
@@ -114,12 +117,9 @@ void intr_event_run_handlers(intr_event_t *ie) {
     }
   }
 
-  if (ithread) {
-    if (ie->ie_disable)
-      ie->ie_disable(ie);
-
+  if (ithread)
     sleepq_signal(&delegated);
-  } else if (!handled)
+  else if (!handled)
     klog("Spurious %s interrupt!", ie->ie_name);
 }
 


### PR DESCRIPTION
Improvements:
- fix of the intr_event_run_handlers():
     - don't lose interrupts on the same interrupt event (I know that it doesn't affect us for now), 
     - handle undefined filter functions (since filter isn't mandatory),
     - properly count handlers on an interrupt event