### PR TITLE
proc_exit: don't call fdtab_drop() while holding p->p_lock

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -581,12 +581,12 @@ __noreturn void proc_exit(int exitstatus) {
   p->p_uspace = NULL;
   vm_map_delete(uspace);
 
-  fdtab_drop(p->p_fdtable);
-
   /* Record process statistics that will stay maintained in zombie state. */
   p->p_exitstatus = exitstatus;
 
   proc_unlock(p);
+
+  fdtab_drop(p->p_fdtable);
 
   WITH_MTX_LOCK (all_proc_mtx) {
     if (p->p_pid == 1)

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -579,13 +579,13 @@ __noreturn void proc_exit(int exitstatus) {
    * being deleted. */
   vm_map_t *uspace = p->p_uspace;
   p->p_uspace = NULL;
-  vm_map_delete(uspace);
 
   /* Record process statistics that will stay maintained in zombie state. */
   p->p_exitstatus = exitstatus;
 
   proc_unlock(p);
 
+  vm_map_delete(uspace);
   fdtab_drop(p->p_fdtable);
 
   WITH_MTX_LOCK (all_proc_mtx) {


### PR DESCRIPTION
`fdtab_drop()` can acquire `tty_t::t_lock` further down the call chain, but we depend on being able to acquire `proc_t::p_lock` while holding `tty_t::t_lock`, so we can't acquire `tty_t::t_lock` while holding `proc_t::p_lock`, which is exactly what might happen if we call `fdtab_drop()` while holding `proc_t::p_lock`.
I have also moved the call to `vm_map_delete()`, since we don't need `p_lock` for that either.

Fixes #1027