### PR TITLE
proc: zero session structs before use

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -137,7 +137,7 @@ static pid_t pid_alloc(void) {
 
 /* Session management helper functions */
 static session_t *session_create(proc_t *leader) {
-  session_t *s = pool_alloc(P_SESSION, 0);
+  session_t *s = pool_alloc(P_SESSION, M_ZERO);
   s->s_sid = leader->p_pid;
   s->s_leader = leader;
   s->s_count = 1;


### PR DESCRIPTION
Sessions struct weren't zeroed on creation, so the field `tty_t *s_tty` could contain a garbage and thus every check like [this](https://mimiker.ii.uni.wroc.pl/source/xref/mimiker/sys/kern/tty.c#1091) or [this](https://mimiker.ii.uni.wroc.pl/source/xref/mimiker/sys/kern/proc.c?r=1a7dabd3#362) wasn't working as expected. 