### PR TITLE
Reclaim devfs directory nodes.

### DIFF
--- a/sys/tests/Makefile
+++ b/sys/tests/Makefile
@@ -6,6 +6,7 @@ SOURCES = \
 	broken.c \
 	callout.c \
 	crash.c \
+	devfs.c \
 	fdt.c \
 	klog.c \
 	kmem.c \

--- a/sys/tests/devfs.c
+++ b/sys/tests/devfs.c
@@ -1,0 +1,35 @@
+#include <sys/errno.h>
+#include <sys/ktest.h>
+#include <sys/vfs.h>
+#include <sys/vnode.h>
+#include <sys/devfs.h>
+
+static int test_devfs(void) {
+  vnode_t *v, *v2;
+  int error;
+  devfs_node_t *d;
+
+  /* Directory creation and removal */
+  error = devfs_makedir(NULL, "testdir", &d);
+  assert(error == 0);
+  error = vfs_namelookup("/dev/testdir", &v);
+  assert(error == 0);
+  /* One reference from devfs, one from us. */
+  assert(v->v_usecnt == 2);
+  assert(v->v_type == V_DIR);
+  error = devfs_unlink(d);
+  assert(error == 0);
+  error = vfs_namelookup("/dev/testdir", &v2);
+  assert(error == ENOENT);
+  /* We're still holding a reference, so the vnode and devfs node should still
+   * be around. */
+  assert(v->v_usecnt == 1);
+  (void)(*(volatile char *)d); /* Access d to trigger KASAN if it was freed. */
+  vnode_drop(v);
+
+  /* Now the vnode and devfs node should be freed... but we can't test it. */
+
+  return KTEST_SUCCESS;
+}
+
+KTEST_ADD(devfs, test_devfs, 0);


### PR DESCRIPTION
There was an oversight in #883: when a devfs directory node is unlinked, the devfs layer is responsible for freeing the directory node after all references to the vnode are gone (i.e. in `VOP_RECLAIM()`), but we didn't provide an implementation of `VOP_RECLAIM()`.
I have also thrown in a devfs directory removal test.