### PR TITLE
Adding timer and performance interrupts to mips.

### DIFF
--- a/include/mips/interrupt.h
+++ b/include/mips/interrupt.h
@@ -39,9 +39,11 @@ typedef enum {
   MIPS_HWINT3,
   MIPS_HWINT4,
   MIPS_HWINT5,
+  MIPS_TIMER,
+  MIPS_PERF
 } mips_intr_t;
 
-#define MIPS_NIRQ 8 /* count of MIPS processor interrupt requests */
+#define MIPS_NIRQ 10 /* count of MIPS processor interrupt requests */
 
 #endif /* !_MACHDEP */
 


### PR DESCRIPTION
According to [MIPS32® 24KEf™ Processor Core Datasheet - _Interrupt Handling_](https://mimiker.ii.uni.wroc.pl/documents/MD00446-2B-24KEF-DTS-02.00.pdf)  and [MIPS® Malta™-R Development Platform
User’s Manual - _Table 4.16_ ](https://mimiker.ii.uni.wroc.pl/documents/MD00627-2B-MALTA_R-USM-01.01.pdf) we have also a timer and performance interrupts.