### PR TITLE
TTY: Introduce concepts of controlling terminal and foreground process group

### DIFF
--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -2,8 +2,9 @@
 #define _SYS_SIGNAL_H_
 
 #include <sys/sigtypes.h>
-#include <machine/signal.h>
 #include <sys/siginfo.h>
+#include <machine/signal.h>
+#include <stdbool.h>
 
 #define SIGHUP 1   /* hangup */
 #define SIGINT 2   /* interrupt */
@@ -142,6 +143,9 @@ int sig_send(signo_t sig, sigset_t *mask, sigaction_t *sa, ksiginfo_t *ksi);
  *
  * \note This is machine dependent code! */
 int sig_return(void);
+
+/*! \brief Returns whether the signal's current action is to stop a process. */
+bool sig_should_stop(sigaction_t *sigactions, signo_t sig);
 
 /* System calls implementation. */
 int do_sigaction(signo_t sig, const sigaction_t *act, sigaction_t *oldact);

--- a/include/sys/tty.h
+++ b/include/sys/tty.h
@@ -133,6 +133,8 @@ void tty_getc_done(tty_t *tty);
  * Must be called with `tty->t_lock` and `p->p_lock` held.
  */
 static inline bool tty_is_ctty(tty_t *tty, proc_t *p) {
+  assert(mtx_owned(&tty->t_lock));
+  assert(mtx_owned(&p->p_lock));
   return (tty->t_session == p->p_pgrp->pg_session);
 }
 

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -350,6 +350,8 @@ int session_enter(proc_t *p) {
 
 /* Called only when process finishes. */
 static void session_leave(proc_t *p) {
+  assert(mtx_owned(all_proc_mtx));
+
   if (!proc_is_session_leader(p))
     return;
 

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -265,7 +265,7 @@ pgrp_t *pgrp_lookup(pgid_t pgid) {
 static void pgrp_remove(pgrp_t *pgrp) {
   assert(mtx_owned(all_proc_mtx));
 
-  /* Check if removed group was a foreground group of some session. */
+  /* Check if removed group was a foreground group of some terminal. */
   tty_t *tty = pgrp->pg_session->s_tty;
   if (tty) {
     WITH_MTX_LOCK (&tty->t_lock) {
@@ -373,7 +373,6 @@ static void session_leave(proc_t *p) {
     }
     /* TODO revoke access to controlling terminal */
   }
-
 }
 
 int pgrp_enter(proc_t *p, pid_t target, pgid_t pgid) {

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -354,6 +354,8 @@ static void session_leave(proc_t *p) {
     return;
 
   session_t *s = p->p_pgrp->pg_session;
+  s->s_leader = NULL;
+
   tty_t *tty = s->s_tty;
   if (tty == NULL)
     return;
@@ -370,7 +372,6 @@ static void session_leave(proc_t *p) {
     /* TODO revoke access to controlling terminal */
   }
 
-  s->s_leader = NULL;
 }
 
 int pgrp_enter(proc_t *p, pid_t target, pgid_t pgid) {

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -265,6 +265,7 @@ pgrp_t *pgrp_lookup(pgid_t pgid) {
 static void pgrp_remove(pgrp_t *pgrp) {
   assert(mtx_owned(all_proc_mtx));
 
+  /* Check if removed group was a foreground group of some session. */
   tty_t *tty = pgrp->pg_session->s_tty;
   if (tty) {
     WITH_MTX_LOCK (&tty->t_lock) {

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -737,7 +737,7 @@ int do_waitpid(pid_t pid, int *status, int options, pid_t *cldpidp) {
           if (child->p_flags & PF_STATE_CHANGED) {
             if ((options & WUNTRACED) && (child->p_state == PS_STOPPED)) {
               child->p_flags &= ~PF_STATE_CHANGED;
-              *status = MAKE_STATUS_SIG_STOP(SIGSTOP);
+              *status = MAKE_STATUS_SIG_STOP(child->p_stopsig);
               return 0;
             }
 

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -518,8 +518,7 @@ static int tty_read(file_t *f, uio_t *uio) {
   WITH_MTX_LOCK (&tty->t_lock) {
 
     while (true) {
-      error = tty_wait_background(tty, SIGTTIN);
-      if (error)
+      if ((error = tty_wait_background(tty, SIGTTIN)))
         return error;
 
       if (tty->t_inq.count > 0)
@@ -531,14 +530,14 @@ static int tty_read(file_t *f, uio_t *uio) {
        * and check again. */
     }
 
+
     if (tty->t_lflag & ICANON) {
       /* In canonical mode, read as many characters as possible, but no more
        * than one line. */
       while (ringbuf_getb(&tty->t_inq, &c)) {
         if (CCEQ(tty->t_cc[VEOF], c))
           break;
-        error = uiomove(&c, 1, uio);
-        if (error)
+        if ((error = uiomove(&c, 1, uio)))
           break;
         if (uio->uio_resid == 0)
           break;
@@ -665,8 +664,7 @@ static int tty_do_write(tty_t *tty, uio_t *uio) {
   int error = 0;
 
   while (uio->uio_resid > 0) {
-    error = uiomove(&c, 1, uio);
-    if (error)
+    if ((error = uiomove(&c, 1, uio)))
       break;
     tty_output_sleep(tty, c);
     tty->t_rocount = 0;
@@ -685,8 +683,7 @@ static int tty_write(file_t *f, uio_t *uio) {
   WITH_MTX_LOCK (&tty->t_lock) {
     if (tty->t_lflag & TOSTOP) {
       /* Wait until we're the foreground process group. */
-      error = tty_wait_background(tty, SIGTTOU);
-      if (error)
+      if ((error = tty_wait_background(tty, SIGTTOU)))
         return error;
     }
 

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -742,95 +742,102 @@ static void tty_reinput(tty_t *tty) {
   }
 }
 
-static int tty_ioctl(file_t *f, u_long cmd, void *data) {
-  tty_t *tty = f->f_data;
-
+static int tty_get_termios(tty_t *tty, struct termios *t) {
   SCOPED_MTX_LOCK(&tty->t_lock);
-  switch (cmd) {
-    case TIOCGETA: { /* Get termios */
-      struct termios *t = (struct termios *)data;
-      memcpy(t, &tty->t_termios, sizeof(struct termios));
-      break;
-    }
-    case TIOCSETA:    /* Set termios immediately */
-    case TIOCSETAW:   /* Set termios after waiting for output to drain */
-    case TIOCSETAF: { /* Like TIOCSETAW, but also discard all pending input */
-      struct termios *t = (struct termios *)data;
-      bool reinput = false; /* Process pending input again. */
+  memcpy(t, &tty->t_termios, sizeof(struct termios));
+  return 0;
+}
 
-      if (cmd == TIOCSETAW || cmd == TIOCSETAF)
-        tty_drain_out(tty);
+static int tty_set_termios(tty_t *tty, u_long cmd, struct termios *t) {
+  SCOPED_MTX_LOCK(&tty->t_lock);
 
-      if (cmd == TIOCSETAF) {
-        /* Discard all pending input. */
-        tty_discard_input(tty);
+  if (cmd == TIOCSETAW || cmd == TIOCSETAF)
+    tty_drain_out(tty);
+  if (cmd == TIOCSETAF)
+    tty_discard_input(tty);
+
+  bool reinput = false; /* Process pending input again. */
+
+  if (cmd != TIOCSETAF) {
+    /* If we didn't discard the input and we're changing from
+     * raw mode to canonical mode or vice versa, we need to handle
+     * characters that the user has already typed appropriately. */
+    if ((t->c_lflag & ICANON) != (tty->t_lflag & ICANON)) {
+      if (t->c_lflag & ICANON) {
+        /* Switching from raw to canonical mode.
+         * Process all pending input again, this time in canonical mode.
+         * Defer until we have made the changes to termios. */
+        reinput = true;
       } else {
-        /* If we didn't discard the input and we're changing from
-         * raw mode to canonical mode or vice versa, we need to handle
-         * characters that the user has already typed appropriately. */
-        if ((t->c_lflag & ICANON) != (tty->t_lflag & ICANON)) {
-          if (t->c_lflag & ICANON) {
-            /* Switching from raw to canonical mode.
-             * Process all pending input again, this time in canonical mode.
-             * Defer until we have made the changes to termios. */
-            reinput = true;
-          } else {
-            /* Switching from canonical to raw mode.
-             * Transfer characters from the unfinished line
-             * to the input queue and wake up readers. */
-            tty_line_finish(tty);
-            tty_wakeup(tty);
-          }
-        }
+        /* Switching from canonical to raw mode.
+         * Transfer characters from the unfinished line
+         * to the input queue and wake up readers. */
+        tty_line_finish(tty);
+        tty_wakeup(tty);
       }
+    }
+  }
 
 #define SET_MASKED_BITS(lhs, rhs, mask)                                        \
   (lhs) = ((lhs) & ~(mask)) | ((rhs) & (mask))
-      SET_MASKED_BITS(tty->t_iflag, t->c_iflag, TTYSUP_IFLAG_CHANGE);
-      SET_MASKED_BITS(tty->t_oflag, t->c_oflag, TTYSUP_OFLAG_CHANGE);
-      SET_MASKED_BITS(tty->t_lflag, t->c_lflag, TTYSUP_LFLAG_CHANGE);
-      /* Changing `t_cflag` is completely unsupported right now. */
+  SET_MASKED_BITS(tty->t_iflag, t->c_iflag, TTYSUP_IFLAG_CHANGE);
+  SET_MASKED_BITS(tty->t_oflag, t->c_oflag, TTYSUP_OFLAG_CHANGE);
+  SET_MASKED_BITS(tty->t_lflag, t->c_lflag, TTYSUP_LFLAG_CHANGE);
+  /* Changing `t_cflag` is completely unsupported right now. */
 #undef SET_MASKED_BITS
-      memcpy(tty->t_cc, t->c_cc, sizeof(tty->t_cc));
+  memcpy(tty->t_cc, t->c_cc, sizeof(tty->t_cc));
 
-      if (reinput)
-        tty_reinput(tty);
-      break;
-    }
-    case TIOCGPGRP: { /* Get foreground process group */
-      proc_t *p = proc_self();
+  if (reinput)
+    tty_reinput(tty);
+  return 0;
+}
+
+static int tty_get_fg_pgrp(tty_t *tty, int *pgid_p) {
+  SCOPED_MTX_LOCK(&tty->t_lock);
+  proc_t *p = proc_self();
+  if (tty->t_session != p->p_pgrp->pg_session)
+    return ENOTTY;
+  if (tty->t_pgrp)
+    *pgid_p = tty->t_pgrp->pg_id;
+  else
+    /* Return a value greater than 1 that's not equal to any PGID. */
+    *pgid_p = INT_MAX;
+  return 0;
+}
+
+static int tty_set_fg_pgrp(tty_t *tty, pgid_t pgid) {
+  WITH_MTX_LOCK (all_proc_mtx) {
+    proc_t *p = proc_self();
+    pgrp_t *pg = pgrp_lookup(pgid);
+    /* The target process group must be in the same session
+     * as the calling process. */
+    if (pg == NULL || pg->pg_session != p->p_pgrp->pg_session)
+      return EPERM;
+    WITH_MTX_LOCK (&tty->t_lock) {
+      /* Calling process must be controlled by the terminal. */
       if (tty->t_session != p->p_pgrp->pg_session)
         return ENOTTY;
-      if (tty->t_pgrp)
-        *(int *)data = tty->t_pgrp->pg_id;
-      else
-        /* Return a value greater than 1 that's not equal to any PGID. */
-        *(int *)data = INT_MAX;
-      break;
-    }
-    case TIOCSPGRP: { /* Set foreground process group */
-      /* XXX */
-      mtx_unlock(&tty->t_lock);
-      mtx_lock(all_proc_mtx);
-      mtx_lock(&tty->t_lock);
-      proc_t *p = proc_self();
-      pgrp_t *pg = pgrp_lookup(*(pgid_t *)data);
-      /* The target process group must be in the same session
-       * as the calling process. */
-      if (pg == NULL || pg->pg_session != p->p_pgrp->pg_session) {
-        mtx_unlock(all_proc_mtx);
-        return EPERM;
-      }
-      /* Calling process must be controlled by the terminal. */
-      if (tty->t_session != p->p_pgrp->pg_session) {
-        mtx_unlock(all_proc_mtx);
-        return ENOTTY;
-      }
       tty->t_pgrp = pg;
-      mtx_unlock(all_proc_mtx);
       cv_broadcast(&tty->t_background_cv);
-      break;
     }
+  }
+  return 0;
+}
+
+static int tty_ioctl(file_t *f, u_long cmd, void *data) {
+  tty_t *tty = f->f_data;
+
+  switch (cmd) {
+    case TIOCGETA:
+      return tty_get_termios(tty, (struct termios *)data);
+    case TIOCSETA:  /* Set termios immediately */
+    case TIOCSETAW: /* Set termios after waiting for output to drain */
+    case TIOCSETAF: /* Like TIOCSETAW, but also discard all pending input */
+      return tty_set_termios(tty, cmd, (struct termios *)data);
+    case TIOCGPGRP:
+      return tty_get_fg_pgrp(tty, data);
+    case TIOCSPGRP:
+      return tty_set_fg_pgrp(tty, *(pgid_t *)data);
     case 0:
       return EPASSTHROUGH;
     default: {
@@ -839,11 +846,9 @@ static int tty_ioctl(file_t *f, u_long cmd, void *data) {
       klog("Unsupported tty ioctl: %s", buf);
       unsigned len = IOCPARM_LEN(cmd);
       memset(data, 0, len);
-      break;
+      return 0;
     }
   }
-
-  return 0;
 }
 
 static int tty_vn_getattr(vnode_t *v, vattr_t *va) {


### PR DESCRIPTION
- Add concepts of controlling tty and foreground pgrp
- Implement ioctls for getting and setting foreground pgrp
- Implement background wait in `tty_{read,write}()`
- Add `SIGTTIN` and `SIGTTOU` signals