### PR TITLE
Discard pending signals when ignoring them via sigaction().

### DIFF
--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -199,6 +199,11 @@ void thread_join(thread_t *td);
  * verify test success. */
 void thread_reap(void);
 
+/*! \brief Continue stopped thread.
+ *
+ * Must be called with acquired td_lock. */
+void thread_continue(thread_t *td);
+
 /* Please use following functions to read state of a thread! */
 static inline bool td_is_ready(thread_t *td) {
   return td->td_state == TDS_READY;

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -202,3 +202,12 @@ thread_t *thread_find(tid_t id) {
   }
   return NULL;
 }
+
+void thread_continue(thread_t *td) {
+  assert(spin_owned(td->td_lock));
+
+  if (td->td_flags & TDF_STOPPING)
+    td->td_flags &= ~TDF_STOPPING;
+  else if (td_is_stopped(td))
+    sched_wakeup(td, 0);
+}


### PR DESCRIPTION
This gives us the nice property that if `sig_pending()` returns a signal, then that signal isn't ignored. I will be using this property in the future.