### PR TITLE
Use tap device as a qemu's backend network interface

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -50,7 +50,8 @@ CONFIG = {
                 'binary': 'qemu-mimiker-mipsel',
                 'options': [
                     '-device', 'VGA',
-                    '-device', 'rtl8139',
+                    '-net nic,model=rtl8139',
+                    '-net tap,ifname=tap0,script=no,downscript=no',
                     '-machine', 'malta',
                     '-cpu', '24Kf'],
                 'uarts': [


### PR DESCRIPTION
It seems that the easiest way to use tap device by qemu is:
- create tap device by our host startup scripts:
```
sudo ip tuntap add dev tap0 mode tap group netdev one_queue vnet_hdr
sudo ip link set tap0 up
```
IMO, this is minimal invasive approach - but perhaps it will be problem if there are more than one qemu running.


Second approach is to create a config file where we can select which tap device we want to use.
For instance, tap0-10 devices would be create by startup scripts.

The third approach is to install `tunctl` on our host PC and then:
```sudo setcap cap_net_admin+ep `which tunctl` ```
But here we still need to discuss how to set some parameters (e.q `ip link set tap0 up`)
