### PR TITLE
fchdir: release old cwd vnode

### DIFF
--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -485,8 +485,8 @@ int do_fchdir(proc_t *p, int fd) {
   vnode_t *v = f->f_vnode;
   if (v->v_type == V_DIR) {
     vnode_hold(v);
-    p->p_cwd = v;
     vnode_drop(p->p_cwd);
+    p->p_cwd = v;
   } else {
     error = ENOTDIR;
   }

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -484,9 +484,10 @@ int do_fchdir(proc_t *p, int fd) {
 
   vnode_t *v = f->f_vnode;
   if (v->v_type == V_DIR) {
+    vnode_t *old_cwd = p->p_cwd;
     vnode_hold(v);
-    vnode_drop(p->p_cwd);
     p->p_cwd = v;
+    vnode_drop(old_cwd);
   } else {
     error = ENOTDIR;
   }


### PR DESCRIPTION
We should drop the reference to the old cwd and acquire the reference to the new one while changing directory.

There was a bug causing that the new cwd was released twice.