### PR TITLE
AArch64: use virtual address instead of physical address in tlb_invalidate.

### DIFF
--- a/include/aarch64/tlb.h
+++ b/include/aarch64/tlb.h
@@ -7,7 +7,7 @@
 
 #include <aarch64/pte.h>
 
-void tlb_invalidate(pte_t pte, asid_t asid);
+void tlb_invalidate(vaddr_t va, asid_t asid);
 void tlb_invalidate_asid(asid_t asid);
 
 #endif /* !_AARCH64_TLB_H_ */

--- a/sys/aarch64/tlb.c
+++ b/sys/aarch64/tlb.c
@@ -9,6 +9,16 @@
 void tlb_invalidate(vaddr_t va, asid_t asid) {
   __dsb("ishst");
 
+  /*
+   * vae1is - Invalidate translation used at EL1 for the specified VA and
+   * Address Space Identifier (ASID) and the current VMID, Inner Shareable.
+   * vaae1is - Invalidate all translations used at EL1 for the specified
+   * address and current VMID and for all ASID values, Inner Shareable.
+   *
+   * Based on arm documentation
+   * [https://developer.arm.com/documentation/ddi0488/h/system-control/aarch64-register-summary/aarch64-tlb-maintenance-operations]
+   * and pmap_invalidate_page from FreeBSD - /sys/arm64/arm64/pmap.c.
+   */
   if (asid > 0) {
     __tlbi("vae1is", ASID_TO_PTE(asid) | (va >> PAGE_SHIFT));
   } else {

--- a/sys/aarch64/tlb.c
+++ b/sys/aarch64/tlb.c
@@ -22,6 +22,11 @@ void tlb_invalidate(vaddr_t va, asid_t asid) {
   if (asid > 0) {
     __tlbi("vae1is", ASID_TO_PTE(asid) | (va >> PAGE_SHIFT));
   } else {
+    /*
+     * We don't know why but NetBSD, FreeBSD and Linux use vaae1is for kernel.
+     * Using vae1is for kernel still works for us but we don't want to leave
+     * potential bug in that part of code.
+     */
     __tlbi("vaae1is", va >> PAGE_SHIFT);
   }
 

--- a/sys/aarch64/tlb.c
+++ b/sys/aarch64/tlb.c
@@ -6,13 +6,13 @@
 #define __dsb(x) __asm__ volatile("DSB " x)
 #define __isb() __asm__ volatile("ISB")
 
-void tlb_invalidate(pte_t pte, asid_t asid) {
+void tlb_invalidate(vaddr_t va, asid_t asid) {
   __dsb("ishst");
 
   if (asid > 0) {
-    __tlbi("vae1is", ASID_TO_PTE(asid) | (pte >> PAGE_SHIFT));
+    __tlbi("vae1is", ASID_TO_PTE(asid) | (va >> PAGE_SHIFT));
   } else {
-    __tlbi("vaae1is", pte >> PAGE_SHIFT);
+    __tlbi("vaae1is", va >> PAGE_SHIFT);
   }
 
   __dsb("ish");


### PR DESCRIPTION
Use virtual address instead of physical address in `tlb_invalidate`.
`TLBI VAE1IS` & `TLBI VAAE1IS` require virtual address as argument.

Fix kernel-space `pmap_page_copy` test for _AArch64_ - #932.