### PR TITLE
Fix deadlock caused by call to pmap_page_remove in pm_free_from_seg

### DIFF
--- a/include/sys/vm.h
+++ b/include/sys/vm.h
@@ -41,6 +41,7 @@ typedef TAILQ_HEAD(vm_pagelist, vm_page) vm_pagelist_t;
 typedef struct pv_entry pv_entry_t;
 typedef struct vm_object vm_object_t;
 typedef struct slab slab_t;
+typedef uintptr_t vm_offset_t;
 
 /* Field marking and corresponding locks:
  * (@) pv_list_lock (in pmap.c)
@@ -58,7 +59,7 @@ struct vm_page {
   };
   TAILQ_HEAD(, pv_entry) pv_list; /* (@) where this page is mapped? */
   vm_object_t *object;            /* (O) object owning that page */
-  off_t offset;                   /* (O) offset to page in vm_object */
+  vm_offset_t offset;             /* (O) offset to page in vm_object */
   paddr_t paddr;                  /* (P) physical address of page */
   pg_flags_t flags;               /* (P) page flags (used by physmem as well) */
   uint32_t size;                  /* (P) size of page in PAGESIZE units */

--- a/include/sys/vm_object.h
+++ b/include/sys/vm_object.h
@@ -24,8 +24,7 @@ typedef struct vm_object {
 vm_object_t *vm_object_alloc(vm_pgr_type_t type);
 void vm_object_free(vm_object_t *obj);
 void vm_object_add_page(vm_object_t *obj, off_t offset, vm_page_t *pg);
-void vm_object_remove_page(vm_object_t *obj, vm_page_t *pg);
-void vm_object_remove_range(vm_object_t *obj, off_t offset, size_t length);
+void vm_object_remove_pages(vm_object_t *obj, off_t offset, size_t length);
 vm_page_t *vm_object_find_page(vm_object_t *obj, off_t offset);
 vm_object_t *vm_object_clone(vm_object_t *obj);
 void vm_map_object_dump(vm_object_t *obj);

--- a/include/sys/vm_object.h
+++ b/include/sys/vm_object.h
@@ -23,9 +23,9 @@ typedef struct vm_object {
 
 vm_object_t *vm_object_alloc(vm_pgr_type_t type);
 void vm_object_free(vm_object_t *obj);
-void vm_object_add_page(vm_object_t *obj, off_t offset, vm_page_t *pg);
-void vm_object_remove_pages(vm_object_t *obj, off_t offset, size_t length);
-vm_page_t *vm_object_find_page(vm_object_t *obj, off_t offset);
+void vm_object_add_page(vm_object_t *obj, vm_offset_t off, vm_page_t *pg);
+void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len);
+vm_page_t *vm_object_find_page(vm_object_t *obj, vm_offset_t off);
 vm_object_t *vm_object_clone(vm_object_t *obj);
 void vm_map_object_dump(vm_object_t *obj);
 

--- a/include/sys/vm_physmem.h
+++ b/include/sys/vm_physmem.h
@@ -20,6 +20,9 @@ vm_page_t *vm_page_alloc(size_t n);
  * initializes `pglist`. Returns ENOMEM if the request cannot be satisfied. */
 int vm_pagelist_alloc(size_t n, vm_pagelist_t *pglist);
 
+/* Releases all pages on `pglist`. */
+void vm_pagelist_free(vm_pagelist_t *pglist);
+
 /* Returns vm_page associated with frame of given address. */
 vm_page_t *vm_page_find(paddr_t pa);
 

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -79,8 +79,9 @@ void kva_unmap(vaddr_t va, size_t size) {
 
   kasan_mark_invalid((void *)va, size, KASAN_CODE_KMEM_FREED);
 
+  size_t end = va + size;
   size_t pgsz;
-  for (; va < va + size; va += pgsz) {
+  for (; va < end; va += pgsz) {
     vm_page_t *pg = kva_find_page(va);
     assert(pg != NULL);
     pgsz = pg->size * PAGESIZE;

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -74,21 +74,19 @@ vm_page_t *kva_find_page(vaddr_t ptr) {
   return NULL;
 }
 
-void kva_unmap(vaddr_t ptr, size_t size) {
-  assert(page_aligned_p(ptr) && page_aligned_p(size));
+void kva_unmap(vaddr_t va, size_t size) {
+  assert(page_aligned_p(va) && page_aligned_p(size));
 
-  kasan_mark_invalid((void *)ptr, size, KASAN_CODE_KMEM_FREED);
+  kasan_mark_invalid((void *)va, size, KASAN_CODE_KMEM_FREED);
 
-  vaddr_t va = (vaddr_t)ptr;
-  vaddr_t end = va + size;
-  while (va < end) {
+  size_t pgsz;
+  for (; va < va + size; va += pgsz) {
     vm_page_t *pg = kva_find_page(va);
     assert(pg != NULL);
-    va += pg->size * PAGESIZE;
+    pgsz = pg->size * PAGESIZE;
+    pmap_kremove(va, pgsz);
     vm_page_free(pg);
   }
-
-  pmap_kremove((vaddr_t)ptr, size);
 }
 
 void *kmem_alloc(size_t size, kmem_flags_t flags) {

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -79,15 +79,19 @@ void kva_unmap(vaddr_t ptr, size_t size) {
 
   kasan_mark_invalid((void *)ptr, size, KASAN_CODE_KMEM_FREED);
 
+  vm_pagelist_t pglist;
+  TAILQ_INIT(&pglist);
+
   vaddr_t va = ptr;
   while (va < ptr + size) {
     vm_page_t *pg = kva_find_page(va);
     assert(pg != NULL);
     va += pg->size * PAGESIZE;
-    vm_page_free(pg);
+    TAILQ_INSERT_TAIL(&pglist, pg, pageq);
   }
 
   pmap_kremove(ptr, size);
+  vm_pagelist_free(&pglist);
 }
 
 void *kmem_alloc(size_t size, kmem_flags_t flags) {

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -172,7 +172,7 @@ void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
   }
 
   size_t length = end - start;
-  vm_object_remove_range(seg->object, start - seg->start, length);
+  vm_object_remove_pages(seg->object, start - seg->start, length);
   pmap_remove(map->pmap, start, end);
 
   if (seg->start == start) {
@@ -181,8 +181,8 @@ void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
     seg->end = start;
   } else { /* a hole inside the segment */
     vm_object_t *obj = vm_object_clone(seg->object);
-    vm_object_remove_range(obj, 0, start - seg->start);
-    vm_object_remove_range(seg->object, end - seg->start, seg->end - end);
+    vm_object_remove_pages(obj, 0, start - seg->start);
+    vm_object_remove_pages(seg->object, end - seg->start, seg->end - end);
     vm_segment_t *new_seg =
       vm_segment_alloc(obj, end, seg->end, seg->prot, seg->flags);
     seg->end = start;
@@ -331,7 +331,7 @@ int vm_segment_resize(vm_map_t *map, vm_segment_t *seg, vaddr_t new_end) {
     /* Shrinking entry */
     off_t offset = new_end - seg->start;
     size_t length = seg->end - new_end;
-    vm_object_remove_range(seg->object, offset, length);
+    vm_object_remove_pages(seg->object, offset, length);
     /* TODO there's no reference to pmap in page, so we have to do it here */
     pmap_remove(map->pmap, new_end, seg->end);
   }

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -166,6 +166,7 @@ void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
   assert(mtx_owned(&map->mtx));
   assert(start >= vm_map_start(map) && end <= vm_map_end(map));
 
+  pmap_remove(map->pmap, start, end);
   if (seg->start == start && seg->end == end) {
     vm_segment_destroy(map, seg);
     return;
@@ -173,7 +174,6 @@ void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
 
   size_t length = end - start;
   vm_object_remove_pages(seg->object, start - seg->start, length);
-  pmap_remove(map->pmap, start, end);
 
   if (seg->start == start) {
     seg->start = end;
@@ -191,12 +191,12 @@ void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
 }
 
 void vm_map_delete(vm_map_t *map) {
+  pmap_delete(map->pmap);
   WITH_MTX_LOCK (&map->mtx) {
     vm_segment_t *seg, *next;
     TAILQ_FOREACH_SAFE (seg, &map->entries, link, next)
       vm_segment_destroy(map, seg);
   }
-  pmap_delete(map->pmap);
   pool_free(P_VMMAP, map);
 }
 
@@ -331,9 +331,9 @@ int vm_segment_resize(vm_map_t *map, vm_segment_t *seg, vaddr_t new_end) {
     /* Shrinking entry */
     off_t offset = new_end - seg->start;
     size_t length = seg->end - new_end;
+    pmap_remove(map->pmap, new_end, seg->end);
     vm_object_remove_pages(seg->object, offset, length);
     /* TODO there's no reference to pmap in page, so we have to do it here */
-    pmap_remove(map->pmap, new_end, seg->end);
   }
 
   seg->end = new_end;

--- a/sys/kern/vm_object.c
+++ b/sys/kern/vm_object.c
@@ -83,7 +83,7 @@ void vm_object_free(vm_object_t *obj) {
   if (!refcnt_release(&obj->ref_counter))
     return;
 
-  vm_object_remove_pages(obj, 0, ~0);
+  vm_object_remove_pages(obj, 0, -PAGESIZE);
   pool_free(P_VMOBJ, obj);
 }
 

--- a/sys/kern/vm_object.c
+++ b/sys/kern/vm_object.c
@@ -55,8 +55,8 @@ void vm_object_add_page(vm_object_t *obj, vm_offset_t offset, vm_page_t *pg) {
   }
 }
 
-static void vmo_remove_pages_nolock(vm_object_t *obj, vm_offset_t offset,
-                                    size_t length) {
+static void vm_object_remove_pages_nolock(vm_object_t *obj, vm_offset_t offset,
+                                          size_t length) {
   assert(mtx_owned(&obj->mtx));
   assert(page_aligned_p(offset) && page_aligned_p(length));
 
@@ -77,7 +77,7 @@ static void vmo_remove_pages_nolock(vm_object_t *obj, vm_offset_t offset,
 
 void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len) {
   SCOPED_MTX_LOCK(&obj->mtx);
-  vmo_remove_pages_nolock(obj, off, len);
+  vm_object_remove_pages_nolock(obj, off, len);
 }
 
 void vm_object_free(vm_object_t *obj) {

--- a/sys/kern/vm_object.c
+++ b/sys/kern/vm_object.c
@@ -80,11 +80,14 @@ void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len) {
   vm_object_remove_pages_nolock(obj, off, len);
 }
 
+#define vm_object_remove_all_pages(obj)                                        \
+  vm_object_remove_pages((obj), 0, -PAGESIZE)
+
 void vm_object_free(vm_object_t *obj) {
   if (!refcnt_release(&obj->ref_counter))
     return;
 
-  vm_object_remove_pages(obj, 0, -PAGESIZE);
+  vm_object_remove_all_pages(obj);
   pool_free(P_VMOBJ, obj);
 }
 

--- a/sys/kern/vm_object.c
+++ b/sys/kern/vm_object.c
@@ -81,7 +81,7 @@ void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len) {
 }
 
 #define vm_object_remove_all_pages(obj)                                        \
-  vm_object_remove_pages((obj), 0, -PAGESIZE)
+  vm_object_remove_pages((obj), 0, (size_t)(-PAGESIZE))
 
 void vm_object_free(vm_object_t *obj) {
   if (!refcnt_release(&obj->ref_counter))

--- a/sys/kern/vm_object.c
+++ b/sys/kern/vm_object.c
@@ -55,43 +55,35 @@ void vm_object_add_page(vm_object_t *obj, off_t offset, vm_page_t *pg) {
   }
 }
 
-static void vm_object_remove_page_nolock(vm_object_t *obj, vm_page_t *page) {
-  page->offset = 0;
-  page->object = NULL;
-
-  TAILQ_REMOVE(&obj->list, page, obj.list);
-  vm_page_free(page);
-  obj->npages--;
-}
-
-void vm_object_remove_page(vm_object_t *obj, vm_page_t *page) {
-  SCOPED_MTX_LOCK(&obj->mtx);
-
-  vm_object_remove_page_nolock(obj, page);
-}
-
-void vm_object_remove_range(vm_object_t *object, off_t offset, size_t length) {
-  SCOPED_MTX_LOCK(&object->mtx);
+static void vmo_remove_pages_nolock(vm_object_t *obj, off_t off, size_t len) {
+  assert(mtx_owned(&obj->mtx));
+  assert(page_aligned_p(off) && page_aligned_p(len));
 
   vm_page_t *pg, *next;
-  TAILQ_FOREACH_SAFE (pg, &object->list, obj.list, next) {
-    if (pg->offset >= (off_t)(offset + length))
+  TAILQ_FOREACH_SAFE (pg, &obj->list, obj.list, next) {
+    if (pg->offset >= (off_t)(off + len))
       break;
-    if (pg->offset >= offset)
-      vm_object_remove_page_nolock(object, pg);
+    if (pg->offset < off)
+      continue;
+
+    pg->offset = 0;
+    pg->object = NULL;
+    TAILQ_REMOVE(&obj->list, pg, obj.list);
+    vm_page_free(pg);
+    obj->npages--;
   }
+}
+
+void vm_object_remove_pages(vm_object_t *obj, off_t off, size_t len) {
+  SCOPED_MTX_LOCK(&obj->mtx);
+  vmo_remove_pages_nolock(obj, off, len);
 }
 
 void vm_object_free(vm_object_t *obj) {
   if (!refcnt_release(&obj->ref_counter))
     return;
 
-  WITH_MTX_LOCK (&obj->mtx) {
-    vm_page_t *pg, *next;
-    TAILQ_FOREACH_SAFE (pg, &obj->list, obj.list, next)
-      vm_object_remove_page_nolock(obj, pg);
-  }
-
+  vm_object_remove_pages(obj, 0, ~0);
   pool_free(P_VMOBJ, obj);
 }
 

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -293,6 +293,7 @@ static void pm_free_from_seg(vm_physseg_t *seg, vm_page_t *page) {
   PAGECOUNT(page)++;
   page->flags |= PG_MANAGED;
   for (unsigned i = 0; i < page->size; i++) {
+    /* TODO: check if reference count is zero? */
     page[i].flags &= ~PG_ALLOCATED;
     page[i].flags &= ~(PG_REFERENCED | PG_MODIFIED);
   }

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -293,7 +293,7 @@ static void pm_free_from_seg(vm_physseg_t *seg, vm_page_t *page) {
   PAGECOUNT(page)++;
   page->flags |= PG_MANAGED;
   for (unsigned i = 0; i < page->size; i++) {
-    /* TODO: check if reference count is zero? */
+    assert(TAILQ_EMPTY(&page[i].pv_list));
     page[i].flags &= ~PG_ALLOCATED;
     page[i].flags &= ~(PG_REFERENCED | PG_MODIFIED);
   }

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -299,21 +299,30 @@ static void pm_free_from_seg(vm_physseg_t *seg, vm_page_t *page) {
   }
 }
 
-void vm_page_free(vm_page_t *page) {
-  vm_physseg_t *seg_it = NULL;
+static void vm_page_free_nolock(vm_page_t *pg) {
+  klog("%s: free %lx of size %ld", __func__, pg->paddr, pg->size);
 
-  SCOPED_MTX_LOCK(physmem_lock);
-
-  klog("%s: free %lx of size %ld", __func__, page->paddr, page->size);
-
-  TAILQ_FOREACH (seg_it, &seglist, seglink) {
-    if (PG_START(page) >= seg_it->start && PG_END(page) <= seg_it->end) {
-      pm_free_from_seg(seg_it, page);
+  vm_physseg_t *seg = NULL;
+  TAILQ_FOREACH (seg, &seglist, seglink) {
+    if (PG_START(pg) >= seg->start && PG_END(pg) <= seg->end) {
+      pm_free_from_seg(seg, pg);
       return;
     }
   }
 
-  panic("page out of range: %p", (void *)page->paddr);
+  panic("page out of range: %p", (void *)pg->paddr);
+}
+
+void vm_page_free(vm_page_t *page) {
+  SCOPED_MTX_LOCK(physmem_lock);
+  vm_page_free_nolock(page);
+}
+
+void vm_pagelist_free(vm_pagelist_t *pglist) {
+  SCOPED_MTX_LOCK(physmem_lock);
+
+  vm_page_t *pg, *pg_next;
+  TAILQ_FOREACH_SAFE (pg, pglist, pageq, pg_next) { vm_page_free_nolock(pg); }
 }
 
 vm_page_t *vm_page_find(paddr_t pa) {

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -293,7 +293,6 @@ static void pm_free_from_seg(vm_physseg_t *seg, vm_page_t *page) {
   PAGECOUNT(page)++;
   page->flags |= PG_MANAGED;
   for (unsigned i = 0; i < page->size; i++) {
-    pmap_page_remove(&page[i]);
     page[i].flags &= ~PG_ALLOCATED;
     page[i].flags &= ~(PG_REFERENCED | PG_MODIFIED);
   }

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -322,7 +322,10 @@ void vm_pagelist_free(vm_pagelist_t *pglist) {
   SCOPED_MTX_LOCK(physmem_lock);
 
   vm_page_t *pg, *pg_next;
-  TAILQ_FOREACH_SAFE (pg, pglist, pageq, pg_next) { vm_page_free_nolock(pg); }
+  TAILQ_FOREACH_SAFE (pg, pglist, pageq, pg_next) {
+    TAILQ_REMOVE(pglist, pg, pageq);
+    vm_page_free_nolock(pg);
+  }
 }
 
 vm_page_t *vm_page_find(paddr_t pa) {


### PR DESCRIPTION
It should fix #968 issue. I investigated every call to `vm_page_free` and made sure there's corresponding call to `pmap_remove` or `pmap_kremove`.