### PR TITLE
Fix build & test run with -O2 optimization flag

### DIFF
--- a/bin/utest/time.c
+++ b/bin/utest/time.c
@@ -59,8 +59,8 @@ int test_nanosleep(void) {
   /* Check if sleept at least requested time */;
   for (int g = 0; g < 20; g++) {
     rqt.tv_nsec = (1000 << g);
-    diff = *((timeval_t *)&rqt);
-    diff.tv_usec /= 1000;
+    diff.tv_sec = rqt.tv_sec;
+    diff.tv_usec = rqt.tv_nsec / 1000;
 
     ret = gettimeofday(&time1, NULL);
     assert(ret == 0);

--- a/sys/aarch64/sigcode.S
+++ b/sys/aarch64/sigcode.S
@@ -5,7 +5,7 @@
         .global esigcode
 
 ENTRY(sigcode)
-        add     x0, sp, 8       /* address of ucontext_t to restore */
+        mov     x0, sp       /* address of ucontext_t to restore */
         svc     #SYS_sigreturn
         brk     #0
 EXPORT(esigcode)

--- a/sys/aarch64/signal.c
+++ b/sys/aarch64/signal.c
@@ -35,7 +35,6 @@ int sig_send(signo_t sig, sigset_t *mask, sigaction_t *sa, ksiginfo_t *ksi) {
   _REG(uctx, X0) = sig;
   _REG(uctx, X1) = sc_info;
   _REG(uctx, X2) = sc_uctx;
-  _REG(uctx, SP) -= sizeof(intptr_t *);
   _REG(uctx, LR) = sc_code;
 
   return 0;

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -227,7 +227,7 @@ fail:
 }
 
 static int open_executable(const char *path, vnode_t **vn_p, cred_t *cred) {
-  vnode_t *vn = *vn_p;
+  vnode_t *vn;
   int error;
 
   klog("Loading program '%s'", path);

--- a/sys/mips/sigcode.S
+++ b/sys/mips/sigcode.S
@@ -7,7 +7,7 @@
         .set noreorder
 
 LEAF_NOPROFILE(sigcode)
-        addi    a0, sp, 4               # address of ucontext_t to restore
+        addi    a0, sp, STACK_ALIGN           # address of ucontext_t to restore
         li      v0, SYS_sigreturn
         syscall
         # just in case sigreturn fails

--- a/sys/mips/signal.c
+++ b/sys/mips/signal.c
@@ -42,9 +42,9 @@ int sig_send(signo_t sig, sigset_t *mask, sigaction_t *sa, ksiginfo_t *ksi) {
   _REG(uctx, A1) = sc_info;
   _REG(uctx, A2) = sc_uctx;
   /* The calling convention is such that the callee may write to the address
-   * pointed by sp before extending the stack - so we need to set it 1 word
-   * before the stored context! */
-  _REG(uctx, SP) -= sizeof(intptr_t *);
+   * pointed by sp before extending the stack - so we need to set it at least
+   * 1 word before the stored context! */
+  _REG(uctx, SP) -= STACK_ALIGN;
   /* Also, make sure that sigcode runs when the handler exits. */
   _REG(uctx, RA) = sc_code;
 

--- a/sys/tests/fdt.c
+++ b/sys/tests/fdt.c
@@ -82,5 +82,5 @@ static int test_fdt_getprop(void) {
 
 KTEST_ADD(fdt_get_path, test_fdt_get_path, 0);
 KTEST_ADD(fdt_get_name, test_fdt_get_name, 0);
-KTEST_ADD(fst_subnode, test_fdt_subnode, 0);
-KTEST_ADD(fst_getprop, test_fdt_getprop, 0);
+KTEST_ADD(fdt_subnode, test_fdt_subnode, 0);
+KTEST_ADD(fdt_getprop, test_fdt_getprop, 0);


### PR DESCRIPTION
This PR fixes a couple of issues I encountered while trying to compile and run the kernel with `-O2`.