### PR TITLE
Restore link register in copy.S.

### DIFF
--- a/sys/aarch64/copy.S
+++ b/sys/aarch64/copy.S
@@ -5,9 +5,8 @@
 #include "assym.h"
 
 /*
- * WARNING:
- * copyin, copyout and copyinstr make unsafe assumption that bcopy and copystr
- * not modify stack.
+ * WARNING: copyin, copyout and copyinstr make unsafe assumption that bcopy and
+ * copystr don't modify stack, stack pointer and callee saved registers.
  */
 
 .macro  set_onfault tmp td func
@@ -129,12 +128,12 @@ END(copyout)
 
 SENTRY(copyerr)
         /* 
-         * Here we need to restore link register from original copyin, copyout
-         * or copyinstr.
+         * Here we restore link register saved by copyin, copyout or copyinstr.
          */
+        mov     x0, #EFAULT
+
         ldr     lr, [sp]
         add     sp, sp, #16
-        mov     x0, #EFAULT
         ret
 END(copyerr)
 

--- a/sys/aarch64/copy.S
+++ b/sys/aarch64/copy.S
@@ -4,6 +4,12 @@
 
 #include "assym.h"
 
+/*
+ * WARNING:
+ * copyin, copyout and copyinstr make unsafe assumption that bcopy and copystr
+ * not modify stack.
+ */
+
 .macro  set_onfault tmp td func
         # load current thread
         mrs     \td, tpidr_el1
@@ -44,7 +50,11 @@ ENTRY(copyinstr)
         b.hi    copyerr
 
         set_onfault x4, x5, copyerr
+        sub     sp, sp, #8
+        str     lr, [sp]
         bl      copystr
+        ldr     lr, [sp]
+        add     sp, sp, #8
         clr_onfault x4
         ret
 END(copyinstr)
@@ -69,7 +79,11 @@ ENTRY(copyin)
         b.hi    copyerr
 
         set_onfault x3, x4, copyerr
+        sub     sp, sp, #8
+        str     lr, [sp]
         bl      bcopy
+        ldr     lr, [sp]
+        add     sp, sp, #8
         clr_onfault x3
 
 1:      mov     x0, xzr
@@ -96,7 +110,11 @@ ENTRY(copyout)
         b.hi    copyerr
 
         set_onfault x3, x4, copyerr
+        sub     sp, sp, #8
+        str     lr, [sp]
         bl      bcopy
+        ldr     lr, [sp]
+        add     sp, sp, #8
         clr_onfault x3
 
 1:      mov     x0, xzr
@@ -104,7 +122,11 @@ ENTRY(copyout)
 END(copyout)
 
 SENTRY(copyerr)
-        # since we return from bcopy/copystr context we need to pop retaddr
+        /* 
+         * Here we need to restore link register from original copyin, copyout
+         * or copyinstr.
+         */
+        ldr     lr, [sp]
         add     sp, sp, #8
         mov     x0, #EFAULT
         ret

--- a/sys/aarch64/copy.S
+++ b/sys/aarch64/copy.S
@@ -50,11 +50,11 @@ ENTRY(copyinstr)
         b.hi    copyerr
 
         set_onfault x4, x5, copyerr
-        sub     sp, sp, #8
+        sub     sp, sp, #16
         str     lr, [sp]
         bl      copystr
         ldr     lr, [sp]
-        add     sp, sp, #8
+        add     sp, sp, #16
         clr_onfault x4
         ret
 END(copyinstr)
@@ -79,11 +79,11 @@ ENTRY(copyin)
         b.hi    copyerr
 
         set_onfault x3, x4, copyerr
-        sub     sp, sp, #8
+        sub     sp, sp, #16
         str     lr, [sp]
         bl      bcopy
         ldr     lr, [sp]
-        add     sp, sp, #8
+        add     sp, sp, #16
         clr_onfault x3
 
 1:      mov     x0, xzr
@@ -110,11 +110,11 @@ ENTRY(copyout)
         b.hi    copyerr
 
         set_onfault x3, x4, copyerr
-        sub     sp, sp, #8
+        sub     sp, sp, #16
         str     lr, [sp]
         bl      bcopy
         ldr     lr, [sp]
-        add     sp, sp, #8
+        add     sp, sp, #16
         clr_onfault x3
 
 1:      mov     x0, xzr
@@ -127,7 +127,7 @@ SENTRY(copyerr)
          * or copyinstr.
          */
         ldr     lr, [sp]
-        add     sp, sp, #8
+        add     sp, sp, #16
         mov     x0, #EFAULT
         ret
 END(copyerr)

--- a/sys/aarch64/copy.S
+++ b/sys/aarch64/copy.S
@@ -34,6 +34,9 @@
  * the kernel address space.
  */
 ENTRY(copyinstr)
+        sub     sp, sp, #16
+        str     lr, [sp]
+
         # len > 0
         cbnz    x2, 1f
         mov     x0, xzr
@@ -50,12 +53,11 @@ ENTRY(copyinstr)
         b.hi    copyerr
 
         set_onfault x4, x5, copyerr
-        sub     sp, sp, #16
-        str     lr, [sp]
         bl      copystr
+        clr_onfault x4
+
         ldr     lr, [sp]
         add     sp, sp, #16
-        clr_onfault x4
         ret
 END(copyinstr)
 
@@ -65,6 +67,9 @@ END(copyinstr)
  * Copy specified amount of data from user space into the kernel.
  */
 ENTRY(copyin)
+        sub     sp, sp, #16
+        str     lr, [sp]
+
         # len > 0
         cbz     x2, 1f
 
@@ -79,14 +84,13 @@ ENTRY(copyin)
         b.hi    copyerr
 
         set_onfault x3, x4, copyerr
-        sub     sp, sp, #16
-        str     lr, [sp]
         bl      bcopy
-        ldr     lr, [sp]
-        add     sp, sp, #16
         clr_onfault x3
 
 1:      mov     x0, xzr
+
+        ldr     lr, [sp]
+        add     sp, sp, #16
         ret
 END(copyin)
 
@@ -96,6 +100,9 @@ END(copyin)
  * Copy specified amount of data from kernel to the user space.
  */
 ENTRY(copyout)
+        sub     sp, sp, #16
+        str     lr, [sp]
+
         # len > 0
         cbz     x2, 1f
 
@@ -110,14 +117,13 @@ ENTRY(copyout)
         b.hi    copyerr
 
         set_onfault x3, x4, copyerr
-        sub     sp, sp, #16
-        str     lr, [sp]
         bl      bcopy
-        ldr     lr, [sp]
-        add     sp, sp, #16
         clr_onfault x3
 
 1:      mov     x0, xzr
+
+        ldr     lr, [sp]
+        add     sp, sp, #16
         ret
 END(copyout)
 


### PR DESCRIPTION
Restore link register in `copyin`, `copyout`, `copyinstr`, `copyerr`.