### PR TITLE
AArch64: map kernel pages with VM_PROT_NONE without read permissions.

### DIFF
--- a/include/aarch64/pte.h
+++ b/include/aarch64/pte.h
@@ -58,17 +58,14 @@ typedef uint64_t pde_t;
 #define ATTR_DBM (1UL << 51)
 #define ATTR_nG (1 << 11)
 #define ATTR_AF (1 << 10)
-#define ATTR_SH(x) ((x) << 8)
-#define ATTR_SH_MASK ATTR_SH(3)
-#define ATTR_SH_NS 0 /* Non-shareable */
-#define ATTR_SH_OS 2 /* Outer-shareable */
-#define ATTR_SH_IS 3 /* Inner-shareable */
-#define ATTR_AP_RW_BIT (1 << 7)
-#define ATTR_AP(x) ((x) << 6)
-#define ATTR_AP_MASK ATTR_AP(3)
-#define ATTR_AP_RW (0 << 1)
-#define ATTR_AP_RO (1 << 1)
-#define ATTR_AP_USER (1 << 0)
+#define ATTR_SH_MASK (3 << 8)
+#define ATTR_SH_NS (0 << 8) /* Non-shareable */
+#define ATTR_SH_OS (2 << 8) /* Outer-shareable */
+#define ATTR_SH_IS (3 << 8) /* Inner-shareable */
+#define ATTR_AP_MASK (3 << 6)
+#define ATTR_AP_RW (0 << 6)
+#define ATTR_AP_RO (2 << 6)
+#define ATTR_AP_USER (1 << 6)
 #define ATTR_NS (1 << 5)
 #define ATTR_IDX(x) ((x) << 2)
 #define ATTR_IDX_MASK (7 << 2)
@@ -78,10 +75,9 @@ typedef uint64_t pde_t;
 #define ATTR_NORMAL_MEM_WB 2
 #define ATTR_NORMAL_MEM_WT 3
 
-#define ATTR_S2_S2AP(x) ((x) << 6)
-#define ATTR_S2_S2AP_MASK 3
-#define ATTR_S2_S2AP_READ 1
-#define ATTR_S2_S2AP_WRITE 2
+#define ATTR_S2_S2AP_MASK (3 << 6)
+#define ATTR_S2_S2AP_READ (1 << 6)
+#define ATTR_S2_S2AP_WRITE (2 << 6)
 
 /* Level 0 table, 512GiB per entry */
 #define L0_SHIFT 39

--- a/include/aarch64/pte.h
+++ b/include/aarch64/pte.h
@@ -55,7 +55,7 @@ typedef uint64_t pde_t;
 #define ATTR_PXN (1UL << 53)
 #define ATTR_XN (ATTR_PXN | ATTR_UXN)
 #define ATTR_CONTIGUOUS (1UL << 52)
-#define ATTR_DBM (1UL << 51) /* Dirty Bit Modifer */
+#define ATTR_DBM (1UL << 51) /* Dirty Bit Modifier */
 #define ATTR_nG (1 << 11)
 #define ATTR_AF (1 << 10) /* Access Flag = 0: MMU faults on any access */
 #define ATTR_SH_MASK (3 << 8)

--- a/include/aarch64/pte.h
+++ b/include/aarch64/pte.h
@@ -55,7 +55,7 @@ typedef uint64_t pde_t;
 #define ATTR_PXN (1UL << 53)
 #define ATTR_XN (ATTR_PXN | ATTR_UXN)
 #define ATTR_CONTIGUOUS (1UL << 52)
-#define ATTR_DBM (1UL << 51) /* Dirty Bit Modifer = 0: MMU faults of write */
+#define ATTR_DBM (1UL << 51) /* Dirty Bit Modifer */
 #define ATTR_nG (1 << 11)
 #define ATTR_AF (1 << 10) /* Access Flag = 0: MMU faults on any access */
 #define ATTR_SH_MASK (3 << 8)

--- a/include/aarch64/pte.h
+++ b/include/aarch64/pte.h
@@ -55,8 +55,10 @@ typedef uint64_t pde_t;
 #define ATTR_PXN (1UL << 53)
 #define ATTR_XN (ATTR_PXN | ATTR_UXN)
 #define ATTR_CONTIGUOUS (1UL << 52)
+/* Dirty bit. */
 #define ATTR_DBM (1UL << 51)
 #define ATTR_nG (1 << 11)
+/* Access to page without AF bit triggers an MMU fault. */
 #define ATTR_AF (1 << 10)
 #define ATTR_SH_MASK (3 << 8)
 #define ATTR_SH_NS (0 << 8) /* Non-shareable */

--- a/include/aarch64/pte.h
+++ b/include/aarch64/pte.h
@@ -55,11 +55,9 @@ typedef uint64_t pde_t;
 #define ATTR_PXN (1UL << 53)
 #define ATTR_XN (ATTR_PXN | ATTR_UXN)
 #define ATTR_CONTIGUOUS (1UL << 52)
-/* Dirty bit. */
-#define ATTR_DBM (1UL << 51)
+#define ATTR_DBM (1UL << 51) /* Dirty Bit Modifer = 0: MMU faults of write */
 #define ATTR_nG (1 << 11)
-/* Access to page without AF bit triggers an MMU fault. */
-#define ATTR_AF (1 << 10)
+#define ATTR_AF (1 << 10) /* Access Flag = 0: MMU faults on any access */
 #define ATTR_SH_MASK (3 << 8)
 #define ATTR_SH_NS (0 << 8) /* Non-shareable */
 #define ATTR_SH_OS (2 << 8) /* Outer-shareable */

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -167,21 +167,21 @@ __boot_text static paddr_t build_page_table(void) {
   }
 
   const pte_t pte_default =
-    L3_PAGE | ATTR_AF | ATTR_SH(ATTR_SH_IS) | ATTR_IDX(ATTR_NORMAL_MEM_WB);
+    L3_PAGE | ATTR_AF | ATTR_SH_IS | ATTR_IDX(ATTR_NORMAL_MEM_WB);
 
   paddr_t pa = (paddr_t)__boot;
 
   /* boot sections */
   for (; pa < text; pa += PAGESIZE, va += PAGESIZE)
-    l3[L3_INDEX(va)] = pa | ATTR_AP(ATTR_AP_RW) | pte_default;
+    l3[L3_INDEX(va)] = pa | ATTR_AP_RW | pte_default;
 
   /* text section */
   for (; pa < data; pa += PAGESIZE, va += PAGESIZE)
-    l3[L3_INDEX(va)] = pa | ATTR_AP(ATTR_AP_RO) | pte_default;
+    l3[L3_INDEX(va)] = pa | ATTR_AP_RO | pte_default;
 
   /* data & bss sections */
   for (; pa < ebss; pa += PAGESIZE, va += PAGESIZE)
-    l3[L3_INDEX(va)] = pa | ATTR_AP(ATTR_AP_RW) | ATTR_XN | pte_default;
+    l3[L3_INDEX(va)] = pa | ATTR_AP_RW | ATTR_XN | pte_default;
 
   /* direct map construction */
   volatile pde_t *l1d = bootmem_alloc(DMAP_L1_SIZE);
@@ -189,7 +189,7 @@ __boot_text static paddr_t build_page_table(void) {
   volatile pde_t *l3d = bootmem_alloc(DMAP_L3_SIZE);
 
   for (intptr_t i = 0; i < DMAP_L3_ENTRIES; i++)
-    l3d[i] = (i * PAGESIZE) | ATTR_AP(ATTR_AP_RW) | ATTR_XN | pte_default;
+    l3d[i] = (i * PAGESIZE) | ATTR_AP_RW | ATTR_XN | pte_default;
 
   for (intptr_t i = 0; i < DMAP_L2_ENTRIES; i++)
     l2d[i] = (pde_t)&l3d[i * PT_ENTRIES] | L2_TABLE;

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -46,16 +46,16 @@ static const pte_t vm_prot_map[] = {
   [VM_PROT_READ] =
     ATTR_AP_RO | ATTR_SW_READ | ATTR_AF | pte_noexec | pte_common,
   [VM_PROT_WRITE] =
-    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | ATTR_AF | pte_noexec | pte_common,
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_AF | pte_noexec | pte_common,
   [VM_PROT_READ | VM_PROT_WRITE] = ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE |
-                                   ATTR_DBM | ATTR_AF | pte_noexec | pte_common,
+                                   ATTR_AF | pte_noexec | pte_common,
   [VM_PROT_EXEC] = ATTR_AF | pte_common,
   [VM_PROT_READ | VM_PROT_EXEC] =
     ATTR_AP_RO | ATTR_SW_READ | ATTR_AF | pte_common,
   [VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | ATTR_AF | pte_common,
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_AF | pte_common,
   [VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_DBM | ATTR_AF | pte_common,
+    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_AF | pte_common,
 };
 
 static pmap_t kernel_pmap;
@@ -353,7 +353,7 @@ void pmap_enter(pmap_t *pmap, vaddr_t va, vm_page_t *pg, vm_prot_t prot,
   bool kern_mapping = (pmap == pmap_kernel());
 
   /* Mark user pages as non-referenced & non-modified. */
-  pte_t mask = kern_mapping ? 0UL : (ATTR_AF | ATTR_DBM);
+  pte_t mask = kern_mapping ? 0UL : (ATTR_AF);
   pte_t pte = make_pte(pa, vm_prot_map[prot] & ~mask, flags);
 
   WITH_MTX_LOCK (pv_list_lock) {
@@ -471,7 +471,7 @@ bool pmap_clear_referenced(vm_page_t *pg) {
 bool pmap_clear_modified(vm_page_t *pg) {
   bool prev = pmap_is_modified(pg);
   pg->flags &= ~PG_MODIFIED;
-  pmap_modify_flags(pg, ATTR_AP_RO, ATTR_DBM);
+  pmap_modify_flags(pg, ATTR_AP_RO, 0);
   return prev;
 }
 
@@ -490,7 +490,7 @@ void pmap_set_referenced(vm_page_t *pg) {
 
 void pmap_set_modified(vm_page_t *pg) {
   pg->flags |= PG_MODIFIED;
-  pmap_modify_flags(pg, ATTR_DBM, ATTR_AP_RO);
+  pmap_modify_flags(pg, 0, ATTR_AP_RO);
 }
 
 int pmap_emulate_bits(pmap_t *pmap, vaddr_t va, vm_prot_t prot) {

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -38,20 +38,22 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */
 #define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
 
-static const pte_t pte_default = L3_PAGE | ATTR_DBM | ATTR_AF | ATTR_SH_IS;
+static const pte_t pte_default = L3_PAGE | ATTR_AF | ATTR_SH_IS;
 static const pte_t pte_noexec = ATTR_XN | ATTR_SW_NOEXEC;
 
 static const pte_t vm_prot_map[] = {
   [VM_PROT_NONE] = L3_PAGE | ATTR_SH_IS | pte_noexec,
   [VM_PROT_READ] = ATTR_AP_RO | ATTR_SW_READ | pte_noexec | pte_default,
-  [VM_PROT_WRITE] = ATTR_AP_RW | ATTR_SW_WRITE | pte_noexec | pte_default,
-  [VM_PROT_READ | VM_PROT_WRITE] =
-    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | pte_noexec | pte_default,
+  [VM_PROT_WRITE] =
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_noexec | pte_default,
+  [VM_PROT_READ | VM_PROT_WRITE] = ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE |
+                                   ATTR_DBM | pte_noexec | pte_default,
   [VM_PROT_EXEC] = pte_default,
   [VM_PROT_READ | VM_PROT_EXEC] = ATTR_AP_RO | ATTR_SW_READ | pte_default,
-  [VM_PROT_WRITE | VM_PROT_EXEC] = ATTR_AP_RW | ATTR_SW_WRITE | pte_default,
+  [VM_PROT_WRITE | VM_PROT_EXEC] =
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_default,
   [VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | pte_default,
+    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_DBM | pte_default,
 };
 
 static pmap_t kernel_pmap;

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -38,22 +38,22 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */
 #define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
 
-static const pte_t pte_default = L3_PAGE | ATTR_AF | ATTR_SH_IS;
+static const pte_t pte_common = L3_PAGE | ATTR_AF | ATTR_SH_IS;
 static const pte_t pte_noexec = ATTR_XN | ATTR_SW_NOEXEC;
 
 static const pte_t vm_prot_map[] = {
   [VM_PROT_NONE] = L3_PAGE | ATTR_SH_IS | pte_noexec,
-  [VM_PROT_READ] = ATTR_AP_RO | ATTR_SW_READ | pte_noexec | pte_default,
+  [VM_PROT_READ] = ATTR_AP_RO | ATTR_SW_READ | pte_noexec | pte_common,
   [VM_PROT_WRITE] =
-    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_noexec | pte_default,
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_noexec | pte_common,
   [VM_PROT_READ | VM_PROT_WRITE] = ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE |
-                                   ATTR_DBM | pte_noexec | pte_default,
-  [VM_PROT_EXEC] = pte_default,
-  [VM_PROT_READ | VM_PROT_EXEC] = ATTR_AP_RO | ATTR_SW_READ | pte_default,
+                                   ATTR_DBM | pte_noexec | pte_common,
+  [VM_PROT_EXEC] = pte_common,
+  [VM_PROT_READ | VM_PROT_EXEC] = ATTR_AP_RO | ATTR_SW_READ | pte_common,
   [VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_default,
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_common,
   [VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_DBM | pte_default,
+    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_DBM | pte_common,
 };
 
 static pmap_t kernel_pmap;

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -38,6 +38,28 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */
 #define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
 
+/*
+ * This table describes which access bits need to be set in page table entry
+ * for successful memory translation by MMU. Other configurations causes memory
+ * fault - see aarch64/trap.c.
+ *
+ * +--------------+----+------+----+----+
+ * |    access    | AF | USER | RO | XN |
+ * +==============+====+======+====+====+
+ * | user read    | 1  | 1    | *  | *  |
+ * +--------------+----+------+----+----+
+ * | user write   | 1  | 1    | 0  | *  |
+ * +--------------+----+------+----+----+
+ * | user exec    | 1  | 1    | *  | 0  |
+ * +--------------+----+------+----+----+
+ * | kernel read  | 1  | *    | *  | *  |
+ * +--------------+----+------+----+----+
+ * | kernel write | 1  | *    | 0  | *  |
+ * +--------------+----+------+----+----+
+ * | kernel exec  | 1  | *    | *  | 0  |
+ * +--------------+----+------+----+----+
+ */
+
 static const pte_t pte_common = L3_PAGE | ATTR_SH_IS;
 static const pte_t pte_noexec = ATTR_XN | ATTR_SW_NOEXEC;
 

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -38,22 +38,24 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */
 #define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
 
-static const pte_t pte_common = L3_PAGE | ATTR_AF | ATTR_SH_IS;
+static const pte_t pte_common = L3_PAGE | ATTR_SH_IS;
 static const pte_t pte_noexec = ATTR_XN | ATTR_SW_NOEXEC;
 
 static const pte_t vm_prot_map[] = {
-  [VM_PROT_NONE] = L3_PAGE | ATTR_SH_IS | pte_noexec,
-  [VM_PROT_READ] = ATTR_AP_RO | ATTR_SW_READ | pte_noexec | pte_common,
+  [VM_PROT_NONE] = pte_noexec | pte_common,
+  [VM_PROT_READ] =
+    ATTR_AP_RO | ATTR_SW_READ | ATTR_AF | pte_noexec | pte_common,
   [VM_PROT_WRITE] =
-    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_noexec | pte_common,
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | ATTR_AF | pte_noexec | pte_common,
   [VM_PROT_READ | VM_PROT_WRITE] = ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE |
-                                   ATTR_DBM | pte_noexec | pte_common,
-  [VM_PROT_EXEC] = pte_common,
-  [VM_PROT_READ | VM_PROT_EXEC] = ATTR_AP_RO | ATTR_SW_READ | pte_common,
+                                   ATTR_DBM | ATTR_AF | pte_noexec | pte_common,
+  [VM_PROT_EXEC] = ATTR_AF | pte_common,
+  [VM_PROT_READ | VM_PROT_EXEC] =
+    ATTR_AP_RO | ATTR_SW_READ | ATTR_AF | pte_common,
   [VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | pte_common,
+    ATTR_AP_RW | ATTR_SW_WRITE | ATTR_DBM | ATTR_AF | pte_common,
   [VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_DBM | pte_common,
+    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | ATTR_DBM | ATTR_AF | pte_common,
 };
 
 static pmap_t kernel_pmap;

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -43,7 +43,7 @@ static const pte_t pte_default =
 static const pte_t pte_noexec = ATTR_XN | ATTR_SW_NOEXEC;
 
 static const pte_t vm_prot_map[] = {
-  [VM_PROT_NONE] = ATTR_XN | pte_noexec | pte_default,
+  [VM_PROT_NONE] = L3_PAGE | ATTR_SH(ATTR_SH_IS) | pte_noexec,
   [VM_PROT_READ] =
     ATTR_AP(ATTR_AP_RO) | ATTR_SW_READ | pte_noexec | pte_default,
   [VM_PROT_WRITE] =

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -38,25 +38,20 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */
 #define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
 
-static const pte_t pte_default =
-  L3_PAGE | ATTR_DBM | ATTR_AF | ATTR_SH(ATTR_SH_IS);
+static const pte_t pte_default = L3_PAGE | ATTR_DBM | ATTR_AF | ATTR_SH_IS;
 static const pte_t pte_noexec = ATTR_XN | ATTR_SW_NOEXEC;
 
 static const pte_t vm_prot_map[] = {
-  [VM_PROT_NONE] = L3_PAGE | ATTR_SH(ATTR_SH_IS) | pte_noexec,
-  [VM_PROT_READ] =
-    ATTR_AP(ATTR_AP_RO) | ATTR_SW_READ | pte_noexec | pte_default,
-  [VM_PROT_WRITE] =
-    ATTR_AP(ATTR_AP_RW) | ATTR_SW_WRITE | pte_noexec | pte_default,
-  [VM_PROT_READ | VM_PROT_WRITE] = ATTR_AP(ATTR_AP_RW) | ATTR_SW_READ |
-                                   ATTR_SW_WRITE | pte_noexec | pte_default,
+  [VM_PROT_NONE] = L3_PAGE | ATTR_SH_IS | pte_noexec,
+  [VM_PROT_READ] = ATTR_AP_RO | ATTR_SW_READ | pte_noexec | pte_default,
+  [VM_PROT_WRITE] = ATTR_AP_RW | ATTR_SW_WRITE | pte_noexec | pte_default,
+  [VM_PROT_READ | VM_PROT_WRITE] =
+    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | pte_noexec | pte_default,
   [VM_PROT_EXEC] = pte_default,
-  [VM_PROT_READ | VM_PROT_EXEC] =
-    ATTR_AP(ATTR_AP_RO) | ATTR_SW_READ | pte_default,
-  [VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP(ATTR_AP_RW) | ATTR_SW_WRITE | pte_default,
+  [VM_PROT_READ | VM_PROT_EXEC] = ATTR_AP_RO | ATTR_SW_READ | pte_default,
+  [VM_PROT_WRITE | VM_PROT_EXEC] = ATTR_AP_RW | ATTR_SW_WRITE | pte_default,
   [VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC] =
-    ATTR_AP(ATTR_AP_RW) | ATTR_SW_READ | ATTR_SW_WRITE | pte_default,
+    ATTR_AP_RW | ATTR_SW_READ | ATTR_SW_WRITE | pte_default,
 };
 
 static pmap_t kernel_pmap;
@@ -226,7 +221,7 @@ static pte_t make_pte(paddr_t pa, pte_t prot, unsigned flags) {
 
 static void pmap_write_pte(pmap_t *pmap, pte_t *ptep, pte_t pte, vaddr_t va) {
   if (pmap != pmap_kernel())
-    pte |= ATTR_AP(ATTR_AP_USER);
+    pte |= ATTR_AP_USER;
   *ptep = pte;
   tlb_invalidate(va, pmap->asid);
 }
@@ -472,7 +467,7 @@ bool pmap_clear_referenced(vm_page_t *pg) {
 bool pmap_clear_modified(vm_page_t *pg) {
   bool prev = pmap_is_modified(pg);
   pg->flags &= ~PG_MODIFIED;
-  pmap_modify_flags(pg, ATTR_AP(ATTR_AP_RO), ATTR_DBM);
+  pmap_modify_flags(pg, ATTR_AP_RO, ATTR_DBM);
   return prev;
 }
 
@@ -491,7 +486,7 @@ void pmap_set_referenced(vm_page_t *pg) {
 
 void pmap_set_modified(vm_page_t *pg) {
   pg->flags |= PG_MODIFIED;
-  pmap_modify_flags(pg, ATTR_DBM, ATTR_AP(ATTR_AP_RO));
+  pmap_modify_flags(pg, ATTR_DBM, ATTR_AP_RO);
 }
 
 int pmap_emulate_bits(pmap_t *pmap, vaddr_t va, vm_prot_t prot) {


### PR DESCRIPTION
Map kernel pages with `VM_PROT_NONE` without read permissions.

It fixes pmap_kenter and rmbits from #932.