### PR TITLE
Implement locking mechanism for pv_list in vm_page_t structure

### DIFF
--- a/include/sys/vm.h
+++ b/include/sys/vm.h
@@ -43,13 +43,13 @@ typedef struct vm_object vm_object_t;
 typedef struct slab slab_t;
 
 /* Field marking and corresponding locks:
- * (@) pmap.c::pv_list_lock
- * (P) vm_physmem.c::physmem_lock
+ * (@) pv_list_lock (in pmap.c)
+ * (P) physmem_lock (in vm_physmem.c)
  * (O) vm_object::mtx */
 
 struct vm_page {
   union {
-    TAILQ_ENTRY(vm_page) freeq; /* list of free pages for buddy system */
+    TAILQ_ENTRY(vm_page) freeq; /* (P) list of free pages for buddy system */
     TAILQ_ENTRY(vm_page) pageq; /* used to group allocated pages */
     struct {
       TAILQ_ENTRY(vm_page) list;

--- a/include/sys/vm.h
+++ b/include/sys/vm.h
@@ -44,6 +44,11 @@ typedef struct pv_entry pv_entry_t;
 typedef struct vm_object vm_object_t;
 typedef struct slab slab_t;
 
+/* Field marking and corresponding locks:
+ * (@) pmap.c::pv_list_lock
+ * (P) vm_physmem.c::physmem_lock
+ * (O) vm_object::mtx */
+
 struct vm_page {
   union {
     TAILQ_ENTRY(vm_page) freeq; /* list of free pages for buddy system */
@@ -51,15 +56,15 @@ struct vm_page {
     struct {
       TAILQ_ENTRY(vm_page) list;
       RB_ENTRY(vm_page) tree;
-    } obj;
+    } obj;        /* (O) list of pages in vm_object */
     slab_t *slab; /* active when page is used by pool allocator */
   };
-  TAILQ_HEAD(, pv_entry) pv_list; /* where this page is mapped? */
-  vm_object_t *object;            /* object owning that page */
-  off_t offset;                   /* offset to page in vm_object */
-  paddr_t paddr;                  /* physical address of page */
-  pg_flags_t flags;               /* page flags (used by physmem as well) */
-  uint32_t size;                  /* size of page in PAGESIZE units */
+  TAILQ_HEAD(, pv_entry) pv_list; /* (@) where this page is mapped? */
+  vm_object_t *object;            /* (O) object owning that page */
+  off_t offset;                   /* (O) offset to page in vm_object */
+  paddr_t paddr;                  /* (P) physical address of page */
+  pg_flags_t flags;               /* (P) page flags (used by physmem as well) */
+  uint32_t size;                  /* (P) size of page in PAGESIZE units */
 };
 
 int do_mmap(vaddr_t *addr_p, size_t length, int u_prot, int u_flags);

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -55,6 +55,8 @@ static pmap_t kernel_pmap;
 paddr_t _kernel_pmap_pde;
 static bitstr_t asid_used[bitstr_size(MAX_ASID)] = {0};
 static spin_t *asid_lock = &SPIN_INITIALIZER(0);
+
+/* this lock is used to protect the vm_page::pv_list field */
 static mtx_t *pv_list_lock = &MTX_INITIALIZER(0);
 
 #define PTE_FRAME_ADDR(pte) ((pte)&PA_MASK)

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -376,7 +376,8 @@ void pmap_remove(pmap_t *pmap, vaddr_t start, vaddr_t end) {
       if (pa == 0)
         continue;
       vm_page_t *pg = vm_page_find(pa);
-      WITH_MTX_LOCK (pv_list_lock) { pv_remove(pmap, va, pg); }
+      WITH_MTX_LOCK (pv_list_lock)
+        pv_remove(pmap, va, pg);
       pmap_write_pte(pmap, ptep, 0);
     }
   }
@@ -516,7 +517,8 @@ void pmap_delete(pmap_t *pmap) {
     paddr_t pa;
     pmap_extract_nolock(pmap, pv->va, &pa);
     pg = vm_page_find(pa);
-    WITH_MTX_LOCK (pv_list_lock) { TAILQ_REMOVE(&pg->pv_list, pv, page_link); }
+    WITH_MTX_LOCK (pv_list_lock)
+      TAILQ_REMOVE(&pg->pv_list, pv, page_link);
     TAILQ_REMOVE(&pmap->pv_list, pv, pmap_link);
     pool_free(P_PV, pv);
   }

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -55,6 +55,7 @@ static pmap_t kernel_pmap;
 paddr_t _kernel_pmap_pde;
 static bitstr_t asid_used[bitstr_size(MAX_ASID)] = {0};
 static spin_t *asid_lock = &SPIN_INITIALIZER(0);
+static mtx_t *pv_list_lock = &MTX_INITIALIZER(0);
 
 #define PTE_FRAME_ADDR(pte) ((pte)&PA_MASK)
 #define PAGE_OFFSET(x) ((x) & (PAGESIZE - 1))
@@ -131,6 +132,7 @@ static void free_asid(asid_t asid) {
  */
 
 static void pv_add(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
+  assert(mtx_owned(pv_list_lock));
   pv_entry_t *pv = pool_alloc(P_PV, M_ZERO);
   pv->pmap = pmap;
   pv->va = va;
@@ -139,6 +141,7 @@ static void pv_add(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
 }
 
 static pv_entry_t *pv_find(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
+  assert(mtx_owned(pv_list_lock));
   pv_entry_t *pv;
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     if (pv->pmap == pmap && pv->va == va)
@@ -148,6 +151,7 @@ static pv_entry_t *pv_find(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
 }
 
 static void pv_remove(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
+  assert(mtx_owned(pv_list_lock));
   pv_entry_t *pv = pv_find(pmap, va, pg);
   assert(pv != NULL);
   TAILQ_REMOVE(&pg->pv_list, pv, page_link);
@@ -341,9 +345,11 @@ void pmap_enter(pmap_t *pmap, vaddr_t va, vm_page_t *pg, vm_prot_t prot,
   pte_t pte = make_pte(pa, prot, flags);
 
   WITH_MTX_LOCK (&pmap->mtx) {
-    pv_entry_t *pv = pv_find(pmap, va, pg);
-    if (pv == NULL)
-      pv_add(pmap, va, pg);
+    WITH_MTX_LOCK (pv_list_lock) {
+      pv_entry_t *pv = pv_find(pmap, va, pg);
+      if (pv == NULL)
+        pv_add(pmap, va, pg);
+    }
     if (kern_mapping)
       pg->flags |= PG_MODIFIED | PG_REFERENCED;
     else
@@ -368,7 +374,7 @@ void pmap_remove(pmap_t *pmap, vaddr_t start, vaddr_t end) {
       if (pa == 0)
         continue;
       vm_page_t *pg = vm_page_find(pa);
-      pv_remove(pmap, va, pg);
+      WITH_MTX_LOCK (pv_list_lock) { pv_remove(pmap, va, pg); }
       pmap_write_pte(pmap, ptep, 0);
     }
   }
@@ -398,6 +404,8 @@ bool pmap_extract(pmap_t *pmap, vaddr_t va, paddr_t *pap) {
 }
 
 void pmap_page_remove(vm_page_t *pg) {
+  SCOPED_MTX_LOCK(pv_list_lock);
+
   while (!TAILQ_EMPTY(&pg->pv_list)) {
     pv_entry_t *pv = TAILQ_FIRST(&pg->pv_list);
     pmap_t *pmap = pv->pmap;
@@ -420,6 +428,7 @@ void pmap_copy_page(vm_page_t *src, vm_page_t *dst) {
 }
 
 static void pmap_modify_flags(vm_page_t *pg, pte_t set, pte_t clr) {
+  SCOPED_MTX_LOCK(pv_list_lock);
   pv_entry_t *pv;
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     pmap_t *pmap = pv->pmap;
@@ -505,7 +514,7 @@ void pmap_delete(pmap_t *pmap) {
     paddr_t pa;
     pmap_extract_nolock(pmap, pv->va, &pa);
     pg = vm_page_find(pa);
-    TAILQ_REMOVE(&pg->pv_list, pv, page_link);
+    WITH_MTX_LOCK (pv_list_lock) { TAILQ_REMOVE(&pg->pv_list, pv, page_link); }
     TAILQ_REMOVE(&pmap->pv_list, pv, pmap_link);
     pool_free(P_PV, pv);
   }

--- a/sys/mips/pmap.c
+++ b/sys/mips/pmap.c
@@ -46,7 +46,6 @@ static pmap_t kernel_pmap;
 pde_t *_kernel_pmap_pde;
 static bitstr_t asid_used[bitstr_size(MAX_ASID)] = {0};
 static spin_t *asid_lock = &SPIN_INITIALIZER(0);
-
 static mtx_t *pv_list_lock = &MTX_INITIALIZER(0);
 
 #define PDE_OF(pmap, vaddr) ((pmap)->pde[PDE_INDEX(vaddr)])
@@ -399,8 +398,8 @@ void pmap_copy_page(vm_page_t *src, vm_page_t *dst) {
 }
 
 static void pmap_modify_flags(vm_page_t *pg, pte_t set, pte_t clr) {
-  pv_entry_t *pv;
   SCOPED_MTX_LOCK(pv_list_lock);
+  pv_entry_t *pv;
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     pmap_t *pmap = pv->pmap;
     vaddr_t va = pv->va;

--- a/sys/mips/pmap.c
+++ b/sys/mips/pmap.c
@@ -46,6 +46,8 @@ static pmap_t kernel_pmap;
 pde_t *_kernel_pmap_pde;
 static bitstr_t asid_used[bitstr_size(MAX_ASID)] = {0};
 static spin_t *asid_lock = &SPIN_INITIALIZER(0);
+
+/* this lock is used to protect the vm_page::pv_list field */
 static mtx_t *pv_list_lock = &MTX_INITIALIZER(0);
 
 #define PDE_OF(pmap, vaddr) ((pmap)->pde[PDE_INDEX(vaddr)])

--- a/sys/mips/pmap.c
+++ b/sys/mips/pmap.c
@@ -347,7 +347,8 @@ void pmap_remove(pmap_t *pmap, vaddr_t start, vaddr_t end) {
       paddr_t pa;
       if (pmap_extract_nolock(pmap, va, &pa)) {
         vm_page_t *pg = vm_page_find(pa);
-        WITH_MTX_LOCK (pv_list_lock) { pv_remove(pmap, va, pg); }
+        WITH_MTX_LOCK (pv_list_lock)
+          pv_remove(pmap, va, pg);
         pmap_pte_write(pmap, va, empty_pte(pmap), 0);
       }
     }
@@ -484,7 +485,8 @@ void pmap_delete(pmap_t *pmap) {
     paddr_t pa;
     pmap_extract_nolock(pmap, pv->va, &pa);
     pg = vm_page_find(pa);
-    WITH_MTX_LOCK (pv_list_lock) { TAILQ_REMOVE(&pg->pv_list, pv, page_link); }
+    WITH_MTX_LOCK (pv_list_lock)
+      TAILQ_REMOVE(&pg->pv_list, pv, page_link);
     TAILQ_REMOVE(&pmap->pv_list, pv, pmap_link);
     pool_free(P_PV, pv);
   }

--- a/sys/mips/pmap.c
+++ b/sys/mips/pmap.c
@@ -47,6 +47,8 @@ pde_t *_kernel_pmap_pde;
 static bitstr_t asid_used[bitstr_size(MAX_ASID)] = {0};
 static spin_t *asid_lock = &SPIN_INITIALIZER(0);
 
+static mtx_t *pv_list_lock = &MTX_INITIALIZER(0);
+
 #define PDE_OF(pmap, vaddr) ((pmap)->pde[PDE_INDEX(vaddr)])
 #define PT_BASE(pde) ((pte_t *)(((pde) >> PTE_PFN_SHIFT) << PTE_INDEX_SHIFT))
 #define PTE_OF(pde, vaddr) (PT_BASE(pde)[PTE_INDEX(vaddr)])
@@ -135,6 +137,7 @@ static void free_asid(asid_t asid) {
  */
 
 static void pv_add(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
+  assert(mtx_owned(pv_list_lock));
   pv_entry_t *pv = pool_alloc(P_PV, M_ZERO);
   pv->pmap = pmap;
   pv->va = va;
@@ -143,6 +146,7 @@ static void pv_add(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
 }
 
 static pv_entry_t *pv_find(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
+  assert(mtx_owned(pv_list_lock));
   pv_entry_t *pv;
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     if (pv->pmap == pmap && pv->va == va)
@@ -152,6 +156,7 @@ static pv_entry_t *pv_find(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
 }
 
 static void pv_remove(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
+  assert(mtx_owned(pv_list_lock));
   pv_entry_t *pv = pv_find(pmap, va, pg);
   assert(pv != NULL);
   TAILQ_REMOVE(&pg->pv_list, pv, page_link);
@@ -317,9 +322,11 @@ void pmap_enter(pmap_t *pmap, vaddr_t va, vm_page_t *pg, vm_prot_t prot,
   pte_t pte = (vm_prot_map[prot] & mask) | empty_pte(pmap);
 
   WITH_MTX_LOCK (&pmap->mtx) {
-    pv_entry_t *pv = pv_find(pmap, va, pg);
-    if (pv == NULL)
-      pv_add(pmap, va, pg);
+    WITH_MTX_LOCK (pv_list_lock) {
+      pv_entry_t *pv = pv_find(pmap, va, pg);
+      if (pv == NULL)
+        pv_add(pmap, va, pg);
+    }
     if (kern_mapping)
       pg->flags |= PG_MODIFIED | PG_REFERENCED;
     else
@@ -339,7 +346,7 @@ void pmap_remove(pmap_t *pmap, vaddr_t start, vaddr_t end) {
       paddr_t pa;
       if (pmap_extract_nolock(pmap, va, &pa)) {
         vm_page_t *pg = vm_page_find(pa);
-        pv_remove(pmap, va, pg);
+        WITH_MTX_LOCK (pv_list_lock) { pv_remove(pmap, va, pg); }
         pmap_pte_write(pmap, va, empty_pte(pmap), 0);
       }
     }
@@ -371,6 +378,7 @@ bool pmap_extract(pmap_t *pmap, vaddr_t va, paddr_t *pap) {
 }
 
 void pmap_page_remove(vm_page_t *pg) {
+  SCOPED_MTX_LOCK(pv_list_lock);
   while (!TAILQ_EMPTY(&pg->pv_list)) {
     pv_entry_t *pv = TAILQ_FIRST(&pg->pv_list);
     pmap_t *pmap = pv->pmap;
@@ -392,6 +400,7 @@ void pmap_copy_page(vm_page_t *src, vm_page_t *dst) {
 
 static void pmap_modify_flags(vm_page_t *pg, pte_t set, pte_t clr) {
   pv_entry_t *pv;
+  SCOPED_MTX_LOCK(pv_list_lock);
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     pmap_t *pmap = pv->pmap;
     vaddr_t va = pv->va;
@@ -468,14 +477,13 @@ pmap_t *pmap_new(void) {
 
 void pmap_delete(pmap_t *pmap) {
   assert(pmap != pmap_kernel());
-
   while (!TAILQ_EMPTY(&pmap->pv_list)) {
     pv_entry_t *pv = TAILQ_FIRST(&pmap->pv_list);
     vm_page_t *pg;
     paddr_t pa;
     pmap_extract_nolock(pmap, pv->va, &pa);
     pg = vm_page_find(pa);
-    TAILQ_REMOVE(&pg->pv_list, pv, page_link);
+    WITH_MTX_LOCK (pv_list_lock) { TAILQ_REMOVE(&pg->pv_list, pv, page_link); }
     TAILQ_REMOVE(&pmap->pv_list, pv, pmap_link);
     pool_free(P_PV, pv);
   }


### PR DESCRIPTION
Now pv_list in vm_page_t structure isn't protected by any mechanism. That can lead to many races when we will try to share our resources. This PR will introduce lock for all pv_list to protect our data and in the same time - to save some memory by using only one lock for all pv_list data structures.