### PR TITLE
Fix sequential PCI bar RIDs

### DIFF
--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -78,7 +78,9 @@ typedef struct pci_bus_driver {
 typedef struct pci_bar {
   device_t *owner; /* pci device owner of this bar */
   size_t size;     /* identified size of this bar */
-  int rid;         /* BAR number in [0,PCI_BAR_MAX-1] */
+  int id;          /* BAR number in [0,PCI_BAR_MAX-1] */
+  int rid;         /* BAR RID (bars always get sequential RIDs,
+                    * no matter what's their actual id) */
   unsigned type;   /* RT_IOPORTS or RT_MEMORY */
   unsigned flags;  /* nothing or RF_PREFETACHBLE */
 } pci_bar_t;

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -108,9 +108,12 @@ void pci_bus_enumerate(device_t *pcib) {
 
         size = -size;
         uint8_t rid = pcid->nbars++;
-        pcid->bar[rid] = (pci_bar_t){
-          .owner = dev, .type = type, .flags = flags, .size = size, .rid = rid,
-          .id = i };
+        pcid->bar[rid] = (pci_bar_t){.owner = dev,
+                                     .type = type,
+                                     .flags = flags,
+                                     .size = size,
+                                     .rid = rid,
+                                     .id = i};
       }
     }
   }

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -50,6 +50,8 @@ static uint32_t pci_bar_size(device_t *pcid, int bar, uint32_t addr) {
 
 DEVCLASS_CREATE(pci);
 
+#define INVALID_BAR 0xff
+
 void pci_bus_enumerate(device_t *pcib) {
   pci_addr_t pcia = {.bus = 0, .device = 0};
   device_t pcid = {.parent = pcib, .bus = DEV_BUS_PCI, .instance = &pcia};
@@ -87,8 +89,10 @@ void pci_bus_enumerate(device_t *pcib) {
         uint32_t addr = pci_read_config(dev, PCIR_BAR(i), 4);
         uint32_t size = pci_bar_size(dev, i, addr);
 
-        if (size == 0 || addr == size)
+        if (size == 0 || addr == size) {
+          pcid->bar[i].rid = INVALID_BAR
           continue;
+        }
 
         unsigned type, flags = 0;
 
@@ -104,7 +108,7 @@ void pci_bus_enumerate(device_t *pcib) {
 
         size = -size;
         uint8_t id = pcid->nbars;
-        pcid->bar[id] = (pci_bar_t){
+        pcid->bar[i] = (pci_bar_t){
           .owner = dev, .type = type, .flags = flags, .size = size, .rid = id};
         pcid->nbars++;
       }

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -107,10 +107,10 @@ void pci_bus_enumerate(device_t *pcib) {
         }
 
         size = -size;
-        uint8_t id = pcid->nbars;
-        pcid->bar[i] = (pci_bar_t){
-          .owner = dev, .type = type, .flags = flags, .size = size, .rid = id};
-        pcid->nbars++;
+        uint8_t rid = pcid->nbars++;
+        pcid->bar[rid] = (pci_bar_t){
+          .owner = dev, .type = type, .flags = flags, .size = size, .rid = rid,
+          .id = i };
       }
     }
   }
@@ -149,7 +149,7 @@ void pci_bus_dump(device_t *pcib) {
       kprintf("%s Interrupt: pin %c routed to IRQ %d\n", devstr,
               'A' + pcid->pin - 1, pcid->irq);
 
-    for (int i = 0; i < PCI_BAR_MAX; i++) {
+    for (int i = 0; i < pcid->nbars; i++) {
       pci_bar_t *bar = &pcid->bar[i];
       char *type;
 

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -90,7 +90,7 @@ void pci_bus_enumerate(device_t *pcib) {
         uint32_t size = pci_bar_size(dev, i, addr);
 
         if (size == 0 || addr == size) {
-          pcid->bar[i].rid = INVALID_BAR
+          pcid->bar[i].rid = INVALID_BAR;
           continue;
         }
 

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -318,16 +318,6 @@ static int gt_pci_attach(device_t *pcib) {
   return bus_generic_probe(pcib);
 }
 
-static inline pci_bar_t *gt_pci_bar_of_rid(pci_device_t *pcid, int rid) {
-  pci_bar_t *bar = NULL;
-  for (uint8_t i = 0; i < PCI_BAR_MAX; i++) {
-    bar = &pcid->bar[i];
-    if (bar->rid == rid)
-      break;
-  }
-  return bar;
-}
-
 static resource_t *gt_pci_alloc_resource(device_t *dev, res_type_t type,
                                          int rid, rman_addr_t start,
                                          rman_addr_t end, size_t size,
@@ -352,9 +342,8 @@ static resource_t *gt_pci_alloc_resource(device_t *dev, res_type_t type,
     /* Now handle only PCI devices. */
     pci_device_t *pcid = pci_device_of(dev);
     /* Find identified bar by rid. */
-    assert(rid < PCI_BAR_MAX);
-    pci_bar_t *bar = gt_pci_bar_of_rid(pcid, rid);
-    assert(bar != NULL);
+    assert(rid < pcid->nbars);
+    pci_bar_t *bar = &pcid->bar[rid];
 
     if (bar->size == 0)
       return NULL;
@@ -415,8 +404,7 @@ static int gt_pci_activate_resource(device_t *dev, res_type_t type, int rid,
   if (type == RT_MEMORY) {
     /* Write BAR address to PCI device register. */
     pci_device_t *pcid = pci_device_of(dev);
-    unsigned int bar_id = gt_pci_bar_of_rid(pcid, rid) - &pcid->bar[0];
-    pci_write_config(dev, PCIR_BAR(bar_id), 4, r->r_bus_handle);
+    pci_write_config(dev, PCIR_BAR(pcid->bar[rid].id), 4, r->r_bus_handle);
     return bus_space_map(r->r_bus_tag, r->r_bus_handle, resource_size(r),
                          &r->r_bus_handle);
   }


### PR DESCRIPTION
First of all, I'm not very familiar with the concept of PCI bars yet, so it's quite possible there's a better solution.

#817 was meant to free PCI device drivers from being responsible for choosing the right PCI bar RIDs by letting them just pick _n_ natural numbers beginning from 0.

**I am surprised it actually ended up getting merged to master branch.** There's just one driver which benefits from this change and it is _stdvga_ on _MIPS_ board. Yet, after this commit, anyone who had run mimiker with `-g` option would notice that the VGA is broken.

Currently, my solution makes the drivers access PCI bar resources using RIDs as if they were sequential while retaining the underlying physical order. Which bar is valid for use depends on its config which is read in `pci_enumerate` procedure and it looks like reordering them (if possible) would require changing their configurations, which I _believe_ are written by the device connected to the PCI bus.