### PR TITLE
Add FIONREAD ioctl

### DIFF
--- a/include/sys/filio.h
+++ b/include/sys/filio.h
@@ -1,0 +1,48 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1982, 1986, 1990, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)filio.h	8.1 (Berkeley) 3/28/94
+ * $FreeBSD$
+ */
+
+#ifndef	_SYS_FILIO_H_
+#define	_SYS_FILIO_H_
+
+#include <sys/ioccom.h>
+
+/* Generic file-descriptor ioctl's. */
+#define	FIONREAD	_IOR('f', 127, int)	/* get # bytes to read */
+
+#endif /* !_SYS_FILIO_H_ */

--- a/include/sys/filio.h
+++ b/include/sys/filio.h
@@ -37,12 +37,12 @@
  * $FreeBSD$
  */
 
-#ifndef	_SYS_FILIO_H_
-#define	_SYS_FILIO_H_
+#ifndef _SYS_FILIO_H_
+#define _SYS_FILIO_H_
 
 #include <sys/ioccom.h>
 
 /* Generic file-descriptor ioctl's. */
-#define	FIONREAD	_IOR('f', 127, int)	/* get # bytes to read */
+#define FIONREAD _IOR('f', 127, int) /* get # bytes to read */
 
 #endif /* !_SYS_FILIO_H_ */

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -21,6 +21,7 @@
 #include <sys/signal.h>
 #include <sys/devfs.h>
 #include <sys/file.h>
+#include <sys/filio.h>
 
 /* START OF FreeBSD CODE */
 
@@ -944,6 +945,11 @@ static int tty_ioctl(file_t *f, u_long cmd, void *data) {
   tty_t *tty = f->f_data;
 
   switch (cmd) {
+    case FIONREAD: {
+      SCOPED_MTX_LOCK(&tty->t_lock);
+      *(int *)data = tty->t_inq.count;
+      return 0;
+    }
     case TIOCGETA:
       return tty_get_termios(tty, (struct termios *)data);
     case TIOCSETA:  /* Set termios immediately */


### PR DESCRIPTION
The `FIONREAD` ioctl returns the number of bytes ready to be read. It will be useful for testing canonical mode, to check that no bytes are ready to be read until a complete line is typed.