### PR TITLE
Track TTY open() and close() calls.

### DIFF
--- a/include/sys/tty.h
+++ b/include/sys/tty.h
@@ -116,8 +116,6 @@ typedef struct tty {
 #define t_oflag t_termios.c_oflag
 #define t_ospeed t_termios.c_ospeed
 
-extern vnodeops_t tty_vnodeops;
-
 /*
  * Allocate and initialize a new `tty` structure.
  */

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -232,7 +232,7 @@ static int ns16550_attach(device_t *dev) {
   out(ns16550->regs, IER, IER_ERXRDY | IER_ETXRDY);
 
   /* Prepare /dev/uart interface. */
-  devfs_makedev(NULL, "uart", &tty_vnodeops, ns16550->tty, &tty->t_vnode);
+  tty_makedev(NULL, "uart", tty);
 
   return 0;
 }

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -909,7 +909,7 @@ static void maybe_assoc_ctty(proc_t *p, tty_t *tty) {
   tty->t_pgrp = p->p_pgrp;
 }
 
-static int __tty_vn_open(vnode_t *v, int mode, file_t *fp) {
+static int _tty_vn_open(vnode_t *v, int mode, file_t *fp) {
   tty_t *tty = devfs_node_data(v);
   proc_t *p = proc_self();
   int error;
@@ -933,7 +933,7 @@ static int __tty_vn_open(vnode_t *v, int mode, file_t *fp) {
 
 static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
   SCOPED_MTX_LOCK(all_proc_mtx);
-  return __tty_vn_open(v, mode, fp);
+  return _tty_vn_open(v, mode, fp);
 }
 
 static vnodeops_t tty_vnodeops = {.v_open = tty_vn_open,
@@ -953,7 +953,7 @@ static int dev_tty_open(vnode_t *v, int mode, file_t *fp) {
   if (!tty)
     return ENXIO;
 
-  return __tty_vn_open(tty->t_vnode, mode, fp);
+  return _tty_vn_open(tty->t_vnode, mode, fp);
 }
 
 static vnodeops_t dev_tty_vnodeops = {.v_open = dev_tty_open};

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -925,7 +925,8 @@ static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
   return __tty_vn_open(v, mode, fp, true);
 }
 
-vnodeops_t tty_vnodeops = {.v_open = tty_vn_open, .v_close = tty_vn_close};
+static vnodeops_t tty_vnodeops = {.v_open = tty_vn_open,
+                                  .v_close = tty_vn_close};
 
 int tty_makedev(devfs_node_t *parent, const char *name, tty_t *tty) {
   return devfs_makedev(parent, name, &tty_vnodeops, tty, &tty->t_vnode);

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -909,7 +909,7 @@ static void maybe_assoc_ctty(proc_t *p, tty_t *tty) {
   tty->t_pgrp = p->p_pgrp;
 }
 
-static int __tty_vn_open(vnode_t *v, int mode, file_t *fp, bool assoc) {
+static int __tty_vn_open(vnode_t *v, int mode, file_t *fp) {
   tty_t *tty = devfs_node_data(v);
   proc_t *p = proc_self();
   int error;
@@ -918,8 +918,7 @@ static int __tty_vn_open(vnode_t *v, int mode, file_t *fp, bool assoc) {
     return error;
 
   WITH_MTX_LOCK (&tty->t_lock) {
-    if (assoc)
-      maybe_assoc_ctty(p, tty);
+    maybe_assoc_ctty(p, tty);
 
     tty->t_opencount++;
 
@@ -934,7 +933,7 @@ static int __tty_vn_open(vnode_t *v, int mode, file_t *fp, bool assoc) {
 
 static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
   SCOPED_MTX_LOCK(all_proc_mtx);
-  return __tty_vn_open(v, mode, fp, true);
+  return __tty_vn_open(v, mode, fp);
 }
 
 static vnodeops_t tty_vnodeops = {.v_open = tty_vn_open,
@@ -954,7 +953,7 @@ static int dev_tty_open(vnode_t *v, int mode, file_t *fp) {
   if (!tty)
     return ENXIO;
 
-  return __tty_vn_open(tty->t_vnode, mode, fp, false);
+  return __tty_vn_open(tty->t_vnode, mode, fp);
 }
 
 static vnodeops_t dev_tty_vnodeops = {.v_open = dev_tty_open};

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -169,12 +169,13 @@ tty_t *tty_alloc(void) {
   tty->t_line.ln_size = LINEBUF_SIZE;
   tty->t_line.ln_count = 0;
   tty_init_termios(&tty->t_termios);
-  tty->t_ops.t_notify_out = NULL;
+  tty->t_ops = (ttyops_t){0};
   tty->t_data = NULL;
   tty->t_column = 0;
   tty->t_rocol = tty->t_rocount = 0;
   tty->t_vnode = NULL;
   tty->t_flags = 0;
+  tty->t_opencount = 0;
   return tty;
 }
 
@@ -737,7 +738,12 @@ static void tty_drain_out(tty_t *tty) {
 }
 
 static int tty_vn_close(vnode_t *v, file_t *fp) {
-  /* TODO implement. */
+  tty_t *tty = v->v_data;
+  SCOPED_MTX_LOCK(&tty->t_lock);
+  assert(tty->t_opencount > 0);
+  tty->t_opencount--;
+  if (tty->t_opencount == 0 && tty->t_ops.t_notify_inactive)
+    tty->t_ops.t_notify_inactive(tty);
   return 0;
 }
 
@@ -876,24 +882,22 @@ static fileops_t tty_fileops = {
  * and the terminal has no associated session, make this terminal
  * the controlling terminal for the session. */
 static void maybe_assoc_ctty(proc_t *p, tty_t *tty) {
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&tty->t_lock));
 
   if (!proc_is_session_leader(p))
     return;
-
-  WITH_MTX_LOCK (&tty->t_lock) {
-    if (tty->t_session != NULL)
-      return;
-    session_t *s = p->p_pgrp->pg_session;
-    if (s->s_tty != NULL)
-      return;
-    tty->t_session = s;
-    s->s_tty = tty;
-    tty->t_pgrp = p->p_pgrp;
-  }
+  if (tty->t_session != NULL)
+    return;
+  session_t *s = p->p_pgrp->pg_session;
+  if (s->s_tty != NULL)
+    return;
+  tty->t_session = s;
+  s->s_tty = tty;
+  tty->t_pgrp = p->p_pgrp;
 }
 
-static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
+static int __tty_vn_open(vnode_t *v, int mode, file_t *fp, bool assoc) {
   tty_t *tty = devfs_node_data(v);
   proc_t *p = proc_self();
   int error;
@@ -901,32 +905,43 @@ static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
   if ((error = vnode_open_generic(v, mode, fp)) != 0)
     return error;
 
-  maybe_assoc_ctty(p, tty);
+  WITH_MTX_LOCK (&tty->t_lock) {
+    if (assoc)
+      maybe_assoc_ctty(p, tty);
+
+    tty->t_opencount++;
+
+    if (tty->t_opencount == 1 && tty->t_ops.t_notify_active)
+      tty->t_ops.t_notify_active(tty);
+  }
 
   fp->f_ops = &tty_fileops;
   fp->f_data = tty;
   return error;
 }
 
+static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
+  SCOPED_MTX_LOCK(all_proc_mtx);
+  return __tty_vn_open(v, mode, fp, true);
+}
+
 vnodeops_t tty_vnodeops = {.v_open = tty_vn_open, .v_close = tty_vn_close};
+
+int tty_makedev(devfs_node_t *parent, const char *name, tty_t *tty) {
+  return devfs_makedev(parent, name, &tty_vnodeops, tty, &tty->t_vnode);
+}
 
 /* Controlling terminal pseudo-device (/dev/tty) */
 
 static int dev_tty_open(vnode_t *v, int mode, file_t *fp) {
   proc_t *p = proc_self();
-  int error;
 
   SCOPED_MTX_LOCK(all_proc_mtx);
   tty_t *tty = p->p_pgrp->pg_session->s_tty;
   if (!tty)
     return ENXIO;
 
-  if ((error = vnode_open_generic(tty->t_vnode, mode, fp)))
-    return error;
-
-  fp->f_ops = &tty_fileops;
-  fp->f_data = tty;
-  return error;
+  return __tty_vn_open(tty->t_vnode, mode, fp, false);
 }
 
 static vnodeops_t dev_tty_vnodeops = {.v_open = dev_tty_open};


### PR DESCRIPTION
- Add an open count to the `tty_t` structure
- Notify the driver when the open count goes from 0 to 1 and from 1 to 0
- Unify common parts of `tty_vn_open()` and `dev_tty_open()`
- Add helper function for making TTY devfs entries