### PR TITLE
drivers: Convert PCI_BUS_METHODS and BUS_METHODS into functions.

### DIFF
--- a/include/sys/bus.h
+++ b/include/sys/bus.h
@@ -145,7 +145,9 @@ struct bus_methods {
   void (*deactivate_resource)(device_t *dev, resource_t *r);
 };
 
-#define BUS_METHODS(dev) (*(bus_methods_t *)(dev)->driver->interfaces[DIF_BUS])
+static inline bus_methods_t *bus_methods(device_t *dev) {
+  return dev->driver->interfaces[DIF_BUS];
+}
 
 /* As for now this actually returns a child of the bus, see a comment
  * above `device_method_provider` in include/sys/device.c */
@@ -175,8 +177,8 @@ static inline resource_t *bus_alloc_resource(device_t *dev, res_type_t type,
                                              rman_addr_t end, size_t size,
                                              rman_flags_t flags) {
   device_t *idev = BUS_METHOD_PROVIDER(dev, alloc_resource);
-  return BUS_METHODS(idev->parent)
-    .alloc_resource(idev, type, rid, start, end, size, flags);
+  return bus_methods(idev->parent)
+    ->alloc_resource(idev, type, rid, start, end, size, flags);
 }
 
 /*! \brief Activates resource for a device.
@@ -199,7 +201,7 @@ void bus_deactivate_resource(device_t *dev, resource_t *r);
 
 static inline void bus_release_resource(device_t *dev, resource_t *r) {
   device_t *idev = BUS_METHOD_PROVIDER(dev, release_resource);
-  BUS_METHODS(idev->parent).release_resource(idev, r);
+  bus_methods(idev->parent)->release_resource(idev, r);
 }
 
 int bus_generic_probe(device_t *bus);

--- a/include/sys/pci.h
+++ b/include/sys/pci.h
@@ -97,8 +97,9 @@ typedef struct pci_device {
   pci_bar_t bar[PCI_BAR_MAX];
 } pci_device_t;
 
-#define PCI_BUS_METHODS(dev)                                                   \
-  (*(pci_bus_methods_t *)(dev)->driver->interfaces[DIF_PCI_BUS])
+static inline pci_bus_methods_t *pci_bus_methods(device_t *dev) {
+  return dev->driver->interfaces[DIF_PCI_BUS];
+}
 
 /* As for now this actually returns a child of the bus, see a comment
  * above `device_method_provider` in include/sys/device.c */
@@ -109,7 +110,7 @@ typedef struct pci_device {
 static inline uint32_t pci_read_config(device_t *dev, unsigned reg,
                                        unsigned size) {
   device_t *idev = PCI_BUS_METHOD_PROVIDER(dev, read_config);
-  return PCI_BUS_METHODS(idev->parent).read_config(idev, reg, size);
+  return pci_bus_methods(idev->parent)->read_config(idev, reg, size);
 }
 
 #define pci_read_config_1(d, r) pci_read_config((d), (r), 1)
@@ -119,7 +120,7 @@ static inline uint32_t pci_read_config(device_t *dev, unsigned reg,
 static inline void pci_write_config(device_t *dev, unsigned reg, unsigned size,
                                     uint32_t value) {
   device_t *idev = PCI_BUS_METHOD_PROVIDER(dev, write_config);
-  PCI_BUS_METHODS(idev->parent).write_config(idev, reg, size, value);
+  pci_bus_methods(idev->parent)->write_config(idev, reg, size, value);
 }
 
 #define pci_write_config_1(d, r, v) pci_write_config((d), (r), 1, (v))
@@ -128,12 +129,12 @@ static inline void pci_write_config(device_t *dev, unsigned reg, unsigned size,
 
 static inline int pci_route_interrupt(device_t *dev) {
   device_t *idev = PCI_BUS_METHOD_PROVIDER(dev, route_interrupt);
-  return PCI_BUS_METHODS(idev->parent).route_interrupt(idev);
+  return pci_bus_methods(idev->parent)->route_interrupt(idev);
 }
 
 static inline void pci_enable_busmaster(device_t *dev) {
   device_t *idev = PCI_BUS_METHOD_PROVIDER(dev, enable_busmaster);
-  PCI_BUS_METHODS(idev->parent).enable_busmaster(idev);
+  pci_bus_methods(idev->parent)->enable_busmaster(idev);
 }
 
 void pci_bus_enumerate(device_t *pcib);

--- a/sys/kern/bus.c
+++ b/sys/kern/bus.c
@@ -99,7 +99,7 @@ bus_space_t *generic_bus_space = &(bus_space_t){
 void bus_intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
                     ih_service_t *service, void *arg, const char *name) {
   device_t *idev = BUS_METHOD_PROVIDER(dev, intr_setup);
-  BUS_METHODS(idev->parent).intr_setup(idev, irq, filter, service, arg, name);
+  bus_methods(idev->parent)->intr_setup(idev, irq, filter, service, arg, name);
   if (irq->r_handler)
     resource_activate(irq);
 }
@@ -107,7 +107,7 @@ void bus_intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
 void bus_intr_teardown(device_t *dev, resource_t *irq) {
   assert(resource_active(irq));
   device_t *idev = BUS_METHOD_PROVIDER(dev, intr_teardown);
-  BUS_METHODS(idev->parent).intr_teardown(idev, irq);
+  bus_methods(idev->parent)->intr_teardown(idev, irq);
   irq->r_handler = NULL;
   resource_deactivate(irq);
 }
@@ -117,7 +117,7 @@ int bus_activate_resource(device_t *dev, resource_t *r) {
     return 0;
 
   device_t *idev = BUS_METHOD_PROVIDER(dev, activate_resource);
-  int error = BUS_METHODS(idev->parent).activate_resource(idev, r);
+  int error = bus_methods(idev->parent)->activate_resource(idev, r);
   if (error == 0)
     resource_activate(r);
   return error;
@@ -127,7 +127,7 @@ void bus_deactivate_resource(device_t *dev, resource_t *r) {
   if (r->r_type != RT_IRQ) {
     assert(resource_active(r));
     device_t *idev = BUS_METHOD_PROVIDER(dev, deactivate_resource);
-    BUS_METHODS(idev->parent).deactivate_resource(idev, r);
+    bus_methods(idev->parent)->deactivate_resource(idev, r);
     resource_deactivate(r);
   }
 }

--- a/sys/mips/82371AB.c
+++ b/sys/mips/82371AB.c
@@ -28,8 +28,8 @@ static resource_t *intel_isa_alloc_resource(device_t *dev, res_type_t type,
   if (type != RT_IOPORTS) {
     assert(type == RT_IRQ);
     device_t *idev = BUS_METHOD_PROVIDER(dev->parent, alloc_resource);
-    return BUS_METHODS(idev->parent)
-      .alloc_resource(idev, type, rid, start, end, size, flags);
+    return bus_methods(idev->parent)
+      ->alloc_resource(idev, type, rid, start, end, size, flags);
   }
 
   assert(start >= IO_ICUSIZE);
@@ -73,7 +73,7 @@ static void intel_isa_release_resource(device_t *dev, resource_t *r) {
   if (r->r_type != RT_IOPORTS) {
     assert(r->r_type == RT_IRQ);
     device_t *idev = BUS_METHOD_PROVIDER(dev->parent, release_resource);
-    BUS_METHODS(idev->parent).release_resource(idev, r);
+    bus_methods(idev->parent)->release_resource(idev, r);
     return;
   }
   bus_deactivate_resource(dev, r);


### PR DESCRIPTION
Convert `PCI_BUS_METHODS` and `BUS_METHODS` into functions.