### PR TITLE
Add launcher option to select UARTs that should be run in raw mode.

### DIFF
--- a/launch
+++ b/launch
@@ -5,6 +5,7 @@ import os
 import os.path
 import subprocess
 import sys
+import re
 
 from launcher import *
 
@@ -75,6 +76,8 @@ if __name__ == '__main__':
                         help='Enable VGA output.')
     parser.add_argument('-b', '--board', default='malta',
                         choices=['malta', 'rpi3'], help='Emulated board.')
+    parser.add_argument('-r', '--raw', type=str,
+                        help='(regex) UARTs to run in raw mode')
     args = parser.parse_args()
 
     # Used by tmux to override ./.tmux.conf with ./.tmux.conf.local
@@ -115,7 +118,9 @@ if __name__ == '__main__':
     else:
         dbg = None
 
-    uarts = [SOCAT(uart['name'], uart['port'], uart.get('raw', False))
+    raw_regex = re.compile(args.raw)
+    uarts = [SOCAT(uart['name'], uart['port'],
+                   bool(raw_regex.search(uart['name'])))
              for uart in getvar('qemu.uarts')]
 
     if args.test_run:


### PR DESCRIPTION
Add support for selecting raw mode UARTs from the command line.
We should also consider running `/dev/tty1` in raw mode by default, since we now have a working TTY subsystem.