### PR TITLE
Assert for vm_segment_destroy_range and simplyfing do_munmap

### DIFF
--- a/sys/kern/mmap.c
+++ b/sys/kern/mmap.c
@@ -76,8 +76,7 @@ int do_munmap(vaddr_t addr, size_t length) {
 
       vaddr_t end = vm_segment_end(seg);
 
-      vm_segment_destroy_range(uspace, seg, addr,
-                               min(right_boundary, end));
+      vm_segment_destroy_range(uspace, seg, addr, min(right_boundary, end));
 
       addr = end;
     }

--- a/sys/kern/mmap.c
+++ b/sys/kern/mmap.c
@@ -74,10 +74,9 @@ int do_munmap(vaddr_t addr, size_t length) {
       if (!seg)
         return EINVAL;
 
-      vaddr_t start = vm_segment_start(seg);
       vaddr_t end = vm_segment_end(seg);
 
-      vm_segment_destroy_range(uspace, seg, max(addr, start),
+      vm_segment_destroy_range(uspace, seg, addr,
                                min(right_boundary, end));
 
       addr = end;

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -164,7 +164,7 @@ void vm_segment_destroy(vm_map_t *map, vm_segment_t *seg) {
 void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
                               vaddr_t end) {
   assert(mtx_owned(&map->mtx));
-  assert(start >= vm_map_start(map) && end <= vm_map_end(map));
+  assert(seg->start >= vm_map_start(map) && seg->end <= vm_map_end(map));
   assert(start >= seg->start && end <= seg->end);
 
   pmap_remove(map->pmap, start, end);

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -165,6 +165,7 @@ void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
                               vaddr_t end) {
   assert(mtx_owned(&map->mtx));
   assert(start >= vm_map_start(map) && end <= vm_map_end(map));
+  assert(start >= seg->start && end <= seg->end);
 
   pmap_remove(map->pmap, start, end);
   if (seg->start == start && seg->end == end) {

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -164,7 +164,6 @@ void vm_segment_destroy(vm_map_t *map, vm_segment_t *seg) {
 void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
                               vaddr_t end) {
   assert(mtx_owned(&map->mtx));
-  assert(seg->start >= vm_map_start(map) && seg->end <= vm_map_end(map));
   assert(start >= seg->start && end <= seg->end);
 
   pmap_remove(map->pmap, start, end);


### PR DESCRIPTION
Asserting that we are destroying the range between a segment can prevent us from some future bugs.
The max for `do_munmap` is unnecessary, cause `vm_map_find_segment` already guarantee that `addr >= start`.