### PR TITLE
pgrp_maybe_orphan(): send SIGHUP + SIGCONT to all members of pgrp if any member is stopped

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -209,7 +209,7 @@ static void pgrp_maybe_orphan(pgrp_t *pg) {
     proc_lock(p);
     if (p->p_state == PS_STOPPED) {
       proc_unlock(p);
-      TAILQ_FOREACH(p, &pg->pg_members, p_pglist) {
+      TAILQ_FOREACH (p, &pg->pg_members, p_pglist) {
         SCOPED_MTX_LOCK(&p->p_lock);
         sig_kill(p, &DEF_KSI_RAW(SIGHUP));
         sig_kill(p, &DEF_KSI_RAW(SIGCONT));


### PR DESCRIPTION
From the specification of `_Exit()` in POSIX (https://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html):
> If the exit of the process causes a process group to become orphaned, and if any member of the newly-orphaned process group is stopped, then a `SIGHUP` signal followed by a `SIGCONT` signal shall be sent to each process in the newly-orphaned process group.