### PR TITLE
Simplify locking rules around pgrp_t::pg_lock

### DIFF
--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -64,16 +64,6 @@ static inline void mtx_lock(mtx_t *m) {
 /*! \brief Unlocks sleep mutex */
 void mtx_unlock(mtx_t *m);
 
-/*! \brief Locks a pair of distinct mutexes belonging to the same class.
- *
- * The mutex with the lower address is locked first. */
-void mtx_lock_pair(mtx_t *m1, mtx_t *m2);
-
-/*! \brief Unlocks a pair of distinct mutexes belonging to the same class.
- *
- * The mutex with the higher address is unlocked first. */
-void mtx_unlock_pair(mtx_t *m1, mtx_t *m2);
-
 DEFINE_CLEANUP_FUNCTION(mtx_t *, mtx_unlock);
 
 /*! \brief Locks sleep mutex and unlocks it when leaving current scope.

--- a/include/sys/proc.h
+++ b/include/sys/proc.h
@@ -54,6 +54,8 @@ typedef struct session {
  *  (!) read-only access, do not modify!
  *  When two locks are specified (see pg_members), either one suffices
  *  for reading, but both must be held for writing.
+ *  NOTE: You can acquire multiple pg_locks, but only if you're already holding
+ *  all_proc_mtx.
  */
 typedef struct pgrp {
   mtx_t pg_lock;

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -80,25 +80,3 @@ void mtx_unlock(mtx_t *m) {
       turnstile_broadcast(m);
   }
 }
-
-void mtx_lock_pair(mtx_t *m1, mtx_t *m2) {
-  assert(m1 != m2);
-  if ((uintptr_t)m1 < (uintptr_t)m2) {
-    mtx_lock(m1);
-    mtx_lock(m2);
-  } else {
-    mtx_lock(m2);
-    mtx_lock(m1);
-  }
-}
-
-void mtx_unlock_pair(mtx_t *m1, mtx_t *m2) {
-  assert(m1 != m2);
-  if ((uintptr_t)m1 < (uintptr_t)m2) {
-    mtx_unlock(m2);
-    mtx_unlock(m1);
-  } else {
-    mtx_unlock(m1);
-    mtx_unlock(m2);
-  }
-}

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -309,6 +309,7 @@ static void pgrp_leave(proc_t *p) {
 static int _pgrp_enter(proc_t *p, pgrp_t *target) {
   pgrp_t *old_pgrp = p->p_pgrp;
   assert(old_pgrp);
+  assert(mtx_owned(all_proc_mtx));
 
   if (old_pgrp == target)
     return 0;
@@ -316,15 +317,17 @@ static int _pgrp_enter(proc_t *p, pgrp_t *target) {
   pgrp_jobc_enter(p, target);
   pgrp_jobc_leave(p, old_pgrp);
 
-  mtx_lock_pair(&old_pgrp->pg_lock, &target->pg_lock);
-
-  WITH_PROC_LOCK(p) {
-    TAILQ_REMOVE(&old_pgrp->pg_members, p, p_pglist);
-    TAILQ_INSERT_HEAD(&target->pg_members, p, p_pglist);
-    p->p_pgrp = target;
+  /* Acquiring multiple pgrp locks here is safe because we're holding
+   * all_proc_mtx, see comments about pgrp_t in proc.h. */
+  WITH_MTX_LOCK (&old_pgrp->pg_lock) {
+    WITH_MTX_LOCK (&target->pg_lock) {
+      WITH_PROC_LOCK(p) {
+        TAILQ_REMOVE(&old_pgrp->pg_members, p, p_pglist);
+        TAILQ_INSERT_HEAD(&target->pg_members, p, p_pglist);
+        p->p_pgrp = target;
+      }
+    }
   }
-
-  mtx_unlock_pair(&old_pgrp->pg_lock, &target->pg_lock);
 
   if (TAILQ_EMPTY(&old_pgrp->pg_members)) {
     pgrp_remove(old_pgrp);


### PR DESCRIPTION
Right now there's only one place where we're acquiring multiple `pg_locks`, and we already happen to hold `all_proc_mtx` there, so we can simplify the locking rules by requiring that `all_proc_mtx` be held in order to acquire multiple `pg_locks`.