### PR TITLE
Add an attribute to disable the compiler instrumentation

### DIFF
--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -73,6 +73,7 @@
 #define __long_call
 #endif
 #define __transparent_union __attribute__((__transparent_union__))
+#define __no_instrument __attribute__((no_sanitize("address,thread,undefined")))
 
 /* Clang introduces support for the fallthrough attribute in C2x. */
 #ifdef __clang__

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -73,7 +73,7 @@
 #define __long_call
 #endif
 #define __transparent_union __attribute__((__transparent_union__))
-#define __no_instrument                                                        \
+#define __no_sanitize                                                          \
   __attribute__((no_sanitize("address", "thread", "undefined")))
 
 /* Clang introduces support for the fallthrough attribute in C2x. */

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -73,7 +73,8 @@
 #define __long_call
 #endif
 #define __transparent_union __attribute__((__transparent_union__))
-#define __no_instrument __attribute__((no_sanitize("address", "thread", "undefined")))
+#define __no_instrument                                                        \
+  __attribute__((no_sanitize("address", "thread", "undefined")))
 
 /* Clang introduces support for the fallthrough attribute in C2x. */
 #ifdef __clang__

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -73,7 +73,7 @@
 #define __long_call
 #endif
 #define __transparent_union __attribute__((__transparent_union__))
-#define __no_instrument __attribute__((no_sanitize("address,thread,undefined")))
+#define __no_instrument __attribute__((no_sanitize("address", "thread", "undefined")))
 
 /* Clang introduces support for the fallthrough attribute in C2x. */
 #ifdef __clang__

--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -95,7 +95,7 @@ bool intr_disabled(void);
        __UNIQUE(__loop); __UNIQUE(__loop) = NULL)
 
 int copystr(const void *restrict kfaddr, void *restrict kdaddr, size_t len,
-            size_t *restrict lencopied) __nonnull(1) __nonnull(2);
+            size_t *restrict lencopied) __nonnull(1) __nonnull(2) __no_sanitize;
 int copyinstr(const void *restrict udaddr, void *restrict kaddr, size_t len,
               size_t *restrict lencopied) __nonnull(1) __nonnull(2);
 int copyin(const void *restrict udaddr, void *restrict kaddr, size_t len)

--- a/sys/libkern/Makefile
+++ b/sys/libkern/Makefile
@@ -8,7 +8,3 @@ FORMAT-RECURSE = no
 SOURCES = copystr.c
 
 include $(TOPDIR)/build/build.kern.mk
-
-# Since copystr function cannot modify stack and caller-saved registers
-# it must be a leaf function, hence it cannot call KASAN functions.
-copystr.o : CFLAGS_KASAN =

--- a/sys/libkern/copystr.c
+++ b/sys/libkern/copystr.c
@@ -20,8 +20,8 @@
  * If you plan to change this function look at machine dependent implementation
  * of copyerr.
  */
-__no_instrument int copystr(const void *kfaddr, void *kdaddr, size_t len,
-                            size_t *done) {
+__no_sanitize int copystr(const void *kfaddr, void *kdaddr, size_t len,
+                          size_t *done) {
   const char *src = kfaddr;
   char *dst = kdaddr;
   size_t i;

--- a/sys/libkern/copystr.c
+++ b/sys/libkern/copystr.c
@@ -11,6 +11,7 @@
  * number of characters copied (including the NIL) in *done.  If the
  * string is too long, return ENAMETOOLONG; else return 0.
  *
+ * IMPORTANT!
  * This function cannot modify stack and caller-saved registers and must be
  * a leaf function. It cannot call KASAN functions and contain regular prologue
  * and epilogue that set up frame pointer. Hence it cannot be compiled with
@@ -19,7 +20,8 @@
  * If you plan to change this function look at machine dependent implementation
  * of copyerr.
  */
-int copystr(const void *kfaddr, void *kdaddr, size_t len, size_t *done) {
+__no_instrument int copystr(const void *kfaddr, void *kdaddr, size_t len,
+                            size_t *done) {
   const char *src = kfaddr;
   char *dst = kdaddr;
   size_t i;


### PR DESCRIPTION
Some functions can't be instrumented because of stack issues. The compilers (both GCC and Clang) provide an attribute to specify that a particular set of instrumentations should not be applied to a function, so we won't have to write extra Makefile rules anymore.