### PR TITLE
Size independent arguments for syscall

### DIFF
--- a/include/sys/syscallargs.h
+++ b/include/sys/syscallargs.h
@@ -8,8 +8,8 @@
 #include <sys/time.h>
 #include <sys/ucontext.h>
 #include <sys/sigtypes.h>
-#define SCARG(p, x) ((p)->x.le.arg)
-#define SYSCALLARG(x)     union {         register_t _pad;         struct {             x arg;         } le;     }
+#define SCARG(p, x) ((p)->x.arg)
+#define SYSCALLARG(x) union { register_t _pad; x arg; }
 
 typedef struct {
   SYSCALLARG(int) number;

--- a/include/sys/syscallargs.h
+++ b/include/sys/syscallargs.h
@@ -8,345 +8,347 @@
 #include <sys/time.h>
 #include <sys/ucontext.h>
 #include <sys/sigtypes.h>
+#define SCARG(p, x) ((p)->x.le.arg)
+#define SYSCALLARG(x)     union {         register_t _pad;         struct {             x arg;         } le;     }
 
 typedef struct {
-  int number;
+  SYSCALLARG(int) number;
 } syscall_args_t;
 
 typedef struct {
-  int rval;
+  SYSCALLARG(int) rval;
 } exit_args_t;
 
 typedef struct {
-  int fd;
-  void * buf;
-  size_t nbyte;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(void *) buf;
+  SYSCALLARG(size_t) nbyte;
 } read_args_t;
 
 typedef struct {
-  int fd;
-  const void * buf;
-  size_t nbyte;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const void *) buf;
+  SYSCALLARG(size_t) nbyte;
 } write_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  int flags;
-  mode_t mode;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(int) flags;
+  SYSCALLARG(mode_t) mode;
 } openat_args_t;
 
 typedef struct {
-  int fd;
+  SYSCALLARG(int) fd;
 } close_args_t;
 
 typedef struct {
-  int fd;
-  off_t offset;
-  int whence;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(off_t) offset;
+  SYSCALLARG(int) whence;
 } lseek_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  int flag;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(int) flag;
 } unlinkat_args_t;
 
 typedef struct {
-  pid_t pid;
-  int sig;
+  SYSCALLARG(pid_t) pid;
+  SYSCALLARG(int) sig;
 } kill_args_t;
 
 typedef struct {
-  int fd;
-  struct stat * sb;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(struct stat *) sb;
 } fstat_args_t;
 
 typedef struct {
-  intptr_t increment;
+  SYSCALLARG(intptr_t) increment;
 } sbrk_args_t;
 
 typedef struct {
-  void * addr;
-  size_t len;
-  int prot;
-  int flags;
-  int fd;
-  off_t pos;
+  SYSCALLARG(void *) addr;
+  SYSCALLARG(size_t) len;
+  SYSCALLARG(int) prot;
+  SYSCALLARG(int) flags;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(off_t) pos;
 } mmap_args_t;
 
 typedef struct {
-  const char * type;
-  const char * path;
+  SYSCALLARG(const char *) type;
+  SYSCALLARG(const char *) path;
 } mount_args_t;
 
 typedef struct {
-  int fd;
-  void * buf;
-  size_t len;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(void *) buf;
+  SYSCALLARG(size_t) len;
 } getdents_args_t;
 
 typedef struct {
-  int fd;
+  SYSCALLARG(int) fd;
 } dup_args_t;
 
 typedef struct {
-  int from;
-  int to;
+  SYSCALLARG(int) from;
+  SYSCALLARG(int) to;
 } dup2_args_t;
 
 typedef struct {
-  int signum;
-  const struct sigaction * nsa;
-  struct sigaction * osa;
+  SYSCALLARG(int) signum;
+  SYSCALLARG(const struct sigaction *) nsa;
+  SYSCALLARG(struct sigaction *) osa;
 } sigaction_args_t;
 
 typedef struct {
-  struct sigcontext * sigctx_p;
+  SYSCALLARG(struct sigcontext *) sigctx_p;
 } sigreturn_args_t;
 
 typedef struct {
-  pid_t pid;
-  int * status;
-  int options;
-  struct rusage * rusage;
+  SYSCALLARG(pid_t) pid;
+  SYSCALLARG(int *) status;
+  SYSCALLARG(int) options;
+  SYSCALLARG(struct rusage *) rusage;
 } wait4_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  mode_t mode;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(mode_t) mode;
 } mkdirat_args_t;
 
 typedef struct {
-  const char * target;
-  int newdirfd;
-  const char * linkpath;
+  SYSCALLARG(const char *) target;
+  SYSCALLARG(int) newdirfd;
+  SYSCALLARG(const char *) linkpath;
 } symlinkat_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  int mode;
-  int flags;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(int) mode;
+  SYSCALLARG(int) flags;
 } faccessat_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  struct stat * sb;
-  int flag;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(struct stat *) sb;
+  SYSCALLARG(int) flag;
 } fstatat_args_t;
 
 typedef struct {
-  int * fdp;
-  int flags;
+  SYSCALLARG(int *) fdp;
+  SYSCALLARG(int) flags;
 } pipe2_args_t;
 
 typedef struct {
-  clockid_t clock_id;
-  struct timespec * tsp;
+  SYSCALLARG(clockid_t) clock_id;
+  SYSCALLARG(struct timespec *) tsp;
 } clock_gettime_args_t;
 
 typedef struct {
-  clockid_t clock_id;
-  int flags;
-  const struct timespec * rqtp;
-  struct timespec * rmtp;
+  SYSCALLARG(clockid_t) clock_id;
+  SYSCALLARG(int) flags;
+  SYSCALLARG(const struct timespec *) rqtp;
+  SYSCALLARG(struct timespec *) rmtp;
 } clock_nanosleep_args_t;
 
 typedef struct {
-  const char * path;
-  char *const * argp;
-  char *const * envp;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(char *const *) argp;
+  SYSCALLARG(char *const *) envp;
 } execve_args_t;
 
 typedef struct {
-  pid_t pid;
-  pid_t pgid;
+  SYSCALLARG(pid_t) pid;
+  SYSCALLARG(pid_t) pgid;
 } setpgid_args_t;
 
 typedef struct {
-  pid_t pid;
+  SYSCALLARG(pid_t) pid;
 } getpgid_args_t;
 
 typedef struct {
-  mode_t newmask;
+  SYSCALLARG(mode_t) newmask;
 } umask_args_t;
 
 typedef struct {
-  void * addr;
-  size_t len;
+  SYSCALLARG(void *) addr;
+  SYSCALLARG(size_t) len;
 } munmap_args_t;
 
 typedef struct {
-  void * addr;
-  size_t len;
-  int prot;
+  SYSCALLARG(void *) addr;
+  SYSCALLARG(size_t) len;
+  SYSCALLARG(int) prot;
 } mprotect_args_t;
 
 typedef struct {
-  const char * path;
+  SYSCALLARG(const char *) path;
 } chdir_args_t;
 
 typedef struct {
-  char * buf;
-  size_t len;
+  SYSCALLARG(char *) buf;
+  SYSCALLARG(size_t) len;
 } getcwd_args_t;
 
 typedef struct {
-  const stack_t * ss;
-  stack_t * old_ss;
+  SYSCALLARG(const stack_t *) ss;
+  SYSCALLARG(stack_t *) old_ss;
 } sigaltstack_args_t;
 
 typedef struct {
-  int how;
-  const sigset_t * set;
-  sigset_t * oset;
+  SYSCALLARG(int) how;
+  SYSCALLARG(const sigset_t *) set;
+  SYSCALLARG(sigset_t *) oset;
 } sigprocmask_args_t;
 
 typedef struct {
-  const ucontext_t * ucp;
+  SYSCALLARG(const ucontext_t *) ucp;
 } setcontext_args_t;
 
 typedef struct {
-  int fd;
-  u_long cmd;
-  void * data;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(u_long) cmd;
+  SYSCALLARG(void *) data;
 } ioctl_args_t;
 
 typedef struct {
-  uid_t * ruid;
-  uid_t * euid;
-  uid_t * suid;
+  SYSCALLARG(uid_t *) ruid;
+  SYSCALLARG(uid_t *) euid;
+  SYSCALLARG(uid_t *) suid;
 } getresuid_args_t;
 
 typedef struct {
-  gid_t * rgid;
-  gid_t * egid;
-  gid_t * sgid;
+  SYSCALLARG(gid_t *) rgid;
+  SYSCALLARG(gid_t *) egid;
+  SYSCALLARG(gid_t *) sgid;
 } getresgid_args_t;
 
 typedef struct {
-  uid_t ruid;
-  uid_t euid;
-  uid_t suid;
+  SYSCALLARG(uid_t) ruid;
+  SYSCALLARG(uid_t) euid;
+  SYSCALLARG(uid_t) suid;
 } setresuid_args_t;
 
 typedef struct {
-  gid_t rgid;
-  gid_t egid;
-  gid_t sgid;
+  SYSCALLARG(gid_t) rgid;
+  SYSCALLARG(gid_t) egid;
+  SYSCALLARG(gid_t) sgid;
 } setresgid_args_t;
 
 typedef struct {
-  int fd;
-  int cmd;
-  void * arg;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(int) cmd;
+  SYSCALLARG(void *) arg;
 } fcntl_args_t;
 
 typedef struct {
-  const char * path;
-  off_t length;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(off_t) length;
 } truncate_args_t;
 
 typedef struct {
-  int fd;
-  off_t length;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(off_t) length;
 } ftruncate_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  char * buf;
-  size_t bufsiz;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(char *) buf;
+  SYSCALLARG(size_t) bufsiz;
 } readlinkat_args_t;
 
 typedef struct {
-  int fd;
+  SYSCALLARG(int) fd;
 } fchdir_args_t;
 
 typedef struct {
-  int fd1;
-  const char * name1;
-  int fd2;
-  const char * name2;
-  int flags;
+  SYSCALLARG(int) fd1;
+  SYSCALLARG(const char *) name1;
+  SYSCALLARG(int) fd2;
+  SYSCALLARG(const char *) name2;
+  SYSCALLARG(int) flags;
 } linkat_args_t;
 
 typedef struct {
-  int fd;
-  mode_t mode;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(mode_t) mode;
 } fchmod_args_t;
 
 typedef struct {
-  int fd;
-  const char * path;
-  mode_t mode;
-  int flag;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(mode_t) mode;
+  SYSCALLARG(int) flag;
 } fchmodat_args_t;
 
 typedef struct {
-  sigset_t * sigmask;
+  SYSCALLARG(sigset_t *) sigmask;
 } sigsuspend_args_t;
 
 typedef struct {
-  const char * path;
-  struct statvfs * buf;
+  SYSCALLARG(const char *) path;
+  SYSCALLARG(struct statvfs *) buf;
 } statvfs_args_t;
 
 typedef struct {
-  int fd;
-  struct statvfs * buf;
+  SYSCALLARG(int) fd;
+  SYSCALLARG(struct statvfs *) buf;
 } fstatvfs_args_t;
 
 typedef struct {
-  int ngroups;
-  gid_t * gidset;
+  SYSCALLARG(int) ngroups;
+  SYSCALLARG(gid_t *) gidset;
 } getgroups_args_t;
 
 typedef struct {
-  int ngroups;
-  const gid_t * gidset;
+  SYSCALLARG(int) ngroups;
+  SYSCALLARG(const gid_t *) gidset;
 } setgroups_args_t;
 
 typedef struct {
-  pid_t pid;
+  SYSCALLARG(pid_t) pid;
 } getsid_args_t;
 
 typedef struct {
-  int which;
-  id_t who;
+  SYSCALLARG(int) which;
+  SYSCALLARG(id_t) who;
 } getpriority_args_t;
 
 typedef struct {
-  int which;
-  id_t who;
-  int prio;
+  SYSCALLARG(int) which;
+  SYSCALLARG(id_t) who;
+  SYSCALLARG(int) prio;
 } setpriority_args_t;
 
 typedef struct {
-  uid_t uid;
+  SYSCALLARG(uid_t) uid;
 } setuid_args_t;
 
 typedef struct {
-  uid_t euid;
+  SYSCALLARG(uid_t) euid;
 } seteuid_args_t;
 
 typedef struct {
-  uid_t ruid;
-  uid_t euid;
+  SYSCALLARG(uid_t) ruid;
+  SYSCALLARG(uid_t) euid;
 } setreuid_args_t;
 
 typedef struct {
-  gid_t gid;
+  SYSCALLARG(gid_t) gid;
 } setgid_args_t;
 
 typedef struct {
-  gid_t egid;
+  SYSCALLARG(gid_t) egid;
 } setegid_args_t;
 
 typedef struct {
-  gid_t rgid;
-  gid_t egid;
+  SYSCALLARG(gid_t) rgid;
+  SYSCALLARG(gid_t) egid;
 } setregid_args_t;

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -168,7 +168,7 @@ static int sys_mmap(proc_t *p, mmap_args_t *args, register_t *res) {
   vm_prot_t prot = SCARG(args, prot);
   int flags = SCARG(args, flags);
 
-  klog("mmap(%p, %u, %d, %d)", SCARG(args, addr), length, prot, flags);
+  klog("mmap(%p, %u, %d, %d)", (void *)va, length, prot, flags);
 
   int error;
   if ((error = do_mmap(&va, length, prot, flags)))
@@ -684,8 +684,7 @@ static int sys_setresuid(proc_t *p, setresuid_args_t *args, register_t *res) {
   uid_t euid = SCARG(args, euid);
   uid_t suid = SCARG(args, suid);
 
-  klog("setresuid(%d, %d, %d)", SCARG(args, ruid), SCARG(args, euid),
-       SCARG(args, suid));
+  klog("setresuid(%d, %d, %d)", ruid, euid, suid);
 
   return do_setresuid(p, ruid, euid, suid);
 }
@@ -695,8 +694,7 @@ static int sys_setresgid(proc_t *p, setresgid_args_t *args, register_t *res) {
   gid_t egid = SCARG(args, egid);
   gid_t sgid = SCARG(args, sgid);
 
-  klog("setresgid(%d, %d, %d)", SCARG(args, rgid), SCARG(args, egid),
-       SCARG(args, sgid));
+  klog("setresgid(%d, %d, %d)", rgid, egid, sgid);
 
   return do_setresgid(p, rgid, egid, sgid);
 }

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -28,21 +28,21 @@
 
 /* Empty syscall handler, for unimplemented and deprecated syscall numbers. */
 int sys_syscall(proc_t *p, syscall_args_t *args, register_t *res) {
-  klog("unimplemented system call %ld", args->number);
+  klog("unimplemented system call %ld", SCARG(args, number));
   return ENOSYS;
 };
 
 static int sys_sbrk(proc_t *p, sbrk_args_t *args, register_t *res) {
-  klog("sbrk(%d)", args->increment);
+  klog("sbrk(%d)", SCARG(args, increment));
 
-  return sbrk_resize(p, args->increment, (vaddr_t *)res);
+  return sbrk_resize(p, SCARG(args, increment), (vaddr_t *)res);
 }
 
 /* https://pubs.opengroup.org/onlinepubs/9699919799/functions/exit.html */
 static int sys_exit(proc_t *p, exit_args_t *args, register_t *res) {
-  klog("exit(%d)", args->rval);
+  klog("exit(%d)", SCARG(args, rval));
   proc_lock(p);
-  proc_exit(MAKE_STATUS_EXIT(args->rval));
+  proc_exit(MAKE_STATUS_EXIT(SCARG(args, rval)));
   __unreachable();
 }
 
@@ -82,8 +82,8 @@ static int sys_getppid(proc_t *p, void *args, register_t *res) {
  *
  * https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgid.html */
 static int sys_setpgid(proc_t *p, setpgid_args_t *args, register_t *res) {
-  pid_t pid = args->pid;
-  pgid_t pgid = args->pgid;
+  pid_t pid = SCARG(args, pid);
+  pgid_t pgid = SCARG(args, pgid);
 
   klog("setpgid(%d, %d)", pid, pgid);
 
@@ -103,7 +103,7 @@ static int sys_setpgid(proc_t *p, setpgid_args_t *args, register_t *res) {
  *
  * https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpgid.html */
 static int sys_getpgid(proc_t *p, getpgid_args_t *args, register_t *res) {
-  pid_t pid = args->pid;
+  pid_t pid = SCARG(args, pid);
   pgid_t pgid;
 
   if (pid < 0)
@@ -119,24 +119,24 @@ static int sys_getpgid(proc_t *p, getpgid_args_t *args, register_t *res) {
 
 /* https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html */
 static int sys_kill(proc_t *p, kill_args_t *args, register_t *res) {
-  klog("kill(%lu, %d)", args->pid, args->sig);
-  return proc_sendsig(args->pid, args->sig);
+  klog("kill(%lu, %d)", SCARG(args, pid), SCARG(args, sig));
+  return proc_sendsig(SCARG(args, pid), SCARG(args, sig));
 }
 
 /* Set and get the file mode creation mask.
  *
  * https://pubs.opengroup.org/onlinepubs/9699919799/functions/umask.html */
 static int sys_umask(proc_t *p, umask_args_t *args, register_t *res) {
-  mode_t newmask = args->newmask;
-  klog("umask(%x)", args->newmask);
+  mode_t newmask = SCARG(args, newmask);
+  klog("umask(%x)", SCARG(args, newmask));
   return do_umask(p, newmask, (int *)res);
 }
 
 /* https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html */
 static int sys_sigaction(proc_t *p, sigaction_args_t *args, register_t *res) {
-  int signo = args->signum;
-  const void *u_newact = args->nsa;
-  void *u_oldact = args->osa;
+  int signo = SCARG(args, signum);
+  const void *u_newact = SCARG(args, nsa);
+  void *u_oldact = SCARG(args, osa);
 
   klog("sigaction(%d, %p, %p)", signo, u_newact, u_oldact);
 
@@ -163,12 +163,12 @@ static int sys_sigreturn(proc_t *p, sigreturn_args_t *args, register_t *res) {
 }
 
 static int sys_mmap(proc_t *p, mmap_args_t *args, register_t *res) {
-  vaddr_t va = (vaddr_t)args->addr;
-  size_t length = args->len;
-  vm_prot_t prot = args->prot;
-  int flags = args->flags;
+  vaddr_t va = (vaddr_t)SCARG(args, addr);
+  size_t length = SCARG(args, len);
+  vm_prot_t prot = SCARG(args, prot);
+  int flags = SCARG(args, flags);
 
-  klog("mmap(%p, %u, %d, %d)", args->addr, length, prot, flags);
+  klog("mmap(%p, %u, %d, %d)", SCARG(args, addr), length, prot, flags);
 
   int error;
   if ((error = do_mmap(&va, length, prot, flags)))
@@ -179,21 +179,22 @@ static int sys_mmap(proc_t *p, mmap_args_t *args, register_t *res) {
 }
 
 static int sys_munmap(proc_t *p, munmap_args_t *args, register_t *res) {
-  klog("munmap(%p, %u)", args->addr, args->len);
-  return do_munmap((vaddr_t)args->addr, args->len);
+  klog("munmap(%p, %u)", SCARG(args, addr), SCARG(args, len));
+  return do_munmap((vaddr_t)SCARG(args, addr), SCARG(args, len));
 }
 
 /* TODO: implement it !!! */
 static int sys_mprotect(proc_t *p, mprotect_args_t *args, register_t *res) {
-  klog("mprotect(%p, %u, %u)", args->addr, args->len, args->prot);
+  klog("mprotect(%p, %u, %u)", SCARG(args, addr), SCARG(args, len),
+       SCARG(args, prot));
   return ENOTSUP;
 }
 
 static int sys_openat(proc_t *p, openat_args_t *args, register_t *res) {
-  int fdat = args->fd;
-  const char *u_path = args->path;
-  int flags = args->flags;
-  mode_t mode = args->mode;
+  int fdat = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  int flags = SCARG(args, flags);
+  mode_t mode = SCARG(args, mode);
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
   size_t n = 0;
@@ -216,15 +217,15 @@ end:
 }
 
 static int sys_close(proc_t *p, close_args_t *args, register_t *res) {
-  klog("close(%d)", args->fd);
+  klog("close(%d)", SCARG(args, fd));
 
-  return do_close(p, args->fd);
+  return do_close(p, SCARG(args, fd));
 }
 
 static int sys_read(proc_t *p, read_args_t *args, register_t *res) {
-  int fd = args->fd;
-  void *u_buf = args->buf;
-  size_t nbyte = args->nbyte;
+  int fd = SCARG(args, fd);
+  void *u_buf = SCARG(args, buf);
+  size_t nbyte = SCARG(args, nbyte);
   int error;
 
   klog("read(%d, %p, %u)", fd, u_buf, nbyte);
@@ -238,9 +239,9 @@ static int sys_read(proc_t *p, read_args_t *args, register_t *res) {
 }
 
 static int sys_write(proc_t *p, write_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_buf = args->buf;
-  size_t nbyte = args->nbyte;
+  int fd = SCARG(args, fd);
+  const char *u_buf = SCARG(args, buf);
+  size_t nbyte = SCARG(args, nbyte);
   int error;
 
   klog("write(%d, %p, %u)", fd, u_buf, nbyte);
@@ -257,8 +258,10 @@ static int sys_lseek(proc_t *p, lseek_args_t *args, register_t *res) {
   off_t newoff;
   int error;
 
-  klog("lseek(%d, %ld, %d)", args->fd, args->offset, args->whence);
-  if ((error = do_lseek(p, args->fd, args->offset, args->whence, &newoff)))
+  klog("lseek(%d, %ld, %d)", SCARG(args, fd), SCARG(args, offset),
+       SCARG(args, whence));
+  if ((error = do_lseek(p, SCARG(args, fd), SCARG(args, offset),
+                        SCARG(args, whence), &newoff)))
     return error;
 
   *res = newoff;
@@ -266,8 +269,8 @@ static int sys_lseek(proc_t *p, lseek_args_t *args, register_t *res) {
 }
 
 static int sys_fstat(proc_t *p, fstat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  stat_t *u_sb = args->sb;
+  int fd = SCARG(args, fd);
+  stat_t *u_sb = SCARG(args, sb);
   stat_t sb;
   int error;
 
@@ -279,7 +282,7 @@ static int sys_fstat(proc_t *p, fstat_args_t *args, register_t *res) {
 }
 
 static int sys_chdir(proc_t *p, chdir_args_t *args, register_t *res) {
-  const char *u_path = args->path;
+  const char *u_path = SCARG(args, path);
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
   size_t len = 0;
   int error = 0;
@@ -295,13 +298,13 @@ end:
 }
 
 static int sys_fchdir(proc_t *p, fchdir_args_t *args, register_t *res) {
-  klog("fchdir(%d)", args->fd);
-  return do_fchdir(p, args->fd);
+  klog("fchdir(%d)", SCARG(args, fd));
+  return do_fchdir(p, SCARG(args, fd));
 }
 
 static int sys_getcwd(proc_t *p, getcwd_args_t *args, register_t *res) {
-  char *u_buf = args->buf;
-  size_t len = args->len;
+  char *u_buf = SCARG(args, buf);
+  size_t len = SCARG(args, len);
   int error;
 
   if (len == 0)
@@ -328,8 +331,8 @@ end:
 }
 
 static int sys_mount(proc_t *p, mount_args_t *args, register_t *res) {
-  const char *u_type = args->type;
-  const char *u_path = args->path;
+  const char *u_type = SCARG(args, type);
+  const char *u_path = SCARG(args, path);
 
   char *type = kmalloc(M_TEMP, PATH_MAX, 0);
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
@@ -354,9 +357,9 @@ end:
 }
 
 static int sys_getdents(proc_t *p, getdents_args_t *args, register_t *res) {
-  int fd = args->fd;
-  void *u_buf = args->buf;
-  size_t len = args->len;
+  int fd = SCARG(args, fd);
+  void *u_buf = SCARG(args, buf);
+  size_t len = SCARG(args, len);
   int error;
 
   klog("getdents(%d, %p, %u)", fd, u_buf, len);
@@ -371,33 +374,35 @@ static int sys_getdents(proc_t *p, getdents_args_t *args, register_t *res) {
 
 static int sys_dup(proc_t *p, dup_args_t *args, register_t *res) {
   int error, fd;
-  klog("dup(%d)", args->fd);
-  error = do_dup(p, args->fd, &fd);
+  klog("dup(%d)", SCARG(args, fd));
+  error = do_dup(p, SCARG(args, fd), &fd);
   *res = fd;
   return error;
 }
 
 static int sys_dup2(proc_t *p, dup2_args_t *args, register_t *res) {
-  klog("dup2(%d, %d)", args->from, args->to);
+  klog("dup2(%d, %d)", SCARG(args, from), SCARG(args, to));
 
-  *res = args->to;
+  *res = SCARG(args, to);
 
-  return do_dup2(p, args->from, args->to);
+  return do_dup2(p, SCARG(args, from), SCARG(args, to));
 }
 
 static int sys_fcntl(proc_t *p, fcntl_args_t *args, register_t *res) {
   int error, value;
-  klog("fcntl(%d, %d, %ld)", args->fd, args->cmd, (long)args->arg);
-  error = do_fcntl(p, args->fd, args->cmd, (long)args->arg, &value);
+  klog("fcntl(%d, %d, %ld)", SCARG(args, fd), SCARG(args, cmd),
+       (long)SCARG(args, arg));
+  error = do_fcntl(p, SCARG(args, fd), SCARG(args, cmd), (long)SCARG(args, arg),
+                   &value);
   *res = value;
   return error;
 }
 
 static int sys_wait4(proc_t *p, wait4_args_t *args, register_t *res) {
-  pid_t pid = args->pid;
-  int *u_status = args->status;
-  int options = args->options;
-  struct rusage *u_rusage = args->rusage;
+  pid_t pid = SCARG(args, pid);
+  int *u_status = SCARG(args, status);
+  int options = SCARG(args, options);
+  struct rusage *u_rusage = SCARG(args, rusage);
   int status = 0;
   int error;
 
@@ -419,8 +424,8 @@ static int sys_wait4(proc_t *p, wait4_args_t *args, register_t *res) {
 }
 
 static int sys_pipe2(proc_t *p, pipe2_args_t *args, register_t *res) {
-  int *u_fdp = args->fdp;
-  int flags = args->flags;
+  int *u_fdp = SCARG(args, fdp);
+  int flags = SCARG(args, flags);
   int fds[2];
   int error;
 
@@ -436,9 +441,9 @@ static int sys_pipe2(proc_t *p, pipe2_args_t *args, register_t *res) {
 }
 
 static int sys_unlinkat(proc_t *p, unlinkat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_path = args->path;
-  int flag = args->flag;
+  int fd = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  int flag = SCARG(args, flag);
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
   size_t n = 0;
@@ -458,9 +463,9 @@ end:
 }
 
 static int sys_mkdirat(proc_t *p, mkdirat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_path = args->path;
-  mode_t mode = args->mode;
+  int fd = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  mode_t mode = SCARG(args, mode);
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
   size_t n = 0;
@@ -479,19 +484,19 @@ end:
 }
 
 static int sys_execve(proc_t *p, execve_args_t *args, register_t *res) {
-  const char *u_path = args->path;
-  char *const *u_argp = args->argp;
-  char *const *u_envp = args->envp;
+  const char *u_path = SCARG(args, path);
+  char *const *u_argp = SCARG(args, argp);
+  char *const *u_envp = SCARG(args, envp);
 
   /* do_execve handles copying data from user-space */
   return do_execve(u_path, u_argp, u_envp);
 }
 
 static int sys_faccessat(proc_t *p, faccessat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_path = args->path;
-  mode_t mode = args->mode;
-  int flags = args->flags;
+  int fd = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  mode_t mode = SCARG(args, mode);
+  int flags = SCARG(args, flags);
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
   int error;
@@ -510,8 +515,8 @@ end:
 
 static int sys_clock_gettime(proc_t *p, clock_gettime_args_t *args,
                              register_t *res) {
-  clockid_t clock_id = args->clock_id;
-  timespec_t *u_ts = args->tsp;
+  clockid_t clock_id = SCARG(args, clock_id);
+  timespec_t *u_ts = SCARG(args, tsp);
   timespec_t ts;
   int error;
 
@@ -523,9 +528,9 @@ static int sys_clock_gettime(proc_t *p, clock_gettime_args_t *args,
 
 static int sys_clock_nanosleep(proc_t *p, clock_nanosleep_args_t *args,
                                register_t *res) {
-  clockid_t clock_id = args->clock_id;
-  int flags = args->flags;
-  const timespec_t *u_rqtp = args->rqtp;
+  clockid_t clock_id = SCARG(args, clock_id);
+  int flags = SCARG(args, flags);
+  const timespec_t *u_rqtp = SCARG(args, rqtp);
   timespec_t rqtp;
   int error;
 
@@ -537,8 +542,8 @@ static int sys_clock_nanosleep(proc_t *p, clock_nanosleep_args_t *args,
 
 static int sys_sigaltstack(proc_t *p, sigaltstack_args_t *args,
                            register_t *res) {
-  const stack_t *ss = args->ss;
-  stack_t *old_ss = args->old_ss;
+  const stack_t *ss = SCARG(args, ss);
+  stack_t *old_ss = SCARG(args, old_ss);
   int error;
 
   klog("sigaltstack(%p, %p)", ss, old_ss);
@@ -560,9 +565,9 @@ static int sys_sigaltstack(proc_t *p, sigaltstack_args_t *args,
 
 static int sys_sigprocmask(proc_t *p, sigprocmask_args_t *args,
                            register_t *res) {
-  int how = args->how;
-  const sigset_t *u_set = args->set;
-  sigset_t *u_oset = args->oset;
+  int how = SCARG(args, how);
+  const sigset_t *u_set = SCARG(args, set);
+  sigset_t *u_oset = SCARG(args, oset);
   sigset_t set, oset;
   int error;
 
@@ -585,7 +590,7 @@ static int sys_sigprocmask(proc_t *p, sigprocmask_args_t *args,
 }
 
 static int sys_sigsuspend(proc_t *p, sigsuspend_args_t *args, register_t *res) {
-  const sigset_t *umask = args->sigmask;
+  const sigset_t *umask = SCARG(args, sigmask);
   sigset_t mask;
   int error;
 
@@ -598,7 +603,7 @@ static int sys_sigsuspend(proc_t *p, sigsuspend_args_t *args, register_t *res) {
 }
 
 static int sys_setcontext(proc_t *p, setcontext_args_t *args, register_t *res) {
-  const ucontext_t *ucp = args->ucp;
+  const ucontext_t *ucp = SCARG(args, ucp);
   klog("setcontext(%p)", ucp);
 
   ucontext_t uc;
@@ -608,9 +613,9 @@ static int sys_setcontext(proc_t *p, setcontext_args_t *args, register_t *res) {
 }
 
 static int sys_ioctl(proc_t *p, ioctl_args_t *args, register_t *res) {
-  int fd = args->fd;
-  u_long cmd = args->cmd;
-  void *u_data = args->data;
+  int fd = SCARG(args, fd);
+  u_long cmd = SCARG(args, cmd);
+  void *u_data = SCARG(args, data);
   int error;
 
   klog("ioctl(%d, %lx, %p)", fd, cmd, u_data);
@@ -641,9 +646,9 @@ fail:
 }
 
 static int sys_getresuid(proc_t *p, getresuid_args_t *args, register_t *res) {
-  uid_t *usr_ruid = args->ruid;
-  uid_t *usr_euid = args->euid;
-  uid_t *usr_suid = args->suid;
+  uid_t *usr_ruid = SCARG(args, ruid);
+  uid_t *usr_euid = SCARG(args, euid);
+  uid_t *usr_suid = SCARG(args, suid);
 
   klog("getresuid()");
 
@@ -658,9 +663,9 @@ static int sys_getresuid(proc_t *p, getresuid_args_t *args, register_t *res) {
 }
 
 static int sys_getresgid(proc_t *p, getresgid_args_t *args, register_t *res) {
-  gid_t *usr_rgid = args->rgid;
-  gid_t *usr_egid = args->egid;
-  gid_t *usr_sgid = args->sgid;
+  gid_t *usr_rgid = SCARG(args, rgid);
+  gid_t *usr_egid = SCARG(args, egid);
+  gid_t *usr_sgid = SCARG(args, sgid);
 
   klog("getresgid()");
 
@@ -675,21 +680,23 @@ static int sys_getresgid(proc_t *p, getresgid_args_t *args, register_t *res) {
 }
 
 static int sys_setresuid(proc_t *p, setresuid_args_t *args, register_t *res) {
-  uid_t ruid = args->ruid;
-  uid_t euid = args->euid;
-  uid_t suid = args->suid;
+  uid_t ruid = SCARG(args, ruid);
+  uid_t euid = SCARG(args, euid);
+  uid_t suid = SCARG(args, suid);
 
-  klog("setresuid(%d, %d, %d)", args->ruid, args->euid, args->suid);
+  klog("setresuid(%d, %d, %d)", SCARG(args, ruid), SCARG(args, euid),
+       SCARG(args, suid));
 
   return do_setresuid(p, ruid, euid, suid);
 }
 
 static int sys_setresgid(proc_t *p, setresgid_args_t *args, register_t *res) {
-  gid_t rgid = args->rgid;
-  gid_t egid = args->egid;
-  gid_t sgid = args->sgid;
+  gid_t rgid = SCARG(args, rgid);
+  gid_t egid = SCARG(args, egid);
+  gid_t sgid = SCARG(args, sgid);
 
-  klog("setresgid(%d, %d, %d)", args->rgid, args->egid, args->sgid);
+  klog("setresgid(%d, %d, %d)", SCARG(args, rgid), SCARG(args, egid),
+       SCARG(args, sgid));
 
   return do_setresgid(p, rgid, egid, sgid);
 }
@@ -702,8 +709,8 @@ static int sys_issetugid(proc_t *p, void *args, register_t *res) {
 }
 
 static int sys_truncate(proc_t *p, truncate_args_t *args, register_t *res) {
-  const char *u_path = args->path;
-  off_t length = args->length;
+  const char *u_path = SCARG(args, path);
+  off_t length = SCARG(args, length);
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
   int error;
@@ -721,17 +728,17 @@ end:
 }
 
 static int sys_ftruncate(proc_t *p, ftruncate_args_t *args, register_t *res) {
-  int fd = args->fd;
-  off_t length = args->length;
+  int fd = SCARG(args, fd);
+  off_t length = SCARG(args, length);
   klog("ftruncate(%d, %d)", fd, length);
   return do_ftruncate(p, fd, length);
 }
 
 static int sys_fstatat(proc_t *p, fstatat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_path = args->path;
-  stat_t *u_sb = args->sb;
-  int flag = args->flag;
+  int fd = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  stat_t *u_sb = SCARG(args, sb);
+  int flag = SCARG(args, flag);
   stat_t sb;
   int error;
 
@@ -751,10 +758,10 @@ end:
 }
 
 static int sys_readlinkat(proc_t *p, readlinkat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_path = args->path;
-  char *u_buf = args->buf;
-  size_t bufsiz = args->bufsiz;
+  int fd = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  char *u_buf = SCARG(args, buf);
+  size_t bufsiz = SCARG(args, bufsiz);
   int error;
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
@@ -774,9 +781,9 @@ end:
 }
 
 static int sys_symlinkat(proc_t *p, symlinkat_args_t *args, register_t *res) {
-  const char *u_target = args->target;
-  int newdirfd = args->newdirfd;
-  const char *u_linkpath = args->linkpath;
+  const char *u_target = SCARG(args, target);
+  int newdirfd = SCARG(args, newdirfd);
+  const char *u_linkpath = SCARG(args, linkpath);
   int error;
 
   char *target = kmalloc(M_TEMP, PATH_MAX, 0);
@@ -798,11 +805,11 @@ end:
 }
 
 static int sys_linkat(proc_t *p, linkat_args_t *args, register_t *res) {
-  int fd1 = args->fd1;
-  const char *u_name1 = args->name1;
-  int fd2 = args->fd2;
-  const char *u_name2 = args->name2;
-  int flags = args->flags;
+  int fd1 = SCARG(args, fd1);
+  const char *u_name1 = SCARG(args, name1);
+  int fd2 = SCARG(args, fd2);
+  const char *u_name2 = SCARG(args, name2);
+  int flags = SCARG(args, flags);
   int error;
 
   char *name1 = kmalloc(M_TEMP, PATH_MAX, 0);
@@ -824,8 +831,8 @@ end:
 }
 
 static int sys_fchmod(proc_t *p, fchmod_args_t *args, register_t *res) {
-  int fd = args->fd;
-  mode_t mode = args->mode;
+  int fd = SCARG(args, fd);
+  mode_t mode = SCARG(args, mode);
 
   klog("fchmod(%d, %d)", fd, mode);
 
@@ -833,10 +840,10 @@ static int sys_fchmod(proc_t *p, fchmod_args_t *args, register_t *res) {
 }
 
 static int sys_fchmodat(proc_t *p, fchmodat_args_t *args, register_t *res) {
-  int fd = args->fd;
-  const char *u_path = args->path;
-  mode_t mode = args->mode;
-  int flag = args->flag;
+  int fd = SCARG(args, fd);
+  const char *u_path = SCARG(args, path);
+  mode_t mode = SCARG(args, mode);
+  int flag = SCARG(args, flag);
   int error;
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
@@ -861,8 +868,8 @@ static int sys_sched_yield(proc_t *p, void *args, register_t *res) {
 
 static int sys_statvfs(proc_t *p, statvfs_args_t *args, register_t *res) {
   int error;
-  const char *u_path = args->path;
-  statvfs_t *u_buf = args->buf;
+  const char *u_path = SCARG(args, path);
+  statvfs_t *u_buf = SCARG(args, buf);
   statvfs_t buf;
 
   char *path = kmalloc(M_TEMP, PATH_MAX, 0);
@@ -882,8 +889,8 @@ end:
 
 static int sys_fstatvfs(proc_t *p, fstatvfs_args_t *args, register_t *res) {
   int error;
-  int fd = args->fd;
-  statvfs_t *u_buf = args->buf;
+  int fd = SCARG(args, fd);
+  statvfs_t *u_buf = SCARG(args, buf);
   statvfs_t buf;
 
   klog("fstatvfs(%d, %p)", fd, u_buf);
@@ -895,8 +902,8 @@ static int sys_fstatvfs(proc_t *p, fstatvfs_args_t *args, register_t *res) {
 }
 
 static int sys_getgroups(proc_t *p, getgroups_args_t *args, register_t *res) {
-  int ngroups = args->ngroups;
-  gid_t *ugidset = args->gidset;
+  int ngroups = SCARG(args, ngroups);
+  gid_t *ugidset = SCARG(args, gidset);
   int pngroups = p->p_cred.cr_ngroups;
 
   klog("getgroups(%d, %p)", ngroups, ugidset);
@@ -916,8 +923,8 @@ static int sys_getgroups(proc_t *p, getgroups_args_t *args, register_t *res) {
 
 static int sys_setgroups(proc_t *p, setgroups_args_t *args, register_t *res) {
   int error = 0;
-  int ungroups = args->ngroups;
-  const gid_t *ugidset = args->gidset;
+  int ungroups = SCARG(args, ngroups);
+  const gid_t *ugidset = SCARG(args, gidset);
 
   klog("setgroups(%d, %p)", ungroups, ugidset);
 
@@ -951,7 +958,7 @@ static int sys_setsid(proc_t *p, void *args, register_t *res) {
 }
 
 static int sys_getsid(proc_t *p, getsid_args_t *args, register_t *res) {
-  pid_t pid = args->pid;
+  pid_t pid = SCARG(args, pid);
   sid_t sid;
   int error;
 
@@ -988,33 +995,33 @@ static int sys_setpriority(proc_t *p, setpriority_args_t *args,
 }
 
 static int sys_setuid(proc_t *p, setuid_args_t *args, register_t *res) {
-  uid_t uid = args->uid;
+  uid_t uid = SCARG(args, uid);
   return do_setuid(p, uid);
 }
 
 static int sys_seteuid(proc_t *p, seteuid_args_t *args, register_t *res) {
-  uid_t euid = args->euid;
+  uid_t euid = SCARG(args, euid);
   return do_seteuid(p, euid);
 }
 
 static int sys_setreuid(proc_t *p, setreuid_args_t *args, register_t *res) {
-  uid_t ruid = args->ruid;
-  uid_t euid = args->euid;
+  uid_t ruid = SCARG(args, ruid);
+  uid_t euid = SCARG(args, euid);
   return do_setreuid(p, ruid, euid);
 }
 
 static int sys_setgid(proc_t *p, setgid_args_t *args, register_t *res) {
-  gid_t gid = args->gid;
+  gid_t gid = SCARG(args, gid);
   return do_setgid(p, gid);
 }
 
 static int sys_setegid(proc_t *p, setegid_args_t *args, register_t *res) {
-  gid_t egid = args->egid;
+  gid_t egid = SCARG(args, egid);
   return do_setegid(p, egid);
 }
 
 static int sys_setregid(proc_t *p, setregid_args_t *args, register_t *res) {
-  gid_t rgid = args->rgid;
-  gid_t egid = args->egid;
+  gid_t rgid = SCARG(args, rgid);
+  gid_t egid = SCARG(args, egid);
   return do_setregid(p, rgid, egid);
 }

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -5,15 +5,8 @@
 #include <sys/ucontext.h>
 #include <sys/sigtypes.h>
 
-#define SCARG(p, x) ((p)->x.le.arg)
-
-#define SYSCALLARG(x) \
-    union { \
-        register_t _pad; \
-        struct { \
-            x arg; \
-        } le; \
-    }
+#define SCARG(p, x) ((p)->x.arg)
+#define SYSCALLARG(x) union { register_t _pad; x arg; }
 
 0   { int sys_syscall(int number); }
 1   { void sys_exit(int rval); }

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -5,6 +5,16 @@
 #include <sys/ucontext.h>
 #include <sys/sigtypes.h>
 
+#define SCARG(p, x) ((p)->x.le.arg)
+
+#define SYSCALLARG(x) \
+    union { \
+        register_t _pad; \
+        struct { \
+            x arg; \
+        } le; \
+    }
+
 0   { int sys_syscall(int number); }
 1   { void sys_exit(int rval); }
 2   { int sys_fork(void); }

--- a/sys/script/makesyscalls.sh
+++ b/sys/script/makesyscalls.sh
@@ -153,6 +153,10 @@ $1 ~ /^#[ 	]*include/ {
 	print > sysarghdr
 	next
 }
+$1 ~ /^#[ 	]*define/ {
+	print > sysarghdr
+	next
+}
 $1 ~ /^#[ 	]*if/ {
 	print > sysent
 	savesyscall[++savedepth] = syscall
@@ -310,7 +314,7 @@ function putent() {
 	if (argc != 0) {
 		printf("\ntypedef struct {\n") > sysarghdr
 		for (i = 1; i <= argc; i++)
-			printf("  %s %s;\n", argtype[i], argname[i]) > sysarghdr
+			printf("  SYSCALLARG(%s) %s;\n", argtype[i], argname[i]) > sysarghdr
 		printf("} %s_args_t;\n", funcalias) > sysarghdr
 	}
 }


### PR DESCRIPTION
That change introduce wrappers for arguments that allow to pass something smaller than register.

All arguments inside `_args_t` are packed into union of `register_t` and real argument so now we can use `memcpy` for creating arguments from CPU context in machine dependent layer of syscalls without problems.

It's necessary for _AArch64_ where arguments are smaller than registers.