### PR TITLE
Assert that the thread is stopped or stopping in thread_continue()

### DIFF
--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -210,8 +210,10 @@ thread_t *thread_find(tid_t id) {
 void thread_continue(thread_t *td) {
   assert(spin_owned(td->td_lock));
 
-  if (td->td_flags & TDF_STOPPING)
+  if (td->td_flags & TDF_STOPPING) {
     td->td_flags &= ~TDF_STOPPING;
-  else if (td_is_stopped(td))
+  } else {
+    assert(td_is_stopped(td));
     sched_wakeup(td, 0);
+  }
 }


### PR DESCRIPTION
`thread_continue()` is meant to continue stopped threads, but currently we allow it to be called on all kinds of threads. This PR checks that the thread is in the expected state (i.e. either stopping or stopped).