### PR TITLE
Sequential bar numbers.

### DIFF
--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -91,6 +91,7 @@ typedef struct pci_device {
   uint8_t class_code;
   uint8_t pin, irq;
 
+  uint8_t nbars;
   pci_bar_t bar[PCI_BAR_MAX];
 } pci_device_t;
 

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -173,7 +173,7 @@ static int stdvga_attach(device_t *dev) {
 
   stdvga->mem =
     bus_alloc_resource_any(dev, RT_MEMORY, 0, RF_ACTIVE | RF_PREFETCHABLE);
-  stdvga->io = bus_alloc_resource_any(dev, RT_MEMORY, 2, RF_ACTIVE);
+  stdvga->io = bus_alloc_resource_any(dev, RT_MEMORY, 1, RF_ACTIVE);
 
   assert(stdvga->mem != NULL);
   assert(stdvga->io != NULL);

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -57,6 +57,9 @@ void pci_bus_enumerate(device_t *pcib) {
   for (; pcia.device < PCI_DEV_MAX_NUM; pcia.device++) {
     pcia.function = 0;
 
+    /* Note that if we don't check the MF bit of the device
+     * and scan all functions, then some single-function devices
+     * will report details for "fucntion 0" for every function. */
     int max_fun = pci_device_nfunctions(&pcid);
 
     for (; pcia.function < max_fun; pcia.function++) {
@@ -100,8 +103,10 @@ void pci_bus_enumerate(device_t *pcib) {
         }
 
         size = -size;
-        pcid->bar[i] = (pci_bar_t){
-          .owner = dev, .type = type, .flags = flags, .size = size, .rid = i};
+	uint8_t id = pcid->nbars;
+        pcid->bar[id] = (pci_bar_t){
+          .owner = dev, .type = type, .flags = flags, .size = size, .rid = id};
+        pcid->nbars++;
       }
     }
   }

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -103,7 +103,7 @@ void pci_bus_enumerate(device_t *pcib) {
         }
 
         size = -size;
-	uint8_t id = pcid->nbars;
+        uint8_t id = pcid->nbars;
         pcid->bar[id] = (pci_bar_t){
           .owner = dev, .type = type, .flags = flags, .size = size, .rid = id};
         pcid->nbars++;


### PR DESCRIPTION
Make device bars appear sequentially in the PCI device structure
so that a driver does not have to check which bar is vaild and which is not.