### PR TITLE
Improve qemu-mimiker cleaning

### DIFF
--- a/toolchain/qemu-mimiker/Makefile
+++ b/toolchain/qemu-mimiker/Makefile
@@ -69,7 +69,7 @@ binary-stamp: install-stamp
 
 clean: unpatch
 	dh_clean
-	rm -rf $(QEMU) qemu-build
+	rm -rf $(QEMU) qemu-build .pc
 	rm -f *~
 
 .PHONY: download unpack patch unpatch configure build install binary clean


### PR DESCRIPTION
To avoid make error caused by quilt - in case when we want to import
new patches, we need to clean also _.pc_

We can be more gentle and use `quilt` here (to clean his files) but this approach is also correct
and covers our needs