### PR TITLE
Removing the expensive HZ2BT operation in pit gettime

### DIFF
--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -104,7 +104,7 @@ static bintime_t timer_pit_gettime(timer_t *tm) {
   uint32_t freq = pit->timer.tm_frequency;
   uint32_t sec = count / freq;
   uint32_t frac = count % freq;
-  bintime_t bt = bintime_mul(HZ2BT(freq), frac);
+  bintime_t bt = bintime_mul(tm->tm_min_period, frac);
   bt.sec += sec;
   return bt;
 }

--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -101,7 +101,7 @@ static bintime_t timer_pit_gettime(timer_t *tm) {
   device_t *dev = device_of(tm);
   pit_state_t *pit = dev->state;
   uint64_t count = pit_get_counter64(pit);
-  uint32_t freq = pit->timer.tm_frequency;
+  uint32_t freq = tm->tm_frequency;
   uint32_t sec = count / freq;
   uint32_t frac = count % freq;
   bintime_t bt = bintime_mul(tm->tm_min_period, frac);


### PR DESCRIPTION
The HZ2BT operation use a 64-bit division, which can be expensive, use the already calculated value for `HZ2BT(freq)`.