### PR TITLE
Remove td_kframe field from thread_t

### DIFF
--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -115,7 +115,6 @@ typedef struct thread {
   volatile unsigned td_idnest; /*!< (*) interrupt disable nest level */
   volatile unsigned td_pdnest; /*!< (*) preemption disable nest level */
   mcontext_t *td_uctx;         /*!< (*) user context (full exc. frame) */
-  ctx_t *td_kframe;            /*!< (*) kernel context (last trap frame) */
   ctx_t *td_kctx;              /*!< (*) kernel context (switch) */
   intptr_t td_onfault;         /*!< (*) PC for copyin/copyout faults */
   kstack_t td_kstack;          /*!< (*) kernel stack structure */

--- a/sys/aarch64/thread.c
+++ b/sys/aarch64/thread.c
@@ -19,13 +19,15 @@ void thread_entry_setup(thread_t *td, entry_fn_t target, void *arg) {
   ctx_t *kctx = kstack_alloc_s(stk, ctx_t);
 
   td->td_uctx = uctx;
-  td->td_kframe = kframe;
   td->td_kctx = kctx;
 
   /* Initialize registers in order to switch to kframe context. */
   ctx_init(kctx, kern_exc_leave, kframe);
 
-  /* This is the context that kern_exc_leave will restore. */
+  /* This is the context that kern_exc_leave will restore.
+   * The thread will start execution at target, with the stack pointer
+   * pointing to uctx.  */
   ctx_init(kframe, target, uctx);
+  /* If the target function returns, it will return to thread_exit. */
   ctx_setup_call(kframe, (register_t)thread_exit, (register_t)arg);
 }

--- a/sys/kern/fork.c
+++ b/sys/kern/fork.c
@@ -43,8 +43,6 @@ int do_fork(void (*start)(void *), void *arg, pid_t *cldpidp) {
   mcontext_copy(newtd->td_uctx, td->td_uctx);
   mcontext_set_retval(newtd->td_uctx, 0, 0);
 
-  /* New thread does not need the exception frame just yet. */
-  newtd->td_kframe = NULL;
   newtd->td_onfault = 0;
 
   newtd->td_wchan = NULL;

--- a/sys/mips/ebase.S
+++ b/sys/mips/ebase.S
@@ -316,13 +316,6 @@ SNESTED(user_exc_enter, MCONTEXT_SIZE, ra)
         # Turn off FPU
         STATUS_CLEAR(SR_CU1)
 
-        # Fetch thread control block pointer to s0 for later use.
-        LOAD_PCPU(s0)
-        lw      s0, PCPU_CURTHREAD(s0)
-
-        # No exeception frame so set td_kframe to NULL.
-        sw      $0, TD_KFRAME(s0)
-
         # Call C interrupt handler routine.
         la      t0, mips_exc_handler
         jalr    t0
@@ -415,13 +408,6 @@ SNESTED(kern_exc_enter, CTX_SIZE, ra)
 
         # Load kernel global pointer.
         la      gp, _gp
-
-        # Fetch thread control block pointer to s0 for later use.
-        LOAD_PCPU(t0)
-        lw      s0, PCPU_CURTHREAD(t0)
-
-        # Save exception frame pointer into td_kframe.
-        sw      sp, TD_KFRAME(s0)
 
         # Call C interrupt handler routine.
         la      t0, mips_exc_handler

--- a/sys/mips/genassym.cf
+++ b/sys/mips/genassym.cf
@@ -11,7 +11,6 @@ define TDP_FPUINUSE TDP_FPUINUSE
 
 define TD_PROC offsetof(thread_t, td_proc)
 define TD_UCTX offsetof(thread_t, td_uctx)
-define TD_KFRAME offsetof(thread_t, td_kframe)
 define TD_KCTX offsetof(thread_t, td_kctx)
 define TD_KSTACK offsetof(thread_t, td_kstack)
 define TD_FLAGS offsetof(thread_t, td_flags)

--- a/sys/mips/switch.S
+++ b/sys/mips/switch.S
@@ -122,7 +122,7 @@ ctx_save:
         lw      t2, TD_PFLAGS(a0)
         and     t2, TDP_FPUINUSE|TDP_FPUCTXSAVED
         li      t3, TDP_FPUINUSE
-        beq     t2, t3, skip_fpu_save
+        bne     t2, t3, skip_fpu_save
         nop
 
         # mark FPU context as saved

--- a/sys/mips/switch.S
+++ b/sys/mips/switch.S
@@ -120,14 +120,12 @@ ctx_save:
         /* save FPU context only
          * if it needs saving and has not already been saved */
         lw      t2, TD_PFLAGS(a0)
-        and     t2, TDP_FPUINUSE|TDP_FPUCTXSAVED
-        li      t3, TDP_FPUINUSE
-        bne     t2, t3, skip_fpu_save
-        nop
+        and     t3, t2, TDP_FPUINUSE|TDP_FPUCTXSAVED
+        li      t1, TDP_FPUINUSE
+        bne     t1, t3, skip_fpu_save
 
         # mark FPU context as saved
-        lw      t2, TD_PFLAGS(a0)
-        or      t2, TDP_FPUCTXSAVED
+        or      t2, TDP_FPUCTXSAVED # delay slot
         sw      t2, TD_PFLAGS(a0)
 
         # ... and finally save it (temporarily enabling FPU)

--- a/sys/mips/thread.c
+++ b/sys/mips/thread.c
@@ -19,13 +19,15 @@ void thread_entry_setup(thread_t *td, entry_fn_t target, void *arg) {
   ctx_t *kctx = kstack_alloc_s(stk, ctx_t);
 
   td->td_uctx = uctx;
-  td->td_kframe = kframe;
   td->td_kctx = kctx;
 
   /* Initialize registers in order to switch to kframe context. */
   ctx_init(kctx, kern_exc_leave, kframe);
 
-  /* This is the context that kern_exc_leave will restore. */
+  /* This is the context that kern_exc_leave will restore.
+   * The thread will start execution at `target`, with the stack pointer
+   * pointing to uctx.  */
   ctx_init(kframe, target, uctx);
+  /* If the `target` function returns, it will return to `thread_exit`. */
   ctx_setup_call(kframe, (register_t)thread_exit, (register_t)arg);
 }


### PR DESCRIPTION
We don't use it anywhere.
Also, fix buggy FPU context save logic in `ctx_switch` on MIPS.