### PR TITLE
klog: fix race

### DIFF
--- a/include/sys/klog.h
+++ b/include/sys/klog.h
@@ -63,7 +63,7 @@ typedef struct klog_entry {
 
 typedef struct klog {
   klog_entry_t array[KL_SIZE];
-  unsigned mask;
+  atomic_uint mask;
   bool verbose;
   volatile unsigned first;
   volatile unsigned last;

--- a/sys/kern/klog.c
+++ b/sys/kern/klog.c
@@ -51,7 +51,7 @@ void klog_append(klog_origin_t origin, const char *file, unsigned line,
                  const char *format, uintptr_t arg1, uintptr_t arg2,
                  uintptr_t arg3, uintptr_t arg4, uintptr_t arg5,
                  uintptr_t arg6) {
-  if (!(KL_MASK(origin) & klog.mask))
+  if (!(KL_MASK(origin) & atomic_load(&klog.mask)))
     return;
 
   klog_entry_t *entry;
@@ -111,13 +111,7 @@ void klog_append(klog_origin_t origin, const char *file, unsigned line,
 }
 
 unsigned klog_setmask(unsigned newmask) {
-  unsigned oldmask;
-
-  WITH_SPIN_LOCK (&klog_lock) {
-    oldmask = klog.mask;
-    klog.mask = newmask;
-  }
-  return oldmask;
+  return atomic_exchange(&klog.mask, newmask);
 }
 
 void klog_dump(void) {


### PR DESCRIPTION
There is a harmless race on the variable `klog.mask`. Although it is set under a spin lock, there is no synchronization when reading it.

Found by KCSAN.