### PR TITLE
Round up memory bars to the page size boundary.

### DIFF
--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -5,7 +5,10 @@
 #include <sys/pci.h>
 #include <dev/isareg.h>
 
-/* For reference look at: http://wiki.osdev.org/PCI */
+/* For reference look at:
+ *   http://wiki.osdev.org/PCI
+ *   https://lekensteyn.nl/files/docs/PCI_SPEV_V3_0.pdf
+ */
 
 static const pci_device_id *pci_find_device(const pci_vendor_id *vendor,
                                             uint16_t device_id) {
@@ -130,6 +133,13 @@ void pci_bus_enumerate(device_t *pcib) {
         }
 
         size = -size;
+        /* PCI specification 3.0, chapter 6.2.5.1 states:
+         * Devices are free to consume more address space than required,
+         * but decoding down to a 4 KB space for memory is suggested for
+         * devices that need less than that amount. */
+        if (type == RT_MEMORY)
+          size = roundup(size, PAGESIZE);
+
         pcid->bar[i] = (pci_bar_t){
           .owner = dev, .type = type, .flags = flags, .size = size, .rid = i};
 

--- a/sys/mips/gt64120.c
+++ b/sys/mips/gt64120.c
@@ -400,11 +400,6 @@ static resource_t *gt_pci_alloc_resource(device_t *dev, res_type_t type,
   if (gt_pci_bar(dev, type, rid, start))
     alignment = max(alignment, size);
 
-  if (type == RT_MEMORY) {
-    /* XXX: Perhaps, the rman_alloc_resource should take this into account */
-    size = roundup(size, PAGESIZE);
-  }
-
   resource_t *r =
     rman_reserve_resource(rman, type, rid, start, end, size, alignment, flags);
   if (!r)


### PR DESCRIPTION
Fix memory bar sizes relying on the PCI 3.0 specification.