### PR TITLE
Identify which tests do not tolerate time jumps.

### DIFF
--- a/sys/tests/callout.c
+++ b/sys/tests/callout.c
@@ -102,7 +102,7 @@ static int test_callout_drain(void) {
   return KTEST_SUCCESS;
 }
 
-KTEST_ADD(callout_simple, test_callout_simple, 0);
+KTEST_ADD(callout_simple, test_callout_simple, KTEST_FLAG_BROKEN);
 KTEST_ADD(callout_order, test_callout_order, 0);
 KTEST_ADD(callout_stop, test_callout_stop, 0);
 KTEST_ADD(callout_drain, test_callout_drain, 0);

--- a/sys/tests/sleepq.c
+++ b/sys/tests/sleepq.c
@@ -52,4 +52,4 @@ static int test_sleepq_sync(void) {
   return KTEST_SUCCESS;
 }
 
-KTEST_ADD(sleepq_sync, test_sleepq_sync, 0);
+KTEST_ADD(sleepq_sync, test_sleepq_sync, KTEST_FLAG_BROKEN);

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -156,7 +156,7 @@ UTEST_ADD_SIMPLE(session_login_name);
 #ifdef __mips__
 UTEST_ADD_SIMPLE(gettimeofday);
 #endif
-UTEST_ADD_SIMPLE(nanosleep);
+/* UTEST_ADD_SIMPLE(nanosleep); */
 
 UTEST_ADD_SIMPLE(get_set_uid);
 UTEST_ADD_SIMPLE(get_set_gid);


### PR DESCRIPTION
Maybe we should rethink those tests instead of returning to `icount` option for _QEmu_. Linux seems to tolerate time jumps well.