### PR TITLE
AArch64: fix buffer overflow in syscall handler

### DIFF
--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -20,7 +20,8 @@ static __noreturn void kernel_oops(ctx_t *ctx) {
 
 static void syscall_handler(register_t code, ctx_t *ctx, syscall_result_t *result) {
   register_t args[SYS_MAXSYSARGS];
-  const int nregs = 8;
+  const int nregs = 6;
+  static_assert(nregs <= SYS_MAXSYSARGS);
 
   memcpy(args, &_REG(ctx, X0), nregs * sizeof(register_t));
 


### PR DESCRIPTION
Fix buffer overflow in syscall handler.
Number of registers copied from context into args buffer should not be greater than `SYS_MAXSYSARGS`.