### PR TITLE
Introduce basic USB related header files.

### DIFF
--- a/include/dev/scsi.h
+++ b/include/dev/scsi.h
@@ -1,8 +1,8 @@
 /*
- * Based on FreeBSD `scsi_all.h`.
+ * Based on FreeBSD `sys/cam/scsi/scsi_all.h`.
  */
-#ifndef _SCSI_H_
-#define _SCSI_H_
+#ifndef _DEV_SCSI_H_
+#define _DEV_SCSI_H_
 
 /* Opcodes. */
 #define REQUEST_SENSE 0x03
@@ -95,4 +95,4 @@ typedef struct scsi_read_capacity_data {
 
 #define REQUEST_TIMEOUT 4
 
-#endif /* _SCSI_H_ */
+#endif /* _DEV_SCSI_H_ */

--- a/include/dev/scsi.h
+++ b/include/dev/scsi.h
@@ -1,0 +1,98 @@
+/*
+ * Based on FreeBSD `scsi_all.h`.
+ */
+#ifndef _SCSI_H_
+#define _SCSI_H_
+
+/* Opcodes. */
+#define REQUEST_SENSE 0x03
+#define INQUIRY 0x12
+#define READ_CAPACITY 0x25
+#define READ_10 0x28
+#define WRITE_10 0x2A
+
+typedef struct scsi_request_sense {
+  uint8_t opcode; /* REQUEST_SENSE */
+  uint8_t byte2;
+  uint8_t unused[2];
+  uint8_t length;
+  uint8_t control;
+} __packed scsi_request_sense_t;
+
+typedef struct {
+  uint8_t opcode; /* INQUIRY */
+  uint8_t byte2;
+  uint8_t page_code;
+  uint16_t length;
+  uint8_t control;
+} __packed scsi_inquiry_t;
+
+typedef struct scsi_read_capacity {
+  uint8_t opcode; /* READ_CAPACITY */
+  uint8_t byte2;
+  uint8_t addr[4];
+  uint8_t unused[2];
+  uint8_t pmi;
+  uint8_t control;
+} __packed scsi_read_capacity_t;
+
+typedef struct scsi_rw_10 {
+  uint8_t opcode;
+  uint8_t byte2;
+  uint32_t addr;
+  uint8_t reserved;
+  uint16_t length;
+  uint8_t control;
+} __packed scsi_rw_10_t;
+
+typedef struct scsi_sense_data {
+  uint8_t error_code;
+  uint8_t segment;
+  uint8_t flags;
+  uint8_t info[4];
+  uint8_t extra_len;
+  uint8_t cmd_spec_info[4];
+  uint8_t add_sense_code;
+  uint8_t add_sense_code_qual;
+  uint8_t fru;
+  uint8_t sense_key_spec[3];
+} __packed scsi_sense_data_t;
+
+#define SHORT_INQUIRY_LENGTH 36
+
+#define SID_VENDOR_SIZE 8
+#define SID_PRODUCT_SIZE 16
+#define SID_REVISION_SIZE 4
+
+typedef struct {
+  uint8_t device;
+  uint8_t dev_qual2;
+  uint8_t version;
+  uint8_t response_format;
+  uint8_t additional_length;
+  uint8_t spc3_flags;
+  uint8_t spc2_flags;
+  uint8_t flags;
+  char vendor[SID_VENDOR_SIZE];
+  char product[SID_PRODUCT_SIZE];
+  char revision[SID_REVISION_SIZE];
+} __packed scsi_inquiry_data_t;
+
+#define SID_TYPE(inq_data) ((inq_data)->device & 0x1f)
+
+#define SID_QUAL(inq_data) (((inq_data)->device & 0xE0) >> 5)
+#define SID_QUAL_LU_CONNECTED 0x00
+
+#define SID_RMB 0x80
+#define SID_IS_REMOVABLE(inq_data) (((inq_data)->dev_qual2 & SID_RMB) != 0)
+
+#define SID_FORMAT(inq_data) ((inq_data)->response_format & 0x0f)
+
+typedef struct scsi_read_capacity_data {
+  uint32_t addr;
+  uint32_t length;
+} __packed scsi_read_capacity_data_t;
+
+#define REQUEST_TIMEOUT 4
+
+#endif /* _SCSI_H_ */

--- a/include/dev/scsi.h
+++ b/include/dev/scsi.h
@@ -30,14 +30,14 @@ typedef struct {
 typedef struct scsi_read_capacity {
   uint8_t opcode; /* READ_CAPACITY */
   uint8_t byte2;
-  uint8_t addr[4];
+  uint32_t addr;
   uint8_t unused[2];
   uint8_t pmi;
   uint8_t control;
 } __packed scsi_read_capacity_t;
 
 typedef struct scsi_rw_10 {
-  uint8_t opcode;
+  uint8_t opcode; /* READ_10/WRITE_10 */
   uint8_t byte2;
   uint32_t addr;
   uint8_t reserved;

--- a/include/dev/uhci.h
+++ b/include/dev/uhci.h
@@ -4,8 +4,6 @@
 #ifndef _DEV_UHCI_H_
 #define _DEV_UHCI_H_
 
-#include <sys/spinlock.h>
-
 #define UHCI_FRAMELIST_COUNT 1024 /* units */
 
 /* Structures alignment (bytes) */
@@ -18,11 +16,9 @@ typedef uint32_t uhci_physaddr_t;
 #define UHCI_PTR_TD 0x00000000
 #define UHCI_PTR_QH 0x00000002
 #define UHCI_PTR_VF 0x00000004
-#define UHCI_PTR_MASK 0x00000007
 
 typedef struct uhci_td uhci_td_t;
 typedef struct uhci_qh uhci_qh_t;
-typedef TAILQ_HEAD(qh_list, uhci_qh) uhci_qh_list_t;
 
 struct uhci_td {
   volatile uint32_t td_next;

--- a/include/dev/uhci.h
+++ b/include/dev/uhci.h
@@ -1,0 +1,86 @@
+/*
+ * Based on FreeBSD `uhci.h`.
+ */
+#ifndef _UHCI_H_
+#define _UHCI_H_
+
+#include <sys/spinlock.h>
+
+#define UHCI_FRAMELIST_COUNT 1024 /* units */
+
+/* Structures alignment (bytes) */
+#define UHCI_TD_ALIGN 16
+#define UHCI_QH_ALIGN 16
+
+typedef uint32_t uhci_physaddr_t;
+
+#define UHCI_PTR_T 0x00000001
+#define UHCI_PTR_TD 0x00000000
+#define UHCI_PTR_QH 0x00000002
+#define UHCI_PTR_VF 0x00000004
+#define UHCI_PTR_MASK 0x00000007
+
+typedef struct uhci_td uhci_td_t;
+typedef struct uhci_qh uhci_qh_t;
+typedef TAILQ_HEAD(qh_list, uhci_qh) uhci_qh_list_t;
+
+struct uhci_td {
+  volatile uint32_t td_next;
+  volatile uint32_t td_status;
+  volatile uint32_t td_token;
+  volatile uint32_t td_buffer;
+  uint32_t __reserved[4]; /* 16 bytes for user usage */
+} __aligned(UHCI_TD_ALIGN);
+
+#define UHCI_TD_GET_ACTLEN(s) (((s) + 1) & 0x3ff)
+#define UHCI_TD_BITSTUFF 0x00020000
+#define UHCI_TD_CRCTO 0x00040000
+#define UHCI_TD_NAK 0x00080000
+#define UHCI_TD_BABBLE 0x00100000
+#define UHCI_TD_DBUFFER 0x00200000
+#define UHCI_TD_STALLED 0x00400000
+#define UHCI_TD_ACTIVE 0x00800000
+#define UHCI_TD_IOC 0x01000000
+#define UHCI_TD_IOS 0x02000000
+#define UHCI_TD_LS 0x04000000
+#define UHCI_TD_GET_ERRCNT(s) (((s) >> 27) & 3)
+#define UHCI_TD_SET_ERRCNT(n) ((n) << 27)
+#define UHCI_TD_SPD 0x20000000
+#define UHCI_TD_PID 0x000000ff
+#define UHCI_TD_PID_IN 0x00000069
+#define UHCI_TD_PID_OUT 0x000000e1
+#define UHCI_TD_PID_SETUP 0x0000002d
+#define UHCI_TD_GET_PID(s) ((s)&0xff)
+#define UHCI_TD_SET_DEVADDR(a) ((a) << 8)
+#define UHCI_TD_GET_DEVADDR(s) (((s) >> 8) & 0x7f)
+#define UHCI_TD_SET_ENDPT(e) (((e)&0xf) << 15)
+#define UHCI_TD_GET_ENDPT(s) (((s) >> 15) & 0xf)
+#define UHCI_TD_SET_DT(t) ((t) << 19)
+#define UHCI_TD_GET_DT(s) (((s) >> 19) & 1)
+#define UHCI_TD_SET_MAXLEN(l) (((l)-1U) << 21)
+#define UHCI_TD_GET_MAXLEN(s) ((((s) >> 21) + 1) & 0x7ff)
+#define UHCI_TD_MAXLEN_MASK 0xffe00000
+
+#define UHCI_TD_ERROR                                                          \
+  (UHCI_TD_BITSTUFF | UHCI_TD_CRCTO | UHCI_TD_BABBLE | UHCI_TD_DBUFFER |       \
+   UHCI_TD_STALLED)
+
+#define UHCI_TD_SETUP(len, endp, dev)                                          \
+  (UHCI_TD_SET_MAXLEN(len) | UHCI_TD_SET_ENDPT(endp) |                         \
+   UHCI_TD_SET_DEVADDR(dev) | UHCI_TD_PID_SETUP)
+
+#define UHCI_TD_OUT(len, endp, dev, dt)                                        \
+  (UHCI_TD_SET_MAXLEN(len) | UHCI_TD_SET_ENDPT(endp) |                         \
+   UHCI_TD_SET_DEVADDR(dev) | UHCI_TD_PID_OUT | UHCI_TD_SET_DT(dt))
+
+#define UHCI_TD_IN(len, endp, dev, dt)                                         \
+  (UHCI_TD_SET_MAXLEN(len) | UHCI_TD_SET_ENDPT(endp) |                         \
+   UHCI_TD_SET_DEVADDR(dev) | UHCI_TD_PID_IN | UHCI_TD_SET_DT(dt))
+
+struct uhci_qh {
+  volatile uint32_t qh_h_next;
+  volatile uint32_t qh_e_next;
+  uint32_t __pad[2];
+} __aligned(UHCI_QH_ALIGN);
+
+#endif /* _UHCI_H_ */

--- a/include/dev/uhci.h
+++ b/include/dev/uhci.h
@@ -1,8 +1,8 @@
 /*
- * Based on FreeBSD `uhci.h`.
+ * Based on FreeBSD `sys/dev/usb/controller/uhci.h`.
  */
-#ifndef _UHCI_H_
-#define _UHCI_H_
+#ifndef _DEV_UHCI_H_
+#define _DEV_UHCI_H_
 
 #include <sys/spinlock.h>
 
@@ -83,4 +83,4 @@ struct uhci_qh {
   uint32_t __pad[2];
 } __aligned(UHCI_QH_ALIGN);
 
-#endif /* _UHCI_H_ */
+#endif /* _DEV_UHCI_H_ */

--- a/include/dev/uhcireg.h
+++ b/include/dev/uhcireg.h
@@ -1,8 +1,8 @@
 /*
- * Based on FreeBSD `uhcireg.h`.
+ * Based on FreeBSD `sys/dev/usb/controller/uhcireg.h`.
  */
-#ifndef _UHCIREG_H_
-#define _UHCIREG_H_
+#ifndef _DEV_UHCIREG_H_
+#define _DEV_UHCIREG_H_
 
 /* PCI config registers  */
 #define PCI_USB_CLASSCODE 0x0c
@@ -59,4 +59,4 @@
 #define URWMASK(x)                                                             \
   ((x) & (UHCI_PORTSC_SUSP | UHCI_PORTSC_PR | UHCI_PORTSC_RD | UHCI_PORTSC_PE))
 
-#endif /* _UHCIREG_H_ */
+#endif /* _DEV_UHCIREG_H_ */

--- a/include/dev/uhcireg.h
+++ b/include/dev/uhcireg.h
@@ -1,0 +1,62 @@
+/*
+ * Based on FreeBSD `uhcireg.h`.
+ */
+#ifndef _UHCIREG_H_
+#define _UHCIREG_H_
+
+/* PCI config registers  */
+#define PCI_USB_CLASSCODE 0x0c
+#define PCI_USB_SUBCLASSCODE 0x03
+#define PCI_USBREV 0x60 /* USB protocol revision */
+#define PCI_USB_REV_PRE_1_0 0x00
+#define PCI_USB_REV_1_0 0x10
+#define PCI_USB_REV_1_1 0x11
+#define PCI_INTERFACE_UHCI 0x00
+
+/* UHCI registers */
+#define UHCI_CMD 0x00
+#define UHCI_CMD_RS 0x0001
+#define UHCI_CMD_HCRESET 0x0002
+#define UHCI_CMD_GRESET 0x0004
+#define UHCI_CMD_EGSM 0x0008
+#define UHCI_CMD_FGR 0x0010
+#define UHCI_CMD_SWDBG 0x0020
+#define UHCI_CMD_CF 0x0040
+#define UHCI_CMD_MAXP 0x0080
+#define UHCI_STS 0x02
+#define UHCI_STS_USBINT 0x0001
+#define UHCI_STS_USBEI 0x0002
+#define UHCI_STS_RD 0x0004
+#define UHCI_STS_HSE 0x0008
+#define UHCI_STS_HCPE 0x0010
+#define UHCI_STS_HCH 0x0020
+#define UHCI_STS_ALLINTRS 0x003f
+#define UHCI_INTR 0x04
+#define UHCI_INTR_TOCRCIE 0x0001
+#define UHCI_INTR_RIE 0x0002
+#define UHCI_INTR_IOCE 0x0004
+#define UHCI_INTR_SPIE 0x0008
+#define UHCI_FRNUM 0x06
+#define UHCI_FRNUM_MASK 0x03ff
+#define UHCI_FLBASEADDR 0x08
+#define UHCI_SOF 0x0c
+#define UHCI_SOF_MASK 0x7f
+#define UHCI_PORTSC(n) (0x10 + (n)*2)
+#define UHCI_PORTSC_CCS 0x0001
+#define UHCI_PORTSC_CSC 0x0002
+#define UHCI_PORTSC_PE 0x0004
+#define UHCI_PORTSC_POEDC 0x0008
+#define UHCI_PORTSC_LS 0x0030
+#define UHCI_PORTSC_LS_SHIFT 4
+#define UHCI_PORTSC_RD 0x0040
+#define UHCI_PORTSC_ONE 0x0080
+#define UHCI_PORTSC_LSDA 0x0100
+#define UHCI_PORTSC_PR 0x0200
+#define UHCI_PORTSC_OCI 0x0400
+#define UHCI_PORTSC_OCIC 0x0800
+#define UHCI_PORTSC_SUSP 0x1000
+
+#define URWMASK(x)                                                             \
+  ((x) & (UHCI_PORTSC_SUSP | UHCI_PORTSC_PR | UHCI_PORTSC_RD | UHCI_PORTSC_PE))
+
+#endif /* _UHCIREG_H_ */

--- a/include/dev/umass.h
+++ b/include/dev/umass.h
@@ -1,8 +1,8 @@
 /*
- * Based on definitions contained in FreeBSD `umass.c`.
+ * Based on definitions contained in FreeBSD `sys/dev/usb/storage/umass.c`.
  */
-#ifndef _UMASS_H_
-#define _UMASS_H_
+#ifndef _DEV_UMASS_H_
+#define _DEV_UMASS_H_
 
 /* Bulk-Only features */
 
@@ -40,4 +40,4 @@ typedef struct {
 #define CSWSTATUS_GOOD 0x0
 #define CSWSTATUS_FAILED 0x1
 
-#endif /* _UMASS_H_ */
+#endif /* _DEV_UMASS_H_ */

--- a/include/dev/umass.h
+++ b/include/dev/umass.h
@@ -1,0 +1,43 @@
+/*
+ * Based on definitions contained in FreeBSD `umass.c`.
+ */
+#ifndef _UMASS_H_
+#define _UMASS_H_
+
+/* Bulk-Only features */
+
+#define UR_BBB_RESET 0xff       /* Bulk-Only reset */
+#define UR_BBB_GET_MAX_LUN 0xfe /* Get maximum lun */
+
+/* Command Block Wrapper */
+#define CBWCDBLENGTH 16
+
+typedef struct {
+  uint32_t dCBWSignature;
+  uint32_t dCBWTag;
+  uint32_t dCBWDataTransferLength;
+  uint8_t bCBWFlags;
+  uint8_t bCBWLUN;
+  uint8_t bCDBLength;
+  uint8_t CBWCDB[CBWCDBLENGTH];
+} __packed umass_bbb_cbw_t;
+
+#define CBWSIGNATURE 0x43425355
+
+#define CBWFLAGS_OUT 0x00
+#define CBWFLAGS_IN 0x80
+
+/* Command Status Wrapper */
+typedef struct {
+  uint32_t dCSWSignature;
+  uint32_t dCSWTag;
+  uint32_t dCSWDataResidue;
+  uint8_t bCSWStatus;
+} __packed umass_bbb_csw_t;
+
+#define CSWSIGNATURE 0x53425355
+
+#define CSWSTATUS_GOOD 0x0
+#define CSWSTATUS_FAILED 0x1
+
+#endif /* _UMASS_H_ */

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -1,0 +1,152 @@
+/*
+ * Based on FreeBSD `usb.h`.
+ */
+#ifndef _USB_H_
+#define _USB_H_
+
+#include <sys/ringbuf.h>
+#include <sys/condvar.h>
+#include <sys/spinlock.h>
+
+/* Definition of some hardcoded USB constants. */
+
+#define USB_MAX_IPACKET 8 /* initial USB packet size */
+
+/* These are the values from the USB specification. */
+#define USB_PORT_ROOT_RESET_DELAY_SPEC 50 /* ms */
+#define USB_PORT_RESET_RECOVERY_SPEC 10   /* ms */
+
+typedef struct usb_device_request {
+  uint8_t bmRequestType;
+  uint8_t bRequest;
+  uint16_t wValue;
+  uint16_t wIndex;
+  uint16_t wLength;
+} __packed usb_device_request_t;
+
+#define UT_WRITE 0x00
+#define UT_READ 0x80
+#define UT_STANDARD 0x00
+#define UT_CLASS 0x20
+#define UT_DEVICE 0x00
+#define UT_INTERFACE 0x01
+#define UT_ENDPOINT 0x02
+
+#define UT_READ_DEVICE (UT_READ | UT_STANDARD | UT_DEVICE)
+#define UT_READ_INTERFACE (UT_READ | UT_STANDARD | UT_INTERFACE)
+#define UT_READ_ENDPOINT (UT_READ | UT_STANDARD | UT_ENDPOINT)
+#define UT_WRITE_DEVICE (UT_WRITE | UT_STANDARD | UT_DEVICE)
+#define UT_WRITE_ENDPOINT (UT_WRITE | UT_STANDARD | UT_ENDPOINT)
+#define UT_READ_CLASS_INTERFACE (UT_READ | UT_CLASS | UT_INTERFACE)
+#define UT_READ_CLASS_ENDPOINT (UT_READ | UT_CLASS | UT_ENDPOINT)
+#define UT_WRITE_CLASS_INTERFACE (UT_WRITE | UT_CLASS | UT_INTERFACE)
+
+/* Requests. */
+#define UR_GET_STATUS 0x00
+#define UR_CLEAR_FEATURE 0x01
+#define UR_SET_ADDRESS 0x05
+#define UR_GET_DESCRIPTOR 0x06
+#define USB_LANGUAGE_TABLE 0x00
+#define UR_GET_CONFIG 0x08
+#define UR_SET_CONFIG 0x09
+#define UDESC_DEVICE 0x01
+#define UDESC_CONFIG 0x02
+#define UDESC_STRING 0x03
+
+/* Feature numbers. */
+#define UF_ENDPOINT_HALT 0
+
+#define UV_MAKE(d, i) ((d) << 8 | (i))
+
+typedef struct usb_device_descriptor {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint16_t bcdUSB;
+  uint8_t bDeviceClass;
+  uint8_t bDeviceSubClass;
+  uint8_t bDeviceProtocol;
+  uint8_t bMaxPacketSize;
+  /* The fields below are not part of the initial descriptor. */
+  uint16_t idVendor;
+  uint16_t idProduct;
+  uint16_t bcdDevice;
+  uint8_t iManufacturer;
+  uint8_t iProduct;
+  uint8_t iSerialNumber;
+  uint8_t bNumConfigurations;
+} __packed usb_device_descriptor_t;
+
+#define US_DATASIZE 126
+
+typedef struct usb_string_descriptor {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint16_t bString[US_DATASIZE];
+  uint8_t bUnused;
+} __packed usb_string_descriptor_t;
+
+typedef struct usb_string_lang {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint8_t bData[US_DATASIZE];
+} __packed usb_string_lang_t;
+
+#define US_ENG_LID 0x0409
+#define US_ENG_STR "English (United States)"
+
+typedef struct usb_config_descriptor {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint16_t wTotalLength;
+  uint8_t bNumInterface;
+  uint8_t bConfigurationValue;
+  uint8_t iConfiguration;
+  uint8_t bmAttributes;
+  uint8_t bMaxPower; /* max current in 2 mA units */
+} __packed usb_config_descriptor_t;
+
+typedef struct usb_interface_descriptor {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint8_t bInterfaceNumber;
+  uint8_t bAlternateSetting;
+  uint8_t bNumEndpoints;
+  uint8_t bInterfaceClass;
+  uint8_t bInterfaceSubClass;
+  uint8_t bInterfaceProtocol;
+  uint8_t iInterface;
+} __packed usb_interface_descriptor_t;
+
+/* Interface class codes */
+#define UICLASS_HID 0x03
+#define UISUBCLASS_BOOT 1
+#define UIPROTO_BOOT_KEYBOARD 1
+#define UIPROTO_MOUSE 2
+
+#define UICLASS_MASS 0x08
+#define UISUBCLASS_SCSI 6
+#define UIPROTO_MASS_BBB 80
+
+typedef struct usb_endpoint_descriptor {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint8_t bEndpointAddress;
+  uint8_t bmAttributes;
+  uint16_t wMaxPacketSize;
+  uint8_t bInterval;
+} __packed usb_endpoint_descriptor_t;
+
+#define UE_ADDR 0x0f
+#define UE_DIR_IN 0x80  /* IN-token endpoint */
+#define UE_DIR_OUT 0x00 /* OUT-token endpoint */
+#define UE_GET_DIR(a) ((a)&0x80)
+#define UE_GET_ADDR(a) ((a)&UE_ADDR)
+
+#define UE_TRANSFER_TYPE(at) ((at)&0x03)
+
+#define UE_CONTROL 0x00
+#define UE_ISOCHRONOUS 0x01
+#define UE_BULK 0x02
+#define UE_INTERRUPT 0x03
+
+#endif /*_USB_H_ */

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -1,8 +1,8 @@
 /*
- * Based on FreeBSD `usb.h`.
+ * Based on FreeBSD `sys/dev/usb/usb.h`.
  */
-#ifndef _USB_H_
-#define _USB_H_
+#ifndef _DEV_USB_H_
+#define _DEV_USB_H_
 
 #include <sys/ringbuf.h>
 #include <sys/condvar.h>
@@ -149,4 +149,4 @@ typedef struct usb_endpoint_descriptor {
 #define UE_BULK 0x02
 #define UE_INTERRUPT 0x03
 
-#endif /*_USB_H_ */
+#endif /*_DEV_USB_H_ */

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -4,10 +4,6 @@
 #ifndef _DEV_USB_H_
 #define _DEV_USB_H_
 
-#include <sys/ringbuf.h>
-#include <sys/condvar.h>
-#include <sys/spinlock.h>
-
 /* Definition of some hardcoded USB constants. */
 
 #define USB_MAX_IPACKET 8 /* initial USB packet size */
@@ -76,7 +72,7 @@ typedef struct usb_device_descriptor {
   uint8_t bNumConfigurations;
 } __packed usb_device_descriptor_t;
 
-#define US_DATASIZE 126
+#define US_DATASIZE 63
 
 typedef struct usb_string_descriptor {
   uint8_t bLength;
@@ -88,7 +84,7 @@ typedef struct usb_string_descriptor {
 typedef struct usb_string_lang {
   uint8_t bLength;
   uint8_t bDescriptorType;
-  uint8_t bData[US_DATASIZE];
+  uint16_t bData[US_DATASIZE];
 } __packed usb_string_lang_t;
 
 #define US_ENG_LID 0x0409
@@ -149,4 +145,4 @@ typedef struct usb_endpoint_descriptor {
 #define UE_BULK 0x02
 #define UE_INTERRUPT 0x03
 
-#endif /*_DEV_USB_H_ */
+#endif /* _DEV_USB_H_ */

--- a/include/dev/usbhid.h
+++ b/include/dev/usbhid.h
@@ -1,0 +1,24 @@
+/*
+ * Based on FreeBSD `usbhid.h`.
+ */
+#ifndef _HID_H_
+#define _HID_H_
+
+#define UDESC_REPORT 0x01
+#define UR_GET_REPORT 0x01
+#define UR_SET_IDLE 0x0a
+#define UR_SET_PROTOCOL 0x0b
+
+typedef struct usb_hid_descriptor {
+  uint8_t bLength;
+  uint8_t bDescriptorType;
+  uint16_t bcdHID;
+  uint8_t bCountryCode;
+  uint8_t bNumDescriptors;
+  struct {
+    uint8_t bDescriptorType;
+    uint16_t wDescriptorLength;
+  } descrs[1];
+} __packed usb_hid_descriptor_t;
+
+#endif /* _HID_H_ */

--- a/include/dev/usbhid.h
+++ b/include/dev/usbhid.h
@@ -1,8 +1,8 @@
 /*
- * Based on FreeBSD `usbhid.h`.
+ * Based on FreeBSD `sys/dev/usb/usbhid.h`.
  */
-#ifndef _HID_H_
-#define _HID_H_
+#ifndef _DEV_HID_H_
+#define _DEV_HID_H_
 
 #define UDESC_REPORT 0x01
 #define UR_GET_REPORT 0x01
@@ -21,4 +21,4 @@ typedef struct usb_hid_descriptor {
   } descrs[1];
 } __packed usb_hid_descriptor_t;
 
-#endif /* _HID_H_ */
+#endif /* _DEV_HID_H_ */


### PR DESCRIPTION
The presented header files are required by #935.
Presented changes (regarding original files):
- `scsi.h`:
    - `length` and `addr` fields aren't expressed in byte units (i.e. instead of `uint8_t addr[4]` we have `uint32_t addr`). This simplifies little endian <-> big endian conversions.
    - I've added the `SID_FORMAT()` macro (used in drive identification).
- `uhci.h`: this is simply a subset of the original file (with a few stylistic changes).
- `uhcireg.h`:
    - I've added `PCI_USB_CLASSCODE` and `PCI_USB_SUBCLASSCODE`.
    - I've added ` UHCI_PORTSC()` instead of `UHCI_PORTSC{1,2}` (The UHCI specification allows more than two root hub ports).
    - I've added `UHCI_PORTSC_ONE` which is used in root hub port detection (I don't assume any specific number of root hub ports).
- `umass.h`: this file doesn't have a strict counterpart in the FreeBSD source tree. Contained definitions were extracted form the FreeBSD's `sys/dev/usb/storage/umass.c` file. This is in order to make the `umass.c` driver thinner and to contain some definitions required by the USB module (`UR_BBB_RESET` and `UR_BBB_GET_MAX_LUN`).
- `usbhid.h`: this is simply a subset of the original file (without the HID descriptor parsing definitions (we assume the boot protocol is supported)).
- `usb.h`:
    - I've added the `UV_MAKE()` macro (they use some counterpart defined elsewhere).
    - I've added the `US_DATASIZE` constant (they use a magic number).
    - I've added the `US_ENG_LID` and `US_ENG_STR` constants.
    - I've added the `US_TRANSFER_TYPE()` macro.