### PR TITLE
Read subclass code and programming interface fields from PCI configuration space.

### DIFF
--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -42,6 +42,8 @@ extern const char *pci_class_code[];
 #define PCIM_CMD_PORTEN 0x0001
 #define PCIM_CMD_MEMEN 0x0002
 #define PCIM_CMD_BUSMASTEREN 0x0004
+#define PCIR_PROGIF 0x09
+#define PCIR_SUBCLASSCODE 0x0a
 #define PCIR_CLASSCODE 0x0b
 #define PCIR_HEADERTYPE 0x0e
 #define PCIH_HDR_MF 0x80
@@ -88,6 +90,8 @@ typedef struct pci_device {
   uint16_t device_id;
   uint16_t vendor_id;
   uint8_t class_code;
+  uint8_t subclass_code;
+  uint8_t progif;
   uint8_t pin, irq;
 
   pci_bar_t bar[PCI_BAR_MAX];

--- a/sys/kern/pci.c
+++ b/sys/kern/pci.c
@@ -105,8 +105,10 @@ void pci_bus_enumerate(device_t *pcib) {
       dev->instance = pcid;
 
       pcid->addr = PCIA(0, d, f);
-      pcid->device_id = pci_read_config_2(dev, PCIR_DEVICEID);
       pcid->vendor_id = pci_read_config_2(dev, PCIR_VENDORID);
+      pcid->device_id = pci_read_config_2(dev, PCIR_DEVICEID);
+      pcid->progif = pci_read_config(dev, PCIR_PROGIF, 1);
+      pcid->subclass_code = pci_read_config(dev, PCIR_SUBCLASSCODE, 1);
       pcid->class_code = pci_read_config_1(dev, PCIR_CLASSCODE);
       pcid->pin = pci_read_config_1(dev, PCIR_IRQPIN);
       pcid->irq = pci_read_config_1(dev, PCIR_IRQLINE);


### PR DESCRIPTION
Introduce `subclass_code` and `progif` in `pci_device`.