### PR TITLE
kmem: allocate contiguous physical memory

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -5,30 +5,46 @@
 
 typedef struct vm_page vm_page_t;
 
-/*! \brief Called during kernel initialization. */
+/* Initializes kernel virtual address space allocator & manager. */
 void init_kmem(void);
 
-void *kmem_alloc(size_t size, kmem_flags_t flags) __warn_unused;
+/*
+ * Kernel page-sized memory allocator.
+ */
 
-/*! \brief Map consecutive physical pages with given pmap flags. */
-vaddr_t kmem_map(paddr_t pa, size_t size, unsigned flags) __warn_unused;
+void *kmem_alloc(size_t size, kmem_flags_t flags) __warn_unused;
 void kmem_free(void *ptr, size_t size);
 
-/* Allocates contiguous physical memory of `size` pages (in bytes) aligned to at
- * least `PAGESIZE` boundary. The memory will be mapped under address stored
- * under `vap`. First physical address of the region will be stored under `pap`.
- * Memory will be mapped read-write with PMAP_NOCACHE flag.
+/* Allocates contiguous physical memory of `size` bytes aligned to at least
+ * `PAGESIZE` boundary. First physical address of the region will be stored
+ * under `pap`. Memory will be mapped read-write with `flags` passed to
+ * `pmap_kenter`.
  *
- * Returns ENOMEM if could not find enough contiguous physical memory to
- * satisfy the request. */
-int kmem_alloc_contig(size_t size, vaddr_t *vap, paddr_t *pap);
+ * Returns kernel virtual address where the memory is mapped.
+ */
+vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size,
+                          unsigned flags) __warn_unused;
 
-/* Kernel virtual address space allocator. */
+/* Map contiguous physical memory of `size` bytes starting from `pa` address.
+ * Memory will be mapped read-write with `flags` passed to `pmap_kenter`.
+ *
+ * Returns kernel virtual address where the memory is mapped. */
+vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) __warn_unused;
+
+/*
+ * Kernel virtual address space allocator.
+ */
+
+/* Allocates a range of kernel virtual address space of `size` pages (in bytes)
+ * and returns virtual address or NULL. */
 vaddr_t kva_alloc(size_t size);
-void kva_free(vaddr_t ptr, size_t size);
+void kva_free(vaddr_t va, size_t size);
 vm_page_t *kva_find_page(vaddr_t ptr);
 
-void kva_map(vaddr_t ptr, size_t size, kmem_flags_t flags);
-void kva_unmap(vaddr_t ptr, size_t size);
+/*
+ * Allocates and deallocates memory in kernel virtual address space.
+ */
+void kva_map(vaddr_t va, size_t size, kmem_flags_t flags);
+void kva_unmap(vaddr_t va, size_t size);
 
 #endif /* !_SYS_KMEM_H_ */

--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -14,6 +14,15 @@ void *kmem_alloc(size_t size, kmem_flags_t flags) __warn_unused;
 vaddr_t kmem_map(paddr_t pa, size_t size, unsigned flags) __warn_unused;
 void kmem_free(void *ptr, size_t size);
 
+/* Allocates contiguous physical memory of `size` pages (in bytes) aligned to at
+ * least `PAGESIZE` boundary. The memory will be mapped under address stored
+ * under `vap`. First physical address of the region will be stored under `pap`.
+ * Memory will be mapped read-write with PMAP_NOCACHE flag.
+ *
+ * Returns ENOMEM if could not find enough contiguous physical memory to
+ * satisfy the request. */
+int kmem_alloc_contig(size_t size, vaddr_t *vap, paddr_t *pap);
+
 /* Kernel virtual address space allocator. */
 vaddr_t kva_alloc(size_t size);
 void kva_free(vaddr_t ptr, size_t size);

--- a/sys/aarch64/rootdev.c
+++ b/sys/aarch64/rootdev.c
@@ -210,11 +210,12 @@ static int rootdev_attach(device_t *bus) {
   rman_manage_region(&rd->irq_rm, 0, NIRQ);
 
   /* Map BCM2836 shared processor only once. */
-  rootdev_local_handle =
-    kmem_map(BCM2836_ARM_LOCAL_BASE, BCM2836_ARM_LOCAL_SIZE, PMAP_NOCACHE);
+  rootdev_local_handle = kmem_map_contig(BCM2836_ARM_LOCAL_BASE,
+                                         BCM2836_ARM_LOCAL_SIZE, PMAP_NOCACHE);
 
-  rootdev_arm_base = kmem_map(BCM2835_PERIPHERALS_BUS_TO_PHYS(BCM2835_ARM_BASE),
-                              BCM2835_ARM_SIZE, PMAP_NOCACHE);
+  rootdev_arm_base =
+    kmem_map_contig(BCM2835_PERIPHERALS_BUS_TO_PHYS(BCM2835_ARM_BASE),
+                    BCM2835_ARM_SIZE, PMAP_NOCACHE);
 
   intr_root_claim(rootdev_intr_handler, bus, NULL);
 

--- a/sys/kern/bus.c
+++ b/sys/kern/bus.c
@@ -7,7 +7,7 @@
 
 int generic_bs_map(bus_addr_t addr, bus_size_t size,
                    bus_space_handle_t *handle_p) {
-  *handle_p = kmem_map(addr, size, PMAP_NOCACHE);
+  *handle_p = kmem_map_contig(addr, size, PMAP_NOCACHE);
   return 0;
 }
 

--- a/sys/kern/initrd.c
+++ b/sys/kern/initrd.c
@@ -130,7 +130,8 @@ static const char *basename(const char *path) {
 }
 
 static void read_cpio_archive(void) {
-  void *tape = (void *)kmem_map(ramdisk_get_start(), ramdisk_get_size(), 0);
+  void *tape =
+    (void *)kmem_map_contig(ramdisk_get_start(), ramdisk_get_size(), 0);
 
   while (true) {
     cpio_node_t *node = cpio_node_alloc();

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -2,9 +2,9 @@
 #include <sys/klog.h>
 #include <sys/mimiker.h>
 #include <sys/libkern.h>
-#include <sys/errno.h>
 #include <sys/param.h>
 #include <sys/pmap.h>
+#include <sys/kmem.h>
 #include <sys/vmem.h>
 #include <sys/vm.h>
 #include <sys/vm_physmem.h>
@@ -104,7 +104,7 @@ void *kmem_alloc(size_t size, kmem_flags_t flags) {
   return (void *)start;
 }
 
-int kmem_alloc_contig(size_t size, vaddr_t *vap, paddr_t *pap) {
+vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, unsigned flags) {
   assert(page_aligned_p(size) && powerof2(size));
 
   vaddr_t va;
@@ -114,8 +114,8 @@ int kmem_alloc_contig(size_t size, vaddr_t *vap, paddr_t *pap) {
   size_t n = size / PAGESIZE;
   vm_page_t *pg = vm_page_alloc(n);
   if (!pg) {
-    vmem_free(kvspace, *vap, size);
-    return ENOMEM;
+    vmem_free(kvspace, va, size);
+    return 0;
   }
 
   /* Mark the entire block as valid */
@@ -123,9 +123,8 @@ int kmem_alloc_contig(size_t size, vaddr_t *vap, paddr_t *pap) {
 
   kva_map_page(va, pg->paddr, pg->size, PMAP_NOCACHE);
 
-  *vap = va;
   *pap = pg->paddr;
-  return 0;
+  return va;
 }
 
 void kmem_free(void *ptr, size_t size) {
@@ -134,7 +133,7 @@ void kmem_free(void *ptr, size_t size) {
   vmem_free(kvspace, (vmem_addr_t)ptr, size);
 }
 
-vaddr_t kmem_map(paddr_t pa, size_t size, unsigned flags) {
+vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) {
   assert(page_aligned_p(pa) && page_aligned_p(size));
 
   vmem_addr_t start;

--- a/sys/mips/uart_cbus.c
+++ b/sys/mips/uart_cbus.c
@@ -34,7 +34,7 @@ static void cbus_uart_init(console_t *dev __unused) {
   /* TODO(pj) This resource allocation should be done in parent of
    * cbus_uart device. Unfortunately now we don't have fully working device
    * infrastructure. It should be changed after done with DEVCLASS. */
-  vaddr_t handle = kmem_map(MALTA_FPGA_BASE, PAGESIZE, PMAP_NOCACHE);
+  vaddr_t handle = kmem_map_contig(MALTA_FPGA_BASE, PAGESIZE, PMAP_NOCACHE);
   cbus_uart->r_bus_handle = handle + MALTA_CBUS_UART_OFFSET;
 
   set(LCR, LCR_DLAB);


### PR DESCRIPTION
`kmem_alloc_contig` is mainly geared toward device driver programmers. It's main use case is to allocate memory for DMA transfers.