### PR TITLE
AArch64: validate status register in setcontext syscall.

### DIFF
--- a/include/aarch64/armreg.h
+++ b/include/aarch64/armreg.h
@@ -734,6 +734,7 @@
 #define PSR_C 0x20000000
 #define PSR_Z 0x40000000
 #define PSR_N 0x80000000
+#define PSR_NZCV (PSR_N | PSR_Z | PSR_C | PSR_V)
 #define PSR_FLAGS 0xf0000000
 
 /* TCR_EL1 - Translation Control Register */

--- a/lib/libc/aarch64/genassym.cf
+++ b/lib/libc/aarch64/genassym.cf
@@ -2,8 +2,10 @@ include <sys/types.h>
 include <ucontext.h>
 include <signal.h>
 include <aarch64/abi.h>
+include <aarch64/armreg.h>
 
 define CALLFRAME_SIZ        CALLFRAME_SIZ
+define PSR_NZCV             PSR_NZCV
 define UCONTEXT_SIZE		sizeof(ucontext_t)
 
 define UC_REGS_X0 offsetof(ucontext_t, uc_mcontext.__gregs[_REG_X0])

--- a/lib/libc/gen/aarch64/longjmp.c
+++ b/lib/libc/gen/aarch64/longjmp.c
@@ -10,6 +10,7 @@
 void longjmp(jmp_buf env, int val) {
   ucontext_t *sc_uc = (void *)env;
   ucontext_t uc;
+  memset(&uc, 0, sizeof(ucontext_t));
 
   /* Ensure non-zero SP */
   if (_REG(sc_uc, SP) == 0)
@@ -46,6 +47,8 @@ void longjmp(jmp_buf env, int val) {
   _REG(&uc, SP) = _REG(sc_uc, SP);
   _REG(&uc, LR) = _REG(sc_uc, LR);
   _REG(&uc, PC) = _REG(sc_uc, PC);
+  _REG(&uc, SPSR) = _REG(sc_uc, SPSR);
+  _REG(&uc, TPIDR) = _REG(sc_uc, TPIDR);
 
   if (sc_uc->uc_flags & _UC_FPU) {
     memcpy(&uc.uc_mcontext.__fregs, &sc_uc->uc_mcontext.__fregs,

--- a/sys/aarch64/context.c
+++ b/sys/aarch64/context.c
@@ -58,8 +58,18 @@ int do_setcontext(thread_t *td, ucontext_t *uc) {
   mcontext_t *from = &uc->uc_mcontext;
   mcontext_t *to = td->td_uctx;
 
-  if (uc->uc_flags & _UC_CPU)
-    memcpy(&to->__gregs, &from->__gregs, sizeof(register_t) * (_REG_ELR + 1));
+  if (uc->uc_flags & _UC_CPU) {
+    register_t spsr = _REG(from, SPSR);
+    /* Validate CPU context. */
+    if (spsr & ~PSR_NZCV)
+      return EINVAL;
+
+    /* Allow only NZCV bits modification. */
+    spsr = (_REG(from, SPSR) & ~PSR_NZCV) | (_REG(to, SPSR) & PSR_NZCV);
+    _REG(from, SPSR) = spsr;
+
+    memcpy(&to->__gregs, &from->__gregs, sizeof(__gregset_t));
+  }
 
   /* 32 FP registers + FPCR + FPSR */
   if (uc->uc_flags & _UC_FPU)

--- a/sys/aarch64/context.c
+++ b/sys/aarch64/context.c
@@ -59,7 +59,7 @@ int do_setcontext(thread_t *td, ucontext_t *uc) {
   mcontext_t *to = td->td_uctx;
 
   if (uc->uc_flags & _UC_CPU)
-    memcpy(&to->__gregs, &from->__gregs, sizeof(__gregset_t));
+    memcpy(&to->__gregs, &from->__gregs, sizeof(register_t) * (_REG_ELR + 1));
 
   /* 32 FP registers + FPCR + FPSR */
   if (uc->uc_flags & _UC_FPU)

--- a/sys/aarch64/context.c
+++ b/sys/aarch64/context.c
@@ -65,7 +65,7 @@ int do_setcontext(thread_t *td, ucontext_t *uc) {
       return EINVAL;
 
     /* Allow only NZCV bits modification. */
-    spsr = (_REG(from, SPSR) & ~PSR_NZCV) | (_REG(to, SPSR) & PSR_NZCV);
+    spsr = (_REG(from, SPSR) & PSR_NZCV) | (_REG(to, SPSR) & ~PSR_NZCV);
     _REG(from, SPSR) = spsr;
 
     memcpy(&to->__gregs, &from->__gregs, sizeof(__gregset_t));

--- a/sys/aarch64/context.c
+++ b/sys/aarch64/context.c
@@ -65,7 +65,7 @@ int do_setcontext(thread_t *td, ucontext_t *uc) {
       return EINVAL;
 
     /* Allow only NZCV bits modification. */
-    spsr = (_REG(from, SPSR) & PSR_NZCV) | (_REG(to, SPSR) & ~PSR_NZCV);
+    spsr |= _REG(to, SPSR) & ~PSR_NZCV;
     _REG(from, SPSR) = spsr;
 
     memcpy(&to->__gregs, &from->__gregs, sizeof(__gregset_t));

--- a/sys/aarch64/evec.S
+++ b/sys/aarch64/evec.S
@@ -84,7 +84,7 @@
 .endif
         ldr     x10, [sp, #CTX_ELR]
         msr     elr_el1, x10
-        ldr     w11, [sp, #CTX_SPSR]
+        ldr     x11, [sp, #CTX_SPSR]
         msr     spsr_el1, x11
         ldp     x0,  x1,  [sp, #CTX_X0]
         ldp     x2,  x3,  [sp, #CTX_X2]


### PR DESCRIPTION
Validate status register in setcontext syscall.

It fixes sigaction_with_setjmp, mmap_prot_none, mmap_prot_read from #932.