### PR TITLE
AArch64: exc tests.

### DIFF
--- a/bin/utest/exceptions.c
+++ b/bin/utest/exceptions.c
@@ -61,3 +61,23 @@ int test_syscall_in_bds(void) {
 }
 
 #endif /* !__mips__ */
+
+#ifdef __aarch64__
+
+int test_exc_unknown_instruction(void) {
+  asm volatile(".long 0x00110011");
+  return 0;
+}
+
+int test_exc_msr_instruction(void) {
+  asm volatile("msr spsr_el1, %0" ::"r"(1));
+  return 0;
+}
+
+int test_exc_mrs_instruction(void) {
+  long x;
+  asm volatile("mrs %0, spsr_el1" : "=r"(x));
+  return 0;
+}
+
+#endif /* !__aarch64__ */

--- a/bin/utest/exceptions.c
+++ b/bin/utest/exceptions.c
@@ -72,7 +72,7 @@ int test_exc_unknown_instruction(void) {
 }
 
 int test_exc_msr_instruction(void) {
-  asm volatile("msr spsr_el1, %0" ::"r"(1));
+  asm volatile("msr spsr_el1, %0" ::"r"(1ULL));
   return 0;
 }
 

--- a/bin/utest/exceptions.c
+++ b/bin/utest/exceptions.c
@@ -4,6 +4,8 @@
 #include <sys/wait.h>
 #include <sys/signal.h>
 #include <stdlib.h>
+#include <setjmp.h>
+#include <signal.h>
 
 #include <stdio.h>
 
@@ -77,6 +79,22 @@ int test_exc_msr_instruction(void) {
 int test_exc_mrs_instruction(void) {
   long x;
   asm volatile("mrs %0, spsr_el1" : "=r"(x));
+  return 0;
+}
+
+static sigjmp_buf jump_buffer;
+static void sigtrap_handler(int signo) {
+  siglongjmp(jump_buffer, 42);
+  assert(0); /* Shouldn't reach here. */
+}
+
+int test_exc_brk(void) {
+  signal(SIGTRAP, sigtrap_handler);
+  if (sigsetjmp(jump_buffer, 1) != 42) {
+    asm volatile("brk 0");
+    assert(0); /* Shouldn't reach here. */
+  }
+  signal(SIGTRAP, SIG_DFL);
   return 0;
 }
 

--- a/bin/utest/main.c
+++ b/bin/utest/main.c
@@ -68,6 +68,7 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(exc_unknown_instruction);
   CHECKRUN_TEST(exc_msr_instruction);
   CHECKRUN_TEST(exc_mrs_instruction);
+  CHECKRUN_TEST(exc_brk);
 #endif /* !__aarch64__ */
 
   CHECKRUN_TEST(setjmp);

--- a/bin/utest/main.c
+++ b/bin/utest/main.c
@@ -63,6 +63,13 @@ int main(int argc, char **argv) {
   CHECKRUN_TEST(exc_sigsys);
   CHECKRUN_TEST(syscall_in_bds);
 #endif /* !__mips__ */
+
+#ifdef __aarch64__
+  CHECKRUN_TEST(exc_unknown_instruction);
+  CHECKRUN_TEST(exc_msr_instruction);
+  CHECKRUN_TEST(exc_mrs_instruction);
+#endif /* !__aarch64__ */
+
   CHECKRUN_TEST(setjmp);
   CHECKRUN_TEST(sigaction_with_setjmp);
   CHECKRUN_TEST(sigaction_handler_returns);

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -62,6 +62,11 @@ int test_exc_reserved_instruction(void);
 int test_exc_integer_overflow(void);
 int test_exc_sigsys(void);
 int test_exc_unaligned_access(void);
+
+int test_exc_unknown_instruction(void);
+int test_exc_msr_instruction(void);
+int test_exc_mrs_instruction(void);
+
 int test_syscall_in_bds(void);
 
 int test_setjmp(void);

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -66,6 +66,7 @@ int test_exc_unaligned_access(void);
 int test_exc_unknown_instruction(void);
 int test_exc_msr_instruction(void);
 int test_exc_mrs_instruction(void);
+int test_exc_brk(void);
 
 int test_syscall_in_bds(void);
 

--- a/include/aarch64/armreg.h
+++ b/include/aarch64/armreg.h
@@ -235,7 +235,7 @@
 #define EXCP_SP_ALIGN 0x26     /* SP slignment fault */
 #define EXCP_TRAP_FP 0x2c      /* Trapped FP exception */
 #define EXCP_SERROR 0x2f       /* SError interrupt */
-#define EXCP_BRKPT_EL0 0x30    /* Hardware breakpoint, from same EL */
+#define EXCP_BRKPT_EL0 0x30    /* Hardware breakpoint, from lower EL */
 #define EXCP_SOFTSTP_EL0 0x32  /* Software Step, from lower EL */
 #define EXCP_SOFTSTP_EL1 0x33  /* Software Step, from same EL */
 #define EXCP_WATCHPT_EL1 0x35  /* Watchpoint, from same EL */

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -254,11 +254,16 @@ __boot_text static void enable_mmu(paddr_t pde) {
   WRITE_SPECIALREG(tcr_el1, tcr);
 
   /* --- more magic bits
-   * M -- MMU enable for EL1 and EL0 stage 1 address translation.
-   * I -- SP must be aligned to 16.
-   * C -- Cacheability control, for data accesses.
+   * M   - MMU enable for EL1 and EL0 stage 1 address translation.
+   * I   - Cacheability control.
+   * C   - Cacheability control, for data accesses.
+   * A   - Alignment check.
+   * SA  - SP alignment check - EL1.
+   * SA0 - SP alignment check - EL0.
+   *
    */
-  WRITE_SPECIALREG(sctlr_el1, SCTLR_M | SCTLR_I | SCTLR_C);
+  WRITE_SPECIALREG(sctlr_el1, SCTLR_M | SCTLR_I | SCTLR_C | SCTLR_A | SCTLR_SA |
+                                SCTLR_SA0);
   __isb();
 
   _kernel_pmap_pde = pde;

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -133,6 +133,11 @@ void user_trap_handler(mcontext_t *uctx) {
       thread_self()->td_pflags |= TDP_FPUINUSE;
       break;
 
+    case EXCP_BRKPT_EL0:
+    case EXCP_BRK:
+      sig_trap(ctx, SIGTRAP);
+      break;
+
     default:
       kernel_oops(ctx);
   }

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -124,6 +124,7 @@ void user_trap_handler(mcontext_t *uctx) {
       sig_trap(ctx, SIGBUS);
       break;
 
+    case EXCP_UNKNOWN:
     case EXCP_MSR: /* privileged instruction */
       sig_trap(ctx, SIGILL);
       break;

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -144,6 +144,8 @@ UTEST_ADD_SIMPLE(exc_sigsys);
 UTEST_ADD_SIGNAL(exc_unknown_instruction, SIGILL);
 UTEST_ADD_SIGNAL(exc_msr_instruction, SIGILL);
 UTEST_ADD_SIGNAL(exc_mrs_instruction, SIGILL);
+
+UTEST_ADD_SIMPLE(exc_brk);
 #endif
 
 UTEST_ADD_SIMPLE(getcwd);

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -140,6 +140,12 @@ UTEST_ADD_SIGNAL(exc_integer_overflow, SIGFPE);
 UTEST_ADD_SIMPLE(exc_sigsys);
 #endif
 
+#ifdef __aarch64__
+UTEST_ADD_SIGNAL(exc_unknown_instruction, SIGILL);
+UTEST_ADD_SIGNAL(exc_msr_instruction, SIGILL);
+UTEST_ADD_SIGNAL(exc_mrs_instruction, SIGILL);
+#endif
+
 UTEST_ADD_SIMPLE(getcwd);
 /* XXX UTEST_ADD_SIMPLE(syscall_in_bds); */
 


### PR DESCRIPTION
* Add tests for user-space exception handler.
* Enable alignment checking - see [SCTLR_EL1](https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/SCTLR-EL1--System-Control-Register--EL1-?lang=en#fieldset_0-25_25) register.