### PR TITLE
Clarify behavior of sig_post().

### DIFF
--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -106,7 +106,12 @@ int sig_check(thread_t *td);
  *
  * If the default action for a signal is to terminate the process and
  * corresponding signal handler is not set, the process calls `sig_exit`.
+ * If the signal's action is to stop the process, this procedure stops
+ * the calling thread.
  *
+ * \note It's ok to call this procedure multiple times before returning
+ * to userspace. The handlers will be called in reverse order of calls
+ * to this procedure.
  * \note Must be called with current process's p_mtx acquired!
  * \sa sig_exit
  */

--- a/sys/kern/exception.c
+++ b/sys/kern/exception.c
@@ -25,6 +25,8 @@ void on_user_exc_leave(void) {
   if (td->td_flags & TDF_NEEDSIGCHK) {
     WITH_PROC_LOCK(p) {
       int sig;
+      /* Calling sig_post() multiple times before returning to userspace
+       * will not make us lose signals, see comment on sig_post() in signal.h */
       while ((sig = sig_check(td)))
         sig_post(sig);
     }


### PR DESCRIPTION
It wasn't clear to me that calling `sig_post()` multiple times won't make us lose pending signals. It turns out it's safe, but it's far from obvious. I have added some comments to help future readers of the code.