### PR TITLE
Enhance configuration space handling.

### DIFF
--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -79,7 +79,7 @@ typedef struct pci_bar {
   device_t *owner;   /* pci device owner of this bar */
   size_t size;       /* identified size of this bar */
   int rid;           /* BAR number in [0,PCI_BAR_MAX-1] */
-  unsigned type;     /* RT_IOPORTS or RT_MEMORY */
+  res_type_t type;   /* RT_IOPORTS or RT_MEMORY */
   bool prefetchable; /* states whether memory bar is prefetchable */
 } pci_bar_t;
 

--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -113,9 +113,9 @@ static inline void pci_write_config(device_t *device, unsigned reg,
   PCI_DRIVER(device)->pci_bus.write_config(device, reg, size, value);
 }
 
-#define pci_write_config_1(d, r, v) pci_write_config((d), (r), 1, v)
-#define pci_write_config_2(d, r, v) pci_write_config((d), (r), 2, v)
-#define pci_write_config_4(d, r, v) pci_write_config((d), (r), 4, v)
+#define pci_write_config_1(d, r, v) pci_write_config((d), (r), 1, (v))
+#define pci_write_config_2(d, r, v) pci_write_config((d), (r), 2, (v))
+#define pci_write_config_4(d, r, v) pci_write_config((d), (r), 4, (v))
 
 static inline void pci_enable_busmaster(device_t *device) {
   PCI_DRIVER(device)->pci_bus.enable_busmaster(device);

--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -76,11 +76,11 @@ typedef struct pci_bus_driver {
 } pci_bus_driver_t;
 
 typedef struct pci_bar {
-  device_t *owner; /* pci device owner of this bar */
-  size_t size;     /* identified size of this bar */
-  int rid;         /* BAR number in [0,PCI_BAR_MAX-1] */
-  unsigned type;   /* RT_IOPORTS or RT_MEMORY */
-  unsigned flags;  /* nothing or RF_PREFETACHBLE */
+  device_t *owner;   /* pci device owner of this bar */
+  size_t size;       /* identified size of this bar */
+  int rid;           /* BAR number in [0,PCI_BAR_MAX-1] */
+  unsigned type;     /* RT_IOPORTS or RT_MEMORY */
+  bool prefetchable; /* states whether memory bar is prefetchable */
 } pci_bar_t;
 
 typedef struct pci_device {
@@ -105,6 +105,24 @@ static inline uint32_t pci_read_config(device_t *device, unsigned reg,
 static inline void pci_write_config(device_t *device, unsigned reg,
                                     unsigned size, uint32_t value) {
   PCI_DRIVER(device)->pci_bus.write_config(device, reg, size, value);
+}
+
+/*! \brief Enable responding to memory space accesses. */
+static inline void pci_enable_memory(device_t *device) {
+  uint16_t cmd = pci_read_config(device, PCIR_COMMAND, 2);
+  pci_write_config(device, PCIR_COMMAND, 2, cmd | 0x2);
+}
+
+/*! \brief Enable responding to I/O space accesses. */
+static inline void pci_enable_io_ports(device_t *device) {
+  uint16_t cmd = pci_read_config(device, PCIR_COMMAND, 2);
+  pci_write_config(device, PCIR_COMMAND, 2, cmd | 0x1);
+}
+
+/*! \brief Enable the bus master mode. */
+static inline void pci_enable_bus_master(device_t *device) {
+  uint16_t cmd = pci_read_config(device, PCIR_COMMAND, 2);
+  pci_write_config(device, PCIR_COMMAND, 2, cmd | 0x4);
 }
 
 void pci_bus_enumerate(device_t *pcib);

--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -107,18 +107,6 @@ static inline void pci_write_config(device_t *device, unsigned reg,
   PCI_DRIVER(device)->pci_bus.write_config(device, reg, size, value);
 }
 
-/*! \brief Enable responding to memory space accesses. */
-static inline void pci_enable_memory(device_t *device) {
-  uint16_t cmd = pci_read_config(device, PCIR_COMMAND, 2);
-  pci_write_config(device, PCIR_COMMAND, 2, cmd | 0x2);
-}
-
-/*! \brief Enable responding to I/O space accesses. */
-static inline void pci_enable_io_ports(device_t *device) {
-  uint16_t cmd = pci_read_config(device, PCIR_COMMAND, 2);
-  pci_write_config(device, PCIR_COMMAND, 2, cmd | 0x1);
-}
-
 /*! \brief Enable the bus master mode. */
 static inline void pci_enable_bus_master(device_t *device) {
   uint16_t cmd = pci_read_config(device, PCIR_COMMAND, 2);

--- a/sys/aarch64/rootdev.c
+++ b/sys/aarch64/rootdev.c
@@ -277,7 +277,7 @@ static void rootdev_release_resource(device_t *dev, res_type_t type, resource_t 
 
 static int rootdev_activate_resource(device_t *dev, res_type_t type, resource_t *r) {
   if (type == RT_MEMORY)
-    return bus_space_map(r->r_bus_tag, r->r_bus_handle, resource_size(r),
+    return bus_space_map(r->r_bus_tag, r->r_start, resource_size(r),
                          &r->r_bus_handle);
   return 0;
 }

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -162,7 +162,7 @@ static int stdvga_probe(device_t *dev) {
   if (!pci_device_match(pcid, QEMU_STDVGA_VENDOR_ID, QEMU_STDVGA_DEVICE_ID))
     return 0;
 
-  if (!(pcid->bar[0].flags & RF_PREFETCHABLE))
+  if (!(pcid->bar[0].prefetchable))
     return 0;
 
   return 1;
@@ -176,6 +176,8 @@ static int stdvga_attach(device_t *dev) {
 
   assert(stdvga->mem != NULL);
   assert(stdvga->io != NULL);
+
+  pci_enable_memory(dev);
 
   stdvga->vga = (vga_device_t){
     .palette_write = stdvga_palette_write,

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -162,7 +162,7 @@ static int stdvga_probe(device_t *dev) {
   if (!pci_device_match(pcid, QEMU_STDVGA_VENDOR_ID, QEMU_STDVGA_DEVICE_ID))
     return 0;
 
-  if (!(pcid->bar[0].prefetchable))
+  if (!(pcid->bar[0].flags & RF_PREFETCHABLE))
     return 0;
 
   return 1;

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -177,8 +177,6 @@ static int stdvga_attach(device_t *dev) {
   assert(stdvga->mem != NULL);
   assert(stdvga->io != NULL);
 
-  pci_enable_memory(dev);
-
   stdvga->vga = (vga_device_t){
     .palette_write = stdvga_palette_write,
     .fb_write = stdvga_fb_write,

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -39,7 +39,7 @@ static int pci_device_nfunctions(device_t *pcid) {
    * no more functions are present. */
   if (!pci_device_present(pcid))
     return 0;
-  uint32_t hdrtype = pci_read_config_1(pcid, PCIR_HEADERTYPE);
+  uint8_t hdrtype = pci_read_config_1(pcid, PCIR_HEADERTYPE);
   return (hdrtype & PCIH_HDR_MF) ? PCI_FUN_MAX_NUM : 1;
 }
 
@@ -54,7 +54,8 @@ static uint32_t pci_bar_size(device_t *pcid, int bar, uint32_t *addr) {
   uint32_t old = pci_read_config_4(pcid, PCIR_BAR(bar));
   /* XXX: we don't handle 64-bit memory space bars. */
 
-  /* Write 0xFFFFFFFF and read it back. */
+  /* If we write 0xFFFFFFFF to a BAR register and then read
+   * it back, we'll obtain a bar size indicator. */
   pci_write_config_4(pcid, PCIR_BAR(bar), -1);
   uint32_t size = pci_read_config_4(pcid, PCIR_BAR(bar));
 

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -54,7 +54,7 @@ static uint32_t pci_bar_size(device_t *pcid, int bar, uint32_t *addr) {
   /* XXX: we don't handle 64-bit memory space bars. */
 
   /* If we write 0xFFFFFFFF to a BAR register and then read
-   * it back, we'll obtain a bar size indicator. */
+   * it back, we'll get a bar size indicator. */
   pci_write_config_4(pcid, PCIR_BAR(bar), -1);
   uint32_t size = pci_read_config_4(pcid, PCIR_BAR(bar));
 

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -109,11 +109,6 @@ void pci_bus_enumerate(device_t *pcib) {
       pcid->pin = pci_read_config(dev, PCIR_IRQPIN, 1);
       pcid->irq = pci_read_config(dev, PCIR_IRQLINE, 1);
 
-      /* We need to enable memory space accesses
-       * or/and IO space accesses based on type of
-       * bars owned by device. */
-      uint16_t access_mask = 0x0000;
-
       /* XXX: we assume here that `dev` is a general PCI device
        * (i.e. header type = 0x00) and therefore has six bars. */
       for (int i = 0; i < PCI_BAR_MAX; i++) {
@@ -129,13 +124,11 @@ void pci_bus_enumerate(device_t *pcib) {
         if (addr & PCI_BAR_IO) {
           type = RT_IOPORTS;
           size &= ~PCI_BAR_IO_MASK;
-          access_mask |= 0x0002;
         } else {
           type = RT_MEMORY;
           if (addr & PCI_BAR_PREFETCHABLE)
             prefetchable = true;
           size &= ~PCI_BAR_MEMORY_MASK;
-          access_mask |= 0x0001;
         }
 
         size = -size;
@@ -154,10 +147,6 @@ void pci_bus_enumerate(device_t *pcib) {
 
         pcid->nbars++;
       }
-
-      /* Enable accesses based on the `access_mask` value. */
-      uint16_t cmd = pci_read_config(dev, PCIR_COMMAND, 2);
-      pci_write_config(dev, PCIR_COMMAND, 2, cmd | access_mask);
     }
   }
 

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -50,7 +50,6 @@ static uint32_t pci_bar_size(device_t *pcid, int bar, uint32_t *addr) {
   pci_write_config_2(pcid, PCIR_COMMAND,
                      cmd & ~(PCIM_CMD_MEMEN | PCIM_CMD_PORTEN));
 
-  /* Read the original value. */
   uint32_t old = pci_read_config_4(pcid, PCIR_BAR(bar));
   /* XXX: we don't handle 64-bit memory space bars. */
 
@@ -61,8 +60,6 @@ static uint32_t pci_bar_size(device_t *pcid, int bar, uint32_t *addr) {
 
   /* The original value of the BAR should be restored. */
   pci_write_config_4(pcid, PCIR_BAR(bar), old);
-
-  /* Restore the command register. */
   pci_write_config_2(pcid, PCIR_COMMAND, cmd);
 
   *addr = old;

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -109,6 +109,11 @@ void pci_bus_enumerate(device_t *pcib) {
       pcid->pin = pci_read_config(dev, PCIR_IRQPIN, 1);
       pcid->irq = pci_read_config(dev, PCIR_IRQLINE, 1);
 
+      /* We need to enable memory space accesses
+       * or/and IO space accesses based on type of
+       * bars owned by device. */
+      uint16_t access_mask = 0x0000;
+
       /* XXX: we assume here that `dev` is a general PCI device
        * (i.e. header type = 0x00) and therefore has six bars. */
       for (int i = 0; i < PCI_BAR_MAX; i++) {
@@ -124,11 +129,13 @@ void pci_bus_enumerate(device_t *pcib) {
         if (addr & PCI_BAR_IO) {
           type = RT_IOPORTS;
           size &= ~PCI_BAR_IO_MASK;
+          access_mask |= 0x0002;
         } else {
           type = RT_MEMORY;
           if (addr & PCI_BAR_PREFETCHABLE)
             prefetchable = true;
           size &= ~PCI_BAR_MEMORY_MASK;
+          access_mask |= 0x0001;
         }
 
         size = -size;
@@ -147,6 +154,10 @@ void pci_bus_enumerate(device_t *pcib) {
 
         pcid->nbars++;
       }
+
+      /* Enable accesses based on the `access_mask` value. */
+      uint16_t cmd = pci_read_config(dev, PCIR_COMMAND, 2);
+      pci_write_config(dev, PCIR_COMMAND, 2, cmd | access_mask);
     }
   }
 

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -147,8 +147,6 @@ void pci_bus_enumerate(device_t *pcib) {
 }
 
 /* TODO: to be replaced with GDB python script */
-
-/* TODO: to be replaced with GDB python script */
 void pci_bus_dump(device_t *pcib) {
   device_t *dev;
 

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -342,10 +342,11 @@ static int gt_pci_attach(device_t *pcib) {
 
 static bool gt_pci_bar(device_t *dev, res_type_t type, int rid,
                        rman_addr_t start) {
+  /* Filter ISA IO ports and irq resources. */
+  if (!((type == RT_IOPORTS && start > IO_ISAEND) || type == RT_MEMORY))
+    return false;
   pci_device_t *pcid = pci_device_of(dev);
-  if ((type == RT_IOPORTS && start > IO_ISAEND) || type == RT_MEMORY)
-    return rid < PCI_BAR_MAX && pcid->bar[rid].size != 0;
-  return false;
+  return rid < PCI_BAR_MAX && pcid->bar[rid].size != 0;
 }
 
 static resource_t *gt_pci_alloc_resource(device_t *dev, res_type_t type,

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -419,7 +419,7 @@ static int gt_pci_activate_resource(device_t *dev, res_type_t type,
   if (gt_pci_bar(dev, type, rid, r->r_start)) {
     /* Write BAR address to PCI device register.
      * Note that in case of IO ports, BAR needs to contain
-     * a relative addres (relative to PCI IO base).
+     * a relative address (relative to PCI IO base).
      * Memory BARs should keep absolute physical addresses. */
     pci_write_config_4(dev, PCIR_BAR(rid), r->r_start);
   }

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -428,6 +428,15 @@ static int gt_pci_activate_resource(device_t *dev, res_type_t type,
     }
     /* Write BAR address to PCI device register. */
     pci_write_config(dev, PCIR_BAR(rid), 4, addr);
+
+    if (type == RT_IOPORTS) {
+      /* After we used physical address to update bar contents,
+       * we need to suply the resource with the virtual address
+       * (for future bus reads/writes). */
+      gt_pci_state_t *gtpci = dev->parent->state;
+      rman_addr_t offset = r->r_bus_handle - gtpci->pci_io->r_start;
+      r->r_bus_handle = gtpci->pci_io->r_bus_handle + offset;
+    }
   }
 
   if (type == RT_MEMORY)

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -342,8 +342,7 @@ static int gt_pci_attach(device_t *pcib) {
 
 static bool gt_pci_bar(device_t *dev, res_type_t type, int rid,
                        rman_addr_t start) {
-  /* Filter ISA IO ports and irq resources. */
-  if (!((type == RT_IOPORTS && start > IO_ISAEND) || type == RT_MEMORY))
+  if ((type == RT_IOPORTS && start <= IO_ISAEND) || type == RT_IRQ)
     return false;
   pci_device_t *pcid = pci_device_of(dev);
   return rid < PCI_BAR_MAX && pcid->bar[rid].size != 0;
@@ -419,9 +418,8 @@ static int gt_pci_activate_resource(device_t *dev, res_type_t type,
   int rid = r->r_rid;
   if (gt_pci_bar(dev, type, rid, r->r_start)) {
     /* Write BAR address to PCI device register.
-     * Note that in case of IO ports, BAR needs to contain
-     * a relative address (relative to PCI IO base).
-     * Memory BARs should keep absolute physical addresses. */
+     * Note that IO ports require relative addresses
+     * whereas memory involves absolute addresses. */
     pci_write_config_4(dev, PCIR_BAR(rid), r->r_start);
   }
 

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -410,22 +410,14 @@ static int gt_pci_activate_resource(device_t *dev, res_type_t type,
     pci_write_config(dev, PCIR_COMMAND, 2, command);
   }
 
-  rman_addr_t paddr = r->r_start;
   int rid = r->r_rid;
-
   if (gt_pci_bar(dev, type, rid, r->r_start)) {
-    /* Obtain the physical address. */
-    if (type == RT_IOPORTS) {
-      gt_pci_state_t *gtpci = dev->parent->state;
-      paddr = gtpci->pci_io->r_start + r->r_start;
-    }
-
     /* Write BAR address to PCI device register. */
-    pci_write_config(dev, PCIR_BAR(rid), 4, paddr);
+    pci_write_config(dev, PCIR_BAR(rid), 4, r->r_start);
   }
 
   if (type == RT_MEMORY)
-    return bus_space_map(r->r_bus_tag, paddr, resource_size(r),
+    return bus_space_map(r->r_bus_tag, r->r_start, resource_size(r),
                          &r->r_bus_handle);
 
   return 0;

--- a/sys/mips/rootdev.c
+++ b/sys/mips/rootdev.c
@@ -106,7 +106,7 @@ static void rootdev_release_resource(device_t *dev, res_type_t type,
 static int rootdev_activate_resource(device_t *dev, res_type_t type,
                                      resource_t *r) {
   if (type == RT_MEMORY)
-    return bus_space_map(r->r_bus_tag, r->r_bus_handle, resource_size(r),
+    return bus_space_map(r->r_bus_tag, r->r_start, resource_size(r),
                          &r->r_bus_handle);
 
   return 0;


### PR DESCRIPTION
- Disable memory/IO accesses during PCI bar sizing (as required by the specification).
- Add function which enables bus master mode for a device.
- Write address to a BAR register while activating a `RT_IOPORTS` resource (RTL8139 and USB controller use `RT_IOPORTS` bars).