### PR TITLE
Login: changes in libc and headers

### DIFF
--- a/include/paths.h
+++ b/include/paths.h
@@ -10,5 +10,6 @@
 #define _PATH_SHELLS "/etc/shells"
 #define _PATH_TTY "/dev/tty"
 #define _PATH_URANDOM "/dev/urandom"
+#define _PATH_NOLOGIN "/etc/nologin"
 
 #endif /* !_PATHS_H_ */

--- a/include/pwd.h
+++ b/include/pwd.h
@@ -70,6 +70,9 @@
 #define _PATH_PASSWD "/etc/passwd"
 #define _PATH_MASTERPASSWD "/etc/master.passwd"
 #define _PASSWORD_LEN 128
+#define _PASSWORD_WARNDAYS 14
+/* special day to force password change at next login */
+#define _PASSWORD_CHGNOW -1
 
 struct passwd {
   const char *pw_name;   /* user name */

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -2,8 +2,10 @@
 #define _SYS_FILE_H_
 
 #include <sys/cdefs.h>
-#include <sys/mutex.h>
 #include <sys/fcntl.h>
+
+#ifdef _KERNEL
+#include <sys/mutex.h>
 #include <sys/refcnt.h>
 
 typedef struct file file_t;
@@ -94,5 +96,7 @@ int do_dup2(proc_t *p, int oldfd, int newfd);
 int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp);
 int do_ioctl(proc_t *p, int fd, u_long cmd, void *data);
 int do_umask(proc_t *p, int newmask, int *oldmaskp);
+
+#endif /* !_KERNEL */
 
 #endif /* !_SYS_FILE_H_ */

--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -7,7 +7,8 @@
 #include <sys/syslimits.h>
 #include <sys/inttypes.h>
 
-#define NGROUPS NGROUPS_MAX /* max number groups */
+#define NGROUPS NGROUPS_MAX             /* max number groups */
+#define MAXLOGNAME (LOGIN_NAME_MAX - 1) /* max login name length */
 
 /* Macros for min/max. */
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))

--- a/include/sysexits.h
+++ b/include/sysexits.h
@@ -1,0 +1,118 @@
+/*	$NetBSD: sysexits.h,v 1.7 2005/09/30 20:56:19 rpaulo Exp $	*/
+
+/*
+ * Copyright (c) 1987, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)sysexits.h	8.1 (Berkeley) 6/2/93
+ */
+
+#ifndef _SYSEXITS_H_
+#define _SYSEXITS_H_
+
+/*
+ *  SYSEXITS.H -- Exit status codes for system programs.
+ *
+ *	This include file attempts to categorize possible error
+ *	exit statuses for system programs, notably delivermail
+ *	and the Berkeley network.
+ *
+ *	Error numbers begin at EX__BASE to reduce the possibility of
+ *	clashing with other exit statuses that random programs may
+ *	already return.  The meaning of the codes is approximately
+ *	as follows:
+ *
+ *	EX_USAGE -- The command was used incorrectly, e.g., with
+ *		the wrong number of arguments, a bad flag, a bad
+ *		syntax in a parameter, or whatever.
+ *	EX_DATAERR -- The input data was incorrect in some way.
+ *		This should only be used for user's data & not
+ *		system files.
+ *	EX_NOINPUT -- An input file (not a system file) did not
+ *		exist or was not readable.  This could also include
+ *		errors like "No message" to a mailer (if it cared
+ *		to catch it).
+ *	EX_NOUSER -- The user specified did not exist.  This might
+ *		be used for mail addresses or remote logins.
+ *	EX_NOHOST -- The host specified did not exist.  This is used
+ *		in mail addresses or network requests.
+ *	EX_UNAVAILABLE -- A service is unavailable.  This can occur
+ *		if a support program or file does not exist.  This
+ *		can also be used as a catchall message when something
+ *		you wanted to do doesn't work, but you don't know
+ *		why.
+ *	EX_SOFTWARE -- An internal software error has been detected.
+ *		This should be limited to non-operating system related
+ *		errors as possible.
+ *	EX_OSERR -- An operating system error has been detected.
+ *		This is intended to be used for such things as "cannot
+ *		fork", "cannot create pipe", or the like.  It includes
+ *		things like getuid returning a user that does not
+ *		exist in the passwd file.
+ *	EX_OSFILE -- Some system file (e.g., /etc/passwd, /etc/utmp,
+ *		etc.) does not exist, cannot be opened, or has some
+ *		sort of error (e.g., syntax error).
+ *	EX_CANTCREAT -- A (user specified) output file cannot be
+ *		created.
+ *	EX_IOERR -- An error occurred while doing I/O on some file.
+ *	EX_TEMPFAIL -- temporary failure, indicating something that
+ *		is not really an error.  In sendmail, this means
+ *		that a mailer (e.g.) could not create a connection,
+ *		and the request should be reattempted later.
+ *	EX_PROTOCOL -- the remote system returned something that
+ *		was "not possible" during a protocol exchange.
+ *	EX_NOPERM -- You did not have sufficient permission to
+ *		perform the operation.  This is not intended for
+ *		file system problems, which should use NOINPUT or
+ *		CANTCREAT, but rather for higher level permissions.
+ *
+ *	Please update the sysexits(3) man page after adding more entries.
+ */
+
+#define EX_OK 0 /* successful termination */
+
+#define EX__BASE 64 /* base value for error messages */
+
+#define EX_USAGE 64       /* command line usage error */
+#define EX_DATAERR 65     /* data format error */
+#define EX_NOINPUT 66     /* cannot open input */
+#define EX_NOUSER 67      /* addressee unknown */
+#define EX_NOHOST 68      /* host name unknown */
+#define EX_UNAVAILABLE 69 /* service unavailable */
+#define EX_SOFTWARE 70    /* internal software error */
+#define EX_OSERR 71       /* system error (e.g., can't fork) */
+#define EX_OSFILE 72      /* critical OS file missing */
+#define EX_CANTCREAT 73   /* can't create (user) output file */
+#define EX_IOERR 74       /* input/output error */
+#define EX_TEMPFAIL 75    /* temp failure; user is invited to retry */
+#define EX_PROTOCOL 76    /* remote error in protocol */
+#define EX_NOPERM 77      /* permission denied */
+#define EX_CONFIG 78      /* configuration error */
+
+#define EX__MAX 78 /* maximum listed value */
+
+#endif /* !_SYSEXITS_H_ */

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -26,6 +26,7 @@ int execlp(const char *, const char *, ...);
 int execv(const char *, char *const *);
 int execve(const char *, char *const *, char *const *);
 int execvp(const char *, char *const *);
+int execvpe(const char *, char *const *, char *const *);
 pid_t fork(void);
 long fpathconf(int, int);
 char *getcwd(char *, size_t);
@@ -59,7 +60,7 @@ unsigned int sleep(unsigned int);
 long sysconf(int);
 pid_t tcgetpgrp(int);
 int tcsetpgrp(int, pid_t);
-const char *ttyname(int);
+char *ttyname(int);
 int unlink(const char *);
 ssize_t write(int, const void *, size_t);
 

--- a/lib/libc/gen/execlp.c
+++ b/lib/libc/gen/execlp.c
@@ -1,0 +1,79 @@
+/*	$NetBSD: execlp.c,v 1.13 2014/09/26 19:28:03 christos Exp $	*/
+
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+
+int execlp(const char *name, const char *arg, ...) {
+  va_list ap;
+  char **argv;
+  size_t i;
+
+  va_start(ap, arg);
+  for (i = 2; va_arg(ap, char *) != NULL; i++)
+    continue;
+  va_end(ap);
+
+  argv = alloca(i * sizeof(char *));
+
+  va_start(ap, arg);
+  argv[0] = __UNCONST(arg);
+  for (i = 1; (argv[i] = va_arg(ap, char *)) != NULL; i++)
+    continue;
+  va_end(ap);
+
+  return execvp(name, argv);
+}
+
+int execlpe(const char *name, const char *arg, ...) {
+  va_list ap;
+  char **argv, **envp;
+  size_t i;
+
+  va_start(ap, arg);
+  for (i = 2; va_arg(ap, char *) != NULL; i++)
+    continue;
+  va_end(ap);
+
+  argv = alloca(i * sizeof(char *));
+
+  va_start(ap, arg);
+  argv[0] = __UNCONST(arg);
+  for (i = 1; (argv[i] = va_arg(ap, char *)) != NULL; i++)
+    continue;
+  envp = va_arg(ap, char **);
+  va_end(ap);
+
+  return execvpe(name, argv, envp);
+}

--- a/lib/libc/gen/ttyname.c
+++ b/lib/libc/gen/ttyname.c
@@ -1,7 +1,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-const char *ttyname(int fd) {
+char *ttyname(int fd) {
   /* TODO(fzdob): to implement */
   errno = ENOTTY;
   return NULL;


### PR DESCRIPTION
I added `sysexits.h` and `execlp()` functions.

I had to add macro `_KERNEL` in `file.h` to allow using it in userspace. (e.g `sys/mutex.h` cannot be included in userspace programs)

This changes are required by #945 