### PR TITLE
launcher: run socat on /dev/tty1 in raw mode by default.

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -54,7 +54,7 @@ CONFIG = {
                     '-machine', 'malta',
                     '-cpu', '24Kf'],
                 'uarts': [
-                    dict(name='/dev/tty1', port=uart_port(0)),
+                    dict(name='/dev/tty1', port=uart_port(0), raw=True),
                     dict(name='/dev/tty2', port=uart_port(1)),
                     dict(name='/dev/cons', port=uart_port(2))
                 ]


### PR DESCRIPTION
At this point our TTY subsystem has enough features to handle raw input. 