### PR TITLE
Checking permission to perform write operation on directory

### DIFF
--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -965,7 +965,7 @@ static int tmpfs_mount(mount_t *mp) {
   /* Allocate the root node. */
   vattr_t va;
   vattr_null(&va);
-  va.va_mode = S_IFDIR | (ACCESSPERMS & ~CMASK);
+  va.va_mode = S_IFDIR | ACCESSPERMS;
   va.va_uid = 0;
   va.va_gid = 0;
   tmpfs_node_t *root = tmpfs_new_node(tfm, &va, V_DIR);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -253,12 +253,12 @@ int do_unlinkat(proc_t *p, int fd, char *path, int flag) {
   else if (vs.vs_vp->v_type == V_DIR) {
     if (!(flag & AT_REMOVEDIR))
       error = EPERM;
-    else
+    else if (!(error = VOP_ACCESS(vs.vs_dvp, VWRITE, &p->p_cred)))
       error = VOP_RMDIR(vs.vs_dvp, vs.vs_vp, &vs.vs_lastcn);
   } else {
     if (flag & AT_REMOVEDIR)
       error = ENOTDIR;
-    else
+    else if (!(error = VOP_ACCESS(vs.vs_dvp, VWRITE, &p->p_cred)))
       error = VOP_REMOVE(vs.vs_dvp, vs.vs_vp, &vs.vs_lastcn);
   }
 

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -65,6 +65,10 @@ static int vfs_create(proc_t *p, int fdat, char *pathname, int *flags, int mode,
     goto fail;
 
   if (vs.vs_vp == NULL) {
+    if ((error = VOP_ACCESS(vs.vs_dvp, VWRITE, &p->p_cred))) {
+      vnode_put(vs.vs_dvp);
+      goto fail;
+    }
     vattr_t va;
     vattr_null(&va);
     va.va_mode = S_IFREG | (mode & ALLPERMS);
@@ -279,6 +283,11 @@ int do_mkdirat(proc_t *p, int fd, char *path, mode_t mode) {
   if (vs.vs_vp != NULL) {
     vnode_drop_both(vs.vs_vp, vs.vs_dvp);
     error = EEXIST;
+    goto fail;
+  }
+
+  if ((error = VOP_ACCESS(vs.vs_dvp, VWRITE, &p->p_cred))) {
+    vnode_put(vs.vs_dvp);
     goto fail;
   }
 


### PR DESCRIPTION
We should check permission to write to directory when we create or remove files and directories.

Now we also should change permissions of `/tmp` dir because everyone should have permission to create files in it. (In the future this directory should have also sticky bit set so users can't delete others' files).