### PR TITLE
Only use physical bar numbers.

### DIFF
--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -91,7 +91,6 @@ typedef struct pci_device {
   uint8_t class_code;
   uint8_t pin, irq;
 
-  uint8_t nbars;
   pci_bar_t bar[PCI_BAR_MAX];
 } pci_device_t;
 

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -172,7 +172,7 @@ static int stdvga_attach(device_t *dev) {
   stdvga_state_t *stdvga = dev->state;
 
   stdvga->mem = device_take_memory(dev, 0, RF_ACTIVE | RF_PREFETCHABLE);
-  stdvga->io = device_take_memory(dev, 1, RF_ACTIVE);
+  stdvga->io = device_take_memory(dev, 2, RF_ACTIVE);
 
   assert(stdvga->mem != NULL);
   assert(stdvga->io != NULL);

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -113,16 +113,13 @@ void pci_bus_enumerate(device_t *pcib) {
         }
 
         size = -size;
-        uint8_t id = pcid->nbars;
-        pcid->bar[id] = (pci_bar_t){
-          .owner = dev, .type = type, .flags = flags, .size = size, .rid = id};
+        pcid->bar[i] = (pci_bar_t){
+          .owner = dev, .type = type, .flags = flags, .size = size, .rid = i};
 
         /* skip ISA I/O ports range */
         rman_addr_t start = (type == RT_IOPORTS) ? (IO_ISAEND + 1) : 0;
 
-        device_add_resource(dev, type, id, start, RMAN_ADDR_MAX, size, flags);
-
-        pcid->nbars++;
+        device_add_resource(dev, type, i, start, RMAN_ADDR_MAX, size, flags);
       }
     }
   }


### PR DESCRIPTION
Abandon the current approach which (incorrectly) tries to provide sequential bar numbers to a device driver. We should only rely on physical bar identifiers, which drivers must be aware of.