### PR TITLE
Get rid of the TDF_SLEEPY flag.

### DIFF
--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -63,7 +63,6 @@ typedef enum {
 #define TDF_NEEDSWITCH 0x00000002 /* must switch on next opportunity */
 #define TDF_NEEDSIGCHK 0x00000004 /* signals were posted for delivery */
 #define TDF_BORROWING 0x00000010  /* priority propagation */
-#define TDF_SLEEPY 0x00000020     /* thread is about to go to sleep */
 /* TDF_SLP* flags are used internally by sleep queue */
 #define TDF_SLPINTR 0x00000040  /* sleep is interruptible */
 #define TDF_SLPTIMED 0x00000080 /* sleep with timeout */


### PR DESCRIPTION
Now we hold a spinlock all the way from entering a thread into the sleepq until `sched_switch()`, so we can't receive a signal
or be woken up in the middle.
This also eliminates the need for 2 signal checks and fixes a bug where we didn't leave the sleepq if the second signal check finds that we should interrupt the sleep:  https://github.com/cahirwpz/mimiker/blob/5073f58cd2cf623713f7f0e9614bb66e7208b563/sys/kern/sleepq.c#L171-L174