### PR TITLE
AArch64: disable interrupts in user_exc_leave.

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -26,7 +26,7 @@ DSTPATH = $(DIR)$@
 
 %.o: %.S
 	@echo "[AS] $(SRCPATH) -> $(DSTPATH)"
-	$(AS) $(ASFLAGS) $(CPPFLAGS) -c -o $@ $(realpath $<)
+	$(AS) $(ASFLAGS) $(CPPFLAGS) $(WFLAGS) -c -o $@ $(realpath $<)
 
 %.c: %.y
 	@echo "[YACC] $(SCRPATH) -> $(DSTPATH)"

--- a/include/aarch64/armreg.h
+++ b/include/aarch64/armreg.h
@@ -122,11 +122,15 @@
 #define CTR_ILINE_VAL(reg) ((reg)&CTR_ILINE_MASK)
 #define CTR_ILINE_SIZE(reg) (4 << (CTR_ILINE_VAL(reg) >> CTR_ILINE_SHIFT))
 
-/* DAIF - Interrupt Mask Bits */
-#define DAIF_D_MASKED (1 << 9)
-#define DAIF_A_MASKED (1 << 8)
-#define DAIF_I_MASKED (1 << 7)
-#define DAIF_F_MASKED (1 << 6)
+/*
+ * DAIF - Interrupt Mask Bits
+ * Use that flags only for daifset, daifclr registers.
+ * For read-only daif register use PSR_*.
+ */
+#define DAIF_D (1 << 3)
+#define DAIF_A (1 << 2)
+#define DAIF_I (1 << 1)
+#define DAIF_F (1 << 0)
 
 /* DCZID_EL0 - Data Cache Zero ID register */
 #define DCZID_DZP (1 << 4) /* DC ZVA prohibited if non-0 */

--- a/lib/libc/aarch64/genassym.cf
+++ b/lib/libc/aarch64/genassym.cf
@@ -61,6 +61,7 @@ define SS_ONSTACK       SS_ONSTACK
 define _UC_SIGMASK      _UC_SIGMASK
 define _UC_CPU          _UC_CPU
 define _UC_FPU          _UC_FPU
+define _UC_STACK        _UC_STACK
 
 define UC_FPREGS_Q0 offsetof(ucontext_t, uc_mcontext.__fregs.__qregs[0])
 define UC_FPREGS_Q1 offsetof(ucontext_t, uc_mcontext.__fregs.__qregs[1])

--- a/lib/libc/gen/aarch64/setjmp.S
+++ b/lib/libc/gen/aarch64/setjmp.S
@@ -1,5 +1,4 @@
 #include <aarch64/asm.h>
-#include <sys/ucontext.h>
 #include <sys/syscall.h>
 
 #include "aarch64/assym.h"

--- a/sys/aarch64/evec.S
+++ b/sys/aarch64/evec.S
@@ -165,6 +165,9 @@ ENTRY(handle_user_trap)
         mov     x0, sp
         bl      user_trap_handler
 user_exc_leave:
+        /* disable interrupts */
+        msr     daifset, (DAIF_I_MASKED >> 6)
+
         /* load thread_t::tdp_flags */
         /* thread_t::tdp_flags is a volatile unsigned - use 32-bit */
         load_pcpu x1

--- a/sys/aarch64/evec.S
+++ b/sys/aarch64/evec.S
@@ -166,7 +166,7 @@ ENTRY(handle_user_trap)
         bl      user_trap_handler
 user_exc_leave:
         /* disable interrupts */
-        msr     daifset, (DAIF_I_MASKED >> 6)
+        msr     daifset, #DAIF_I
 
         /* load thread_t::tdp_flags */
         /* thread_t::tdp_flags is a volatile unsigned - use 32-bit */

--- a/sys/aarch64/genassym.cf
+++ b/sys/aarch64/genassym.cf
@@ -5,6 +5,8 @@ include <sys/proc.h>
 include <aarch64/mcontext.h>
 include <aarch64/armreg.h>
 
+define DAIF_I_MASKED DAIF_I_MASKED
+
 define TD_PROC offsetof(thread_t, td_proc)
 define TD_KCTX offsetof(thread_t, td_kctx)
 define TD_UCTX offsetof(thread_t, td_uctx)

--- a/sys/aarch64/genassym.cf
+++ b/sys/aarch64/genassym.cf
@@ -5,7 +5,8 @@ include <sys/proc.h>
 include <aarch64/mcontext.h>
 include <aarch64/armreg.h>
 
-define DAIF_I_MASKED DAIF_I_MASKED
+define PSR_I PSR_I
+define DAIF_I DAIF_I
 
 define TD_PROC offsetof(thread_t, td_proc)
 define TD_KCTX offsetof(thread_t, td_kctx)

--- a/sys/aarch64/interrupt.c
+++ b/sys/aarch64/interrupt.c
@@ -2,17 +2,15 @@
 #include <aarch64/interrupt.h>
 #include <aarch64/armreg.h>
 
-#define _DAIF(x) ((DAIF_##x##_MASKED) >> 6)
-
 void cpu_intr_disable(void) {
-  __asm __volatile("msr daifset, %0" ::"i"(_DAIF(I)));
+  __asm __volatile("msr daifset, %0" ::"i"(DAIF_I));
 }
 
 void cpu_intr_enable(void) {
-  __asm __volatile("msr daifclr, %0" ::"i"(_DAIF(I)));
+  __asm __volatile("msr daifclr, %0" ::"i"(DAIF_I));
 }
 
 bool cpu_intr_disabled(void) {
   uint32_t daif = READ_SPECIALREG(daif);
-  return (daif & DAIF_I_MASKED) != 0;
+  return (daif & PSR_I) != 0;
 }

--- a/sys/aarch64/switch.S
+++ b/sys/aarch64/switch.S
@@ -70,7 +70,7 @@
 ENTRY(ctx_switch)
         # ctx_switch must be called with interrupts disabled
         mrs     x2, daif
-        and     x2, x2, #DAIF_I_MASKED
+        and     x2, x2, #PSR_I
         cmp     x2, xzr
         bne     .ctx_save
         hlt     #0

--- a/sys/aarch64/switch.S
+++ b/sys/aarch64/switch.S
@@ -1,5 +1,4 @@
 #include <aarch64/asm.h>
-#include <aarch64/armreg.h>
 #include <aarch64/pcpu.h>
 
 #include "assym.h"

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -148,7 +148,7 @@ void kern_trap_handler(ctx_t *ctx) {
   register_t far = READ_SPECIALREG(far_el1);
 
   /* If interrupts were enabled before we trapped, then turn them on here. */
-  if ((_REG(ctx, SPSR) & DAIF_I_MASKED) == 0)
+  if ((_REG(ctx, SPSR) & PSR_I) == 0)
     cpu_intr_enable();
 
   switch (ESR_ELx_EXCEPTION(esr)) {


### PR DESCRIPTION
Disable interrupts in `user_exc_leave`.