### PR TITLE
ringbuf_move[n]b to move data between two ringbuffers

### DIFF
--- a/include/sys/ringbuf.h
+++ b/include/sys/ringbuf.h
@@ -29,6 +29,8 @@ bool ringbuf_putnb(ringbuf_t *buf, uint8_t *data, size_t n);
 bool ringbuf_getb(ringbuf_t *buf, uint8_t *byte_p);
 /*! \brief Get exactly n bytes from buf if there's enough data. */
 bool ringbuf_getnb(ringbuf_t *buf, uint8_t *data, size_t n);
+bool ringbuf_moveb(ringbuf_t *src, ringbuf_t *dst);
+bool ringbuf_movenb(ringbuf_t *src, ringbuf_t *dst, size_t n);
 int ringbuf_read(ringbuf_t *buf, uio_t *uio);
 int ringbuf_write(ringbuf_t *buf, uio_t *uio);
 void ringbuf_reset(ringbuf_t *buf);

--- a/sys/kern/ringbuf.c
+++ b/sys/kern/ringbuf.c
@@ -74,6 +74,7 @@ bool ringbuf_movenb(ringbuf_t *src, ringbuf_t *dst, size_t n) {
     return false;
   for (size_t i = 0; i < n; i++)
     ringbuf_moveb(src, dst);
+  return true;
 }
 
 int ringbuf_read(ringbuf_t *buf, uio_t *uio) {

--- a/sys/kern/ringbuf.c
+++ b/sys/kern/ringbuf.c
@@ -60,6 +60,22 @@ bool ringbuf_getnb(ringbuf_t *buf, uint8_t *data, size_t n) {
   return true;
 }
 
+bool ringbuf_moveb(ringbuf_t *src, ringbuf_t *dst) {
+  uint8_t byte;
+  if (src->count == 0 || dst->count == dst->size)
+    return false;
+  ringbuf_getb(src, &byte);
+  ringbuf_putb(dst, byte);
+  return true;
+}
+
+bool ringbuf_movenb(ringbuf_t *src, ringbuf_t *dst, size_t n) {
+  if (src->count < n || dst->count + n > dst->size)
+    return false;
+  for (size_t i = 0; i < n; i++)
+    ringbuf_moveb(src, dst);
+}
+
 int ringbuf_read(ringbuf_t *buf, uio_t *uio) {
   assert(uio->uio_op == UIO_READ);
   /* repeat when used space is split into two parts */

--- a/sys/tests/ringbuf.c
+++ b/sys/tests/ringbuf.c
@@ -90,6 +90,28 @@ static int test_ringbuf_nontrivial(void) {
   return KTEST_SUCCESS;
 }
 
+static int test_ringbuf_move(void) {
+  ringbuf_t src, dst;
+  char buf0[5], buf1[5];
+  ringbuf_init(&src, buf0, 5);
+  ringbuf_init(&dst, buf1, 5);
+
+  uint8_t testbuf[] = "abcde";
+
+  uio_t uio_src = UIO_SINGLE_KERNEL(UIO_WRITE, 0, testbuf, 5);
+  assert(ringbuf_write(&src, &uio_src) == 0);
+
+  assert(ringbuf_movenb(&src, &dst, 5) == true);
+
+  assert(buf1[0] == 'a');
+  assert(buf1[1] == 'b');
+  assert(buf1[2] == 'c');
+  assert(buf1[3] == 'd');
+  assert(buf1[4] == 'e');
+
+  return KTEST_SUCCESS;
+}
+
 static int test_uio_ringbuf_trivial(void) {
   ringbuf_t rbt;
   char buf[5];
@@ -202,6 +224,7 @@ static int test_uio_ringbuf_cyclic_transfers(void) {
 
 KTEST_ADD(ringbuf_trivial, test_ringbuf_trivial, 0);
 KTEST_ADD(ringbuf_nontrivial, test_ringbuf_nontrivial, 0);
+KTEST_ADD(ringbuf_move, test_ringbuf_move, 0);
 KTEST_ADD(uio_ringbuf_trivial, test_uio_ringbuf_trivial, 0);
 KTEST_ADD(uio_ringbuf_one_transfer, test_uio_ringbuf_one_transfer, 0);
 KTEST_ADD(uio_ringbuf_two_transfers, test_uio_ringbuf_two_transfers, 0);


### PR DESCRIPTION
this function is needed to be used in coming rtl8139's PR