### PR TITLE
tty: notify driver when there's space in the input queue.

### DIFF
--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -171,7 +171,8 @@ static void ns16550_tty_thread(void *arg) {
       if (work & TTY_THREAD_RXRDY) {
         /* Move characters from rx_buf into the tty's input queue. */
         while (ns16550_getb_lock(ns16550, &byte))
-          tty_input(tty, byte);
+          if (!tty_input(tty, byte))
+            klog("dropped character %hhx", byte);
       }
       if (work & TTY_THREAD_TXRDY) {
         ns16550_fill_txbuf(ns16550, tty);

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -186,6 +186,12 @@ static void tty_notify_out(tty_t *tty) {
   }
 }
 
+static void tty_notify_in(tty_t *tty) {
+  assert(mtx_owned(&tty->t_lock));
+  if (tty->t_ops.t_notify_in)
+    tty->t_ops.t_notify_in(tty);
+}
+
 /* Line buffer helper functions */
 static bool tty_line_putc(tty_t *tty, uint8_t c) {
   linebuf_t *line = &tty->t_line;
@@ -517,8 +523,7 @@ static void tty_check_in_lowat(tty_t *tty) {
 
   if (tty->t_inq.count < TTY_IN_LOW_WATER) {
     tty->t_flags &= ~TF_IN_HIWAT;
-    if (tty->t_ops.t_notify_in)
-      tty->t_ops.t_notify_in(tty);
+    tty_notify_in(tty);
   }
 }
 

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -510,6 +510,8 @@ bool tty_input(tty_t *tty, uint8_t c) {
 }
 
 static void tty_check_in_lowat(tty_t *tty) {
+  assert(mtx_owned(&tty->t_lock));
+
   if (!(tty->t_flags & TF_IN_HIWAT))
     return;
 


### PR DESCRIPTION
This PR kicks off a series of (hopefully small) PRs with an end goal of implementing pseudoterminals.
Why we need this PR:
`write()` calls on a PTY master device can block due to the slave device's input queue being full. We need some means of notifying the master that space has become available.