### PR TITLE
Introduce MTX_DEFINE & SPIN_DEFINE macro

### DIFF
--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -26,10 +26,13 @@ typedef struct mtx {
 #define MTX_CONTESTED 1
 #define MTX_FLAGMASK 7
 
-#define MTX_INITIALIZER(recursive)                                             \
+#define MTX_INITIALIZER(mutexname, recursive)                                  \
   (mtx_t) {                                                                    \
     .m_attr = (recursive) | LK_TYPE_BLOCK                                      \
   }
+
+#define MTX_DEFINE(mutexname, recursive)                                       \
+  mtx_t mutexname = MTX_INITIALIZER(mutexname, recursive)
 
 /*! \brief Initializes mutex.
  *

--- a/include/sys/proc.h
+++ b/include/sys/proc.h
@@ -22,7 +22,7 @@ typedef TAILQ_HEAD(, proc) proc_list_t;
 typedef TAILQ_HEAD(, pgrp) pgrp_list_t;
 typedef TAILQ_HEAD(, session) session_list_t;
 
-extern mtx_t *all_proc_mtx;
+extern mtx_t all_proc_mtx;
 extern proc_list_t proc_list, zombie_list;
 
 /*! \brief Called during kernel initialization. */

--- a/include/sys/spinlock.h
+++ b/include/sys/spinlock.h
@@ -30,10 +30,13 @@ typedef struct spin {
   const void *s_lockpt;       /*!< place where the lock was acquired */
 } spin_t;
 
-#define SPIN_INITIALIZER(recursive)                                            \
+#define SPIN_INITIALIZER(spinname, recursive)                                  \
   (spin_t) {                                                                   \
     .s_attr = (recursive) | LK_TYPE_SPIN                                       \
   }
+
+#define SPIN_DEFINE(spinname, recursive)                                       \
+  spin_t spinname = SPIN_INITIALIZER(spinname, recursive);
 
 /*! \brief Initializes spin lock.
  *

--- a/sys/kern/callout.c
+++ b/sys/kern/callout.c
@@ -81,7 +81,7 @@ static void callout_thread(void *arg) {
 void init_callout(void) {
   bzero(&ci, sizeof(ci));
 
-  ci.lock = SPIN_INITIALIZER(0);
+  spin_init(&ci.lock, 0);
 
   for (int i = 0; i < CALLOUT_BUCKETS; i++)
     TAILQ_INIT(ci_list(i));

--- a/sys/kern/cred_checks.c
+++ b/sys/kern/cred_checks.c
@@ -21,7 +21,7 @@ int cred_cansignal(proc_t *target, cred_t *cred) {
 }
 
 int proc_cansignal(proc_t *target, signo_t sig) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
   assert(mtx_owned(&target->p_lock));
 
   proc_t *p = proc_self();

--- a/sys/kern/dev_procstat.c
+++ b/sys/kern/dev_procstat.c
@@ -123,7 +123,7 @@ static int dev_procstat_open(vnode_t *v, int mode, file_t *fp) {
   ps->nproc = 0;
   mtx_init(&ps->lock, 0);
 
-  WITH_MTX_LOCK (all_proc_mtx) {
+  WITH_MTX_LOCK (&all_proc_mtx) {
     TAILQ_FOREACH (p, &proc_list, p_all) {
       if (p->p_pid == 0)
         continue; /* we don't want to show proc0 to user */

--- a/sys/kern/devfs.c
+++ b/sys/kern/devfs.c
@@ -40,7 +40,7 @@ typedef struct devfs_mount {
 } devfs_mount_t;
 
 static devfs_mount_t devfs = {
-  .lock = MTX_INITIALIZER(0), .next_ino = 2, .root = {}};
+  .lock = MTX_INITIALIZER(devfs.lock, 0), .next_ino = 2, .root = {}};
 static vnode_lookup_t devfs_vop_lookup;
 static vnode_readdir_t devfs_vop_readdir;
 static vnode_getattr_t devfs_vop_getattr;

--- a/sys/kern/fork.c
+++ b/sys/kern/fork.c
@@ -88,7 +88,7 @@ int do_fork(void (*start)(void *), void *arg, pid_t *cldpidp) {
 
   /* Link the child process into all the structures
    * by which it can be reached from the outside at once. */
-  WITH_MTX_LOCK (all_proc_mtx) {
+  WITH_MTX_LOCK (&all_proc_mtx) {
     /* Enter child into parent's process group.
      * No jobc adjustments are necessary, since the new child has no children
      * of its own, and it's in the same process group as the parent. */

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -12,7 +12,7 @@ static KMALLOC_DEFINE(M_INTR, "interrupt events & handlers");
 
 typedef TAILQ_HEAD(, intr_event) ie_list_t;
 
-static mtx_t all_ievents_mtx = MTX_INITIALIZER(0);
+static MTX_DEFINE(all_ievents_mtx, 0);
 static ie_list_t all_ievents_list = TAILQ_HEAD_INITIALIZER(all_ievents_list);
 
 /*
@@ -65,7 +65,7 @@ intr_event_t *intr_event_create(void *source, int irq, ie_action_t *disable,
   intr_event_t *ie = kmalloc(M_INTR, sizeof(intr_event_t), M_WAITOK | M_ZERO);
   ie->ie_irq = irq;
   ie->ie_name = name;
-  ie->ie_lock = SPIN_INITIALIZER(LK_RECURSIVE);
+  spin_init(&ie->ie_lock, LK_RECURSIVE);
   ie->ie_enable = enable;
   ie->ie_disable = disable;
   ie->ie_source = source;

--- a/sys/kern/klog.c
+++ b/sys/kern/klog.c
@@ -29,7 +29,7 @@ typedef struct klog {
 } klog_t;
 
 static klog_t klog;
-static spin_t klog_lock = SPIN_INITIALIZER(LK_RECURSIVE);
+static SPIN_DEFINE(klog_lock, LK_RECURSIVE);
 
 static const char *subsystems[] = {
   [KL_SLEEPQ] = "sleepq",   [KL_CALLOUT] = "callout", [KL_INIT] = "init",

--- a/sys/kern/pool.c
+++ b/sys/kern/pool.c
@@ -51,7 +51,7 @@ typedef struct pool {
 } pool_t;
 
 static TAILQ_HEAD(, pool) pool_list = TAILQ_HEAD_INITIALIZER(pool_list);
-static mtx_t *pool_list_lock = &MTX_INITIALIZER(0);
+static MTX_DEFINE(pool_list_lock, 0);
 static KMALLOC_DEFINE(M_POOL, "pool allocators");
 
 typedef struct slab {
@@ -268,7 +268,7 @@ static void pool_init(pool_t *pool, const char *desc, size_t size,
   kasan_quar_init(&pool->pp_quarantine, (quar_free_t)_pool_free);
   klog("initialized '%s' pool at %p (item size = %d)", pool->pp_desc, pool,
        pool->pp_itemsize);
-  WITH_MTX_LOCK (pool_list_lock)
+  WITH_MTX_LOCK (&pool_list_lock)
     TAILQ_INSERT_TAIL(&pool_list, pool, pp_link);
 }
 
@@ -289,7 +289,7 @@ pool_t *pool_create(const char *desc, size_t size) {
 }
 
 void pool_destroy(pool_t *pool) {
-  WITH_MTX_LOCK (pool_list_lock)
+  WITH_MTX_LOCK (&pool_list_lock)
     TAILQ_REMOVE(&pool_list, pool, pp_link);
   WITH_MTX_LOCK (&pool->pp_mtx)
     /* Lock needed as the quarantine may call _pool_free! */

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -39,7 +39,7 @@ static POOL_DEFINE(P_PROC, "proc", sizeof(proc_t));
 static POOL_DEFINE(P_PGRP, "pgrp", sizeof(pgrp_t));
 static POOL_DEFINE(P_SESSION, "session", sizeof(session_t));
 
-mtx_t *all_proc_mtx = &MTX_INITIALIZER(0);
+MTX_DEFINE(all_proc_mtx, 0);
 
 /* all_proc_mtx protects following data: */
 proc_list_t proc_list = TAILQ_HEAD_INITIALIZER(proc_list);
@@ -69,7 +69,7 @@ static session_t session0 = {
 };
 
 static pgrp_t pgrp0 = {
-  .pg_lock = MTX_INITIALIZER(0),
+  .pg_lock = MTX_INITIALIZER(pgrp0.pg_lock, 0),
   .pg_members = TAILQ_HEAD_INITIALIZER(pgrp0.pg_members),
   .pg_session = &session0,
   .pg_jobc = 0,
@@ -77,7 +77,7 @@ static pgrp_t pgrp0 = {
 };
 
 proc_t proc0 = {
-  .p_lock = MTX_INITIALIZER(0),
+  .p_lock = MTX_INITIALIZER(proc0.p_lock, 0),
   .p_thread = &thread0,
   .p_pid = 0,
   .p_pgrp = &pgrp0,
@@ -121,7 +121,7 @@ static bool pid_is_taken(pid_t pid) {
 }
 
 static pid_t pid_alloc(void) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   static pid_t lastpid = 0;
 
@@ -148,13 +148,13 @@ static session_t *session_create(proc_t *leader) {
 }
 
 static void session_hold(session_t *s) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   s->s_count++;
 }
 
 static void session_drop(session_t *s) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   if (--s->s_count == 0) {
     TAILQ_REMOVE(SESSION_HASH_CHAIN(s->s_sid), s, s_hash);
@@ -163,7 +163,7 @@ static void session_drop(session_t *s) {
 }
 
 static session_t *session_lookup(sid_t sid) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   session_t *s;
   TAILQ_FOREACH (s, SESSION_HASH_CHAIN(sid), s_hash)
@@ -175,7 +175,7 @@ static session_t *session_lookup(sid_t sid) {
 /* Session functions */
 
 int proc_getsid(pid_t pid, sid_t *sidp) {
-  WITH_MTX_LOCK (all_proc_mtx) {
+  WITH_MTX_LOCK (&all_proc_mtx) {
     proc_t *p = proc_find(pid);
     if (p == NULL)
       return ESRCH;
@@ -199,7 +199,7 @@ static pgrp_t *pgrp_create(pgid_t pgid) {
 /* If the process group becomes orphaned and has at least one stopped process,
  * send SIGHUP followed by SIGCONT to every process in the group. */
 static void pgrp_maybe_orphan(pgrp_t *pg) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   SCOPED_MTX_LOCK(&pg->pg_lock);
   if (--pg->pg_jobc > 0)
@@ -236,7 +236,7 @@ static bool same_session_p(pgrp_t *pg1, pgrp_t *pg2) {
  * These counters need to be adjusted whenever any process leaves
  * or joins a process group. */
 static void pgrp_jobc_enter(proc_t *p, pgrp_t *pg) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   if (same_session_p(p->p_parent->p_pgrp, pg))
     pg->pg_jobc++;
@@ -248,7 +248,7 @@ static void pgrp_jobc_enter(proc_t *p, pgrp_t *pg) {
 }
 
 static void pgrp_jobc_leave(proc_t *p, pgrp_t *pg) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   if (same_session_p(p->p_parent->p_pgrp, pg))
     pgrp_maybe_orphan(pg);
@@ -261,7 +261,7 @@ static void pgrp_jobc_leave(proc_t *p, pgrp_t *pg) {
 
 /* Finds process group with the ID specified by pgid or returns NULL. */
 pgrp_t *pgrp_lookup(pgid_t pgid) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   pgrp_t *pgrp;
   TAILQ_FOREACH (pgrp, PGRP_HASH_CHAIN(pgid), pg_hash)
@@ -271,7 +271,7 @@ pgrp_t *pgrp_lookup(pgid_t pgid) {
 }
 
 static void pgrp_remove(pgrp_t *pgrp) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   /* Check if removed group was a foreground group of some terminal. */
   tty_t *tty = pgrp->pg_session->s_tty;
@@ -290,7 +290,7 @@ static void pgrp_remove(pgrp_t *pgrp) {
 /* Make a process leave its process group.
  * Called only on process exit, use _pgrp_enter for changing groups. */
 static void pgrp_leave(proc_t *p) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   pgrp_t *pgrp = p->p_pgrp;
 
@@ -310,7 +310,7 @@ static void pgrp_leave(proc_t *p) {
 static int _pgrp_enter(proc_t *p, pgrp_t *target) {
   pgrp_t *old_pgrp = p->p_pgrp;
   assert(old_pgrp);
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   if (old_pgrp == target)
     return 0;
@@ -338,7 +338,7 @@ static int _pgrp_enter(proc_t *p, pgrp_t *target) {
 }
 
 int session_enter(proc_t *p) {
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  SCOPED_MTX_LOCK(&all_proc_mtx);
   assert(p->p_pgrp);
 
   pgid_t pgid = p->p_pid;
@@ -361,7 +361,7 @@ int session_enter(proc_t *p) {
 
 /* Called only when process finishes. */
 static void session_leave(proc_t *p) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   if (!proc_is_session_leader(p))
     return;
@@ -394,7 +394,7 @@ static void session_leave(proc_t *p) {
 int pgrp_enter(proc_t *p, pid_t target, pgid_t pgid) {
   /* TODO: disallow setting the process group of children
    * that have called exec(). */
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  SCOPED_MTX_LOCK(&all_proc_mtx);
   assert(p->p_pgrp);
 
   proc_t *targetp = proc_find_raw(target);
@@ -470,7 +470,7 @@ proc_t *proc_create(thread_t *td, proc_t *parent) {
 
 void proc_add(proc_t *p) {
   assert(p->p_parent);
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   p->p_pid = pid_alloc();
   TAILQ_INSERT_TAIL(&proc_list, p, p_all);
@@ -483,7 +483,7 @@ void proc_add(proc_t *p) {
 /* Lookup a process in the PID hash table.
  * The returned process, if any, is NOT locked. */
 static proc_t *proc_find_raw(pid_t pid) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   proc_t *p = NULL;
   TAILQ_FOREACH (p, PROC_HASH_CHAIN(pid), p_hash)
@@ -494,7 +494,7 @@ static proc_t *proc_find_raw(pid_t pid) {
 }
 
 proc_t *proc_find(pid_t pid) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   proc_t *p = proc_find_raw(pid);
   if (p != NULL) {
@@ -508,7 +508,7 @@ proc_t *proc_find(pid_t pid) {
 }
 
 int proc_getpgid(pid_t pid, pgid_t *pgidp) {
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  SCOPED_MTX_LOCK(&all_proc_mtx);
 
   proc_t *p = proc_find(pid);
   if (!p)
@@ -521,7 +521,7 @@ int proc_getpgid(pid_t pid, pgid_t *pgidp) {
 
 /* Release zombie process after parent processed its state. */
 static void proc_reap(proc_t *p) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
 
   assert(p->p_state == PS_ZOMBIE);
   assert(p->p_parent);
@@ -537,7 +537,7 @@ static void proc_reap(proc_t *p) {
 }
 
 static void proc_reparent(proc_t *old_parent, proc_t *new_parent) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
   assert(new_parent);
 
   proc_t *child, *next;
@@ -597,7 +597,7 @@ __noreturn void proc_exit(int exitstatus) {
   vm_map_delete(uspace);
   fdtab_drop(p->p_fdtable);
 
-  WITH_MTX_LOCK (all_proc_mtx) {
+  WITH_MTX_LOCK (&all_proc_mtx) {
     if (p->p_pid == 1)
       panic("'init' process died!");
 
@@ -655,7 +655,7 @@ __noreturn void proc_exit(int exitstatus) {
 
 static int proc_pgsignal(pgid_t pgid, signo_t sig) {
   pgrp_t *pgrp = NULL;
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  SCOPED_MTX_LOCK(&all_proc_mtx);
 
   if (pgid == 0) {
     pgrp = proc_self()->p_pgrp;
@@ -689,7 +689,7 @@ int proc_sendsig(pid_t pid, signo_t sig) {
   proc_t *target;
 
   if (pid > 0) {
-    SCOPED_MTX_LOCK(all_proc_mtx);
+    SCOPED_MTX_LOCK(&all_proc_mtx);
     target = proc_find(pid);
     if (target == NULL)
       return ESRCH;
@@ -747,7 +747,7 @@ int do_waitpid(pid_t pid, int *status, int options, pid_t *cldpidp) {
     int error = ECHILD;
     proc_t *child;
 
-    WITH_MTX_LOCK (all_proc_mtx) {
+    WITH_MTX_LOCK (&all_proc_mtx) {
       /* Check children meeting criteria implied by pid. */
       TAILQ_FOREACH (child, CHILDREN(p), p_child) {
         if (!child_matches(child, pid, p->p_pgrp))
@@ -814,7 +814,7 @@ int do_setlogin(const char *name) {
   if (strnlen(name, LOGIN_NAME_MAX) == LOGIN_NAME_MAX)
     return EINVAL;
 
-  WITH_MTX_LOCK (all_proc_mtx)
+  WITH_MTX_LOCK (&all_proc_mtx)
     strncpy(p->p_pgrp->pg_session->s_login, name, LOGIN_NAME_MAX);
 
   return 0;

--- a/sys/kern/pty.c
+++ b/sys/kern/pty.c
@@ -235,7 +235,7 @@ int do_posix_openpt(proc_t *p, int flags, register_t *res) {
   tty->t_data = pty;
 
   if (!(flags & O_NOCTTY)) {
-    WITH_MTX_LOCK (all_proc_mtx)
+    WITH_MTX_LOCK (&all_proc_mtx)
       WITH_MTX_LOCK (&tty->t_lock)
         maybe_assoc_ctty(p, tty);
   }

--- a/sys/kern/sched.c
+++ b/sys/kern/sched.c
@@ -11,7 +11,7 @@
 #include <sys/pcpu.h>
 #include <sys/turnstile.h>
 
-static spin_t sched_lock = SPIN_INITIALIZER(0);
+static SPIN_DEFINE(sched_lock, 0);
 static runq_t runq;
 static bool sched_active = false;
 

--- a/sys/kern/sleepq.c
+++ b/sys/kern/sleepq.c
@@ -64,7 +64,7 @@ void init_sleepq(void) {
 
   for (int i = 0; i < SC_TABLESIZE; i++) {
     sleepq_chain_t *sc = &sleepq_chains[i];
-    sc->sc_lock = SPIN_INITIALIZER(0);
+    spin_init(&sc->sc_lock, 0);
     TAILQ_INIT(&sc->sc_queues);
   }
 }

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -1075,7 +1075,7 @@ static int sys_getlogin(proc_t *p, getlogin_args_t *args, register_t *res) {
 
   klog("getlogin(%p, %zu)", namebuf, buflen);
 
-  WITH_MTX_LOCK (all_proc_mtx)
+  WITH_MTX_LOCK (&all_proc_mtx)
     memcpy(login_tmp, p->p_pgrp->pg_session->s_login, sizeof(login_tmp));
 
   return copyout(login_tmp, namebuf, min(buflen, sizeof(login_tmp)));

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -18,7 +18,7 @@ static POOL_DEFINE(P_THREAD, "thread", sizeof(thread_t));
 
 typedef TAILQ_HEAD(, thread) thread_list_t;
 
-static mtx_t *threads_lock = &MTX_INITIALIZER(0);
+static MTX_DEFINE(threads_lock, 0);
 static thread_list_t all_threads = TAILQ_HEAD_INITIALIZER(all_threads);
 static thread_list_t zombie_threads = TAILQ_HEAD_INITIALIZER(zombie_threads);
 
@@ -54,14 +54,14 @@ void init_thread0(void) {
   sigpend_init(&td->td_sigpend);
   LIST_INIT(&td->td_contested);
 
-  WITH_MTX_LOCK (threads_lock)
+  WITH_MTX_LOCK (&threads_lock)
     TAILQ_INSERT_TAIL(&all_threads, td, td_all);
 }
 
 void thread_reap(void) {
   thread_list_t zombies;
 
-  WITH_MTX_LOCK (threads_lock) {
+  WITH_MTX_LOCK (&threads_lock) {
     zombies = zombie_threads;
     TAILQ_INIT(&zombie_threads);
   }
@@ -102,7 +102,7 @@ thread_t *thread_create(const char *name, void (*fn)(void *), void *arg,
   thread_entry_setup(td, fn, arg);
 
   /* From now on, you must use locks on new thread structure. */
-  WITH_MTX_LOCK (threads_lock)
+  WITH_MTX_LOCK (&threads_lock)
     TAILQ_INSERT_TAIL(&all_threads, td, td_all);
 
   klog("Thread %ld {%p} has been created", td->td_tid, td);
@@ -117,7 +117,7 @@ void thread_delete(thread_t *td) {
 
   klog("Freeing up thread %ld {%p}", td->td_tid, td);
 
-  WITH_MTX_LOCK (threads_lock)
+  WITH_MTX_LOCK (&threads_lock)
     TAILQ_REMOVE(&all_threads, td, td_all);
 
   kmem_free(td->td_kstack.stk_base, PAGESIZE);
@@ -158,7 +158,7 @@ __noreturn void thread_exit(void) {
    */
   preempt_disable();
 
-  WITH_MTX_LOCK (threads_lock) {
+  WITH_MTX_LOCK (&threads_lock) {
     spin_lock(td->td_lock); /* force threads_lock >> thread_t::td_lock order */
     TAILQ_INSERT_TAIL(&zombie_threads, td, td_zombieq);
   }
@@ -195,7 +195,7 @@ void thread_yield(void) {
 /* It would be better to have a hash-map from tid_t to thread_t,
  * but using a list is sufficient for now. */
 thread_t *thread_find(tid_t id) {
-  SCOPED_MTX_LOCK(threads_lock);
+  SCOPED_MTX_LOCK(&threads_lock);
 
   thread_t *td;
   TAILQ_FOREACH (td, &all_threads, td_all) {

--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -6,7 +6,7 @@
 #include <sys/mutex.h>
 #include <sys/errno.h>
 
-static mtx_t timers_mtx = MTX_INITIALIZER(0);
+static MTX_DEFINE(timers_mtx, 0);
 static timer_list_t timers = TAILQ_HEAD_INITIALIZER(timers);
 static timer_t *time_source = NULL;
 static bintime_t boottime = BINTIME(0);

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -665,7 +665,7 @@ static tmpfs_node_t *tmpfs_new_node(tmpfs_mount_t *tfm, vattr_t *va,
   node->tfn_atime = nanotime();
   node->tfn_ctime = node->tfn_atime;
   node->tfn_mtime = node->tfn_atime;
-  node->tfn_timelock = MTX_INITIALIZER(0);
+  mtx_init(&node->tfn_timelock, 0);
 
   mtx_lock(&tfm->tfm_lock);
   node->tfn_ino = tfm->tfm_next_ino++;
@@ -1033,7 +1033,7 @@ static int tmpfs_mount(mount_t *mp) {
   /* Allocate the tmpfs mount structure and fill it. */
   tmpfs_mount_t *tfm = &tmpfs;
 
-  tfm->tfm_lock = MTX_INITIALIZER(LK_RECURSIVE);
+  mtx_init(&tfm->tfm_lock, LK_RECURSIVE);
   tfm->tfm_next_ino = 2;
   mp->mnt_data = tfm;
 

--- a/sys/kern/tty.c
+++ b/sys/kern/tty.c
@@ -945,7 +945,7 @@ static int tty_get_fg_pgrp(tty_t *tty, int *pgid_p) {
 }
 
 static int tty_set_fg_pgrp(tty_t *tty, pgid_t pgid) {
-  WITH_MTX_LOCK (all_proc_mtx) {
+  WITH_MTX_LOCK (&all_proc_mtx) {
     proc_t *p = proc_self();
     pgrp_t *pg = pgrp_lookup(pgid);
     WITH_MTX_LOCK (&tty->t_lock) {
@@ -1005,7 +1005,7 @@ int tty_ioctl(file_t *f, u_long cmd, void *data) {
     case TIOCSWINSZ:
       return tty_set_winsize(tty, data);
     case TIOCSCTTY: {
-      SCOPED_MTX_LOCK(all_proc_mtx);
+      SCOPED_MTX_LOCK(&all_proc_mtx);
       SCOPED_MTX_LOCK(&tty->t_lock);
       if (!maybe_assoc_ctty(proc_self(), tty))
         return EPERM;
@@ -1084,7 +1084,7 @@ static fileops_t tty_fileops = {
 };
 
 bool maybe_assoc_ctty(proc_t *p, tty_t *tty) {
-  assert(mtx_owned(all_proc_mtx));
+  assert(mtx_owned(&all_proc_mtx));
   assert(mtx_owned(&tty->t_lock));
 
   if (!proc_is_session_leader(p))
@@ -1127,7 +1127,7 @@ static int _tty_vn_open(vnode_t *v, int mode, file_t *fp) {
 }
 
 static int tty_vn_open(vnode_t *v, int mode, file_t *fp) {
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  SCOPED_MTX_LOCK(&all_proc_mtx);
   return _tty_vn_open(v, mode, fp);
 }
 
@@ -1152,7 +1152,7 @@ int tty_makedev(devfs_node_t *parent, const char *name, tty_t *tty) {
 static int dev_tty_open(vnode_t *v, int mode, file_t *fp) {
   proc_t *p = proc_self();
 
-  SCOPED_MTX_LOCK(all_proc_mtx);
+  SCOPED_MTX_LOCK(&all_proc_mtx);
   tty_t *tty = p->p_pgrp->pg_session->s_tty;
   if (!tty)
     return ENXIO;

--- a/sys/kern/turnstile.c
+++ b/sys/kern/turnstile.c
@@ -69,7 +69,7 @@ static void turnstile_ctor(turnstile_t *ts) {
 void init_turnstile(void) {
   for (int i = 0; i < TC_TABLESIZE; i++) {
     turnstile_chain_t *tc = &turnstile_chains[i];
-    tc->tc_lock = SPIN_INITIALIZER(0);
+    spin_init(&tc->tc_lock, 0);
     LIST_INIT(&tc->tc_turnstiles);
   }
 }

--- a/sys/kern/vfs.c
+++ b/sys/kern/vfs.c
@@ -15,12 +15,12 @@ static KMALLOC_DEFINE(M_VFS, "vfs");
 
 /* The list of all installed filesystem types */
 vfsconf_list_t vfsconf_list = TAILQ_HEAD_INITIALIZER(vfsconf_list);
-mtx_t vfsconf_list_mtx = MTX_INITIALIZER(0);
+MTX_DEFINE(vfsconf_list_mtx, 0);
 
 /* The list of all mounts mounted */
 typedef TAILQ_HEAD(, mount) mount_list_t;
 static mount_list_t mount_list = TAILQ_HEAD_INITIALIZER(mount_list);
-static mtx_t mount_list_mtx = MTX_INITIALIZER(0);
+static MTX_DEFINE(mount_list_mtx, 0);
 
 /* Default vfs operations */
 static vfs_root_t vfs_default_root;

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -28,7 +28,7 @@ typedef struct vm_physseg {
 static TAILQ_HEAD(, vm_physseg) seglist = TAILQ_HEAD_INITIALIZER(seglist);
 static vm_pagelist_t freelist[PM_NQUEUES];
 static size_t pagecount[PM_NQUEUES];
-static mtx_t *physmem_lock = &MTX_INITIALIZER(LK_RECURSIVE);
+static MTX_DEFINE(physmem_lock, LK_RECURSIVE);
 
 void _vm_physseg_plug(paddr_t start, paddr_t end, bool used) {
   assert(page_aligned_p(start) && page_aligned_p(end) && start < end);
@@ -36,7 +36,7 @@ void _vm_physseg_plug(paddr_t start, paddr_t end, bool used) {
   static vm_physseg_t freeseg[VM_PHYSSEG_NMAX];
   static unsigned freeseg_last = 0;
 
-  SCOPED_MTX_LOCK(physmem_lock);
+  SCOPED_MTX_LOCK(&physmem_lock);
 
   assert(freeseg_last < VM_PHYSSEG_NMAX - 1);
 
@@ -210,7 +210,7 @@ static vm_page_t *pm_take_page(size_t fl) {
 vm_page_t *vm_page_alloc(size_t npages) {
   assert((npages > 0) && powerof2(npages));
 
-  SCOPED_MTX_LOCK(physmem_lock);
+  SCOPED_MTX_LOCK(&physmem_lock);
 
   size_t n = log2(npages);
   size_t fl = n;
@@ -231,7 +231,7 @@ vm_page_t *vm_page_alloc(size_t npages) {
 int vm_pagelist_alloc(size_t n, vm_pagelist_t *pglist) {
   TAILQ_INIT(pglist);
 
-  SCOPED_MTX_LOCK(physmem_lock);
+  SCOPED_MTX_LOCK(&physmem_lock);
 
   /* Check if the request can be satisfied at all. */
   size_t sums[PM_NQUEUES + 1];
@@ -314,12 +314,12 @@ static void vm_page_free_nolock(vm_page_t *pg) {
 }
 
 void vm_page_free(vm_page_t *page) {
-  SCOPED_MTX_LOCK(physmem_lock);
+  SCOPED_MTX_LOCK(&physmem_lock);
   vm_page_free_nolock(page);
 }
 
 void vm_pagelist_free(vm_pagelist_t *pglist) {
-  SCOPED_MTX_LOCK(physmem_lock);
+  SCOPED_MTX_LOCK(&physmem_lock);
 
   vm_page_t *pg, *pg_next;
   TAILQ_FOREACH_SAFE (pg, pglist, pageq, pg_next) {
@@ -329,7 +329,7 @@ void vm_pagelist_free(vm_pagelist_t *pglist) {
 }
 
 vm_page_t *vm_page_find(paddr_t pa) {
-  SCOPED_MTX_LOCK(physmem_lock);
+  SCOPED_MTX_LOCK(&physmem_lock);
 
   vm_physseg_t *seg_it;
   TAILQ_FOREACH (seg_it, &seglist, seglink) {

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -25,7 +25,7 @@ typedef LIST_HEAD(vmem_freelist, bt) vmem_freelist_t;
 typedef LIST_HEAD(vmem_hashlist, bt) vmem_hashlist_t;
 
 /* List of all vmem instances and a guarding mutex */
-static mtx_t vmem_list_lock = MTX_INITIALIZER(0);
+static MTX_DEFINE(vmem_list_lock, 0);
 static LIST_HEAD(, vmem) vmem_list = LIST_HEAD_INITIALIZER(vmem_list);
 
 /*! \brief vmem structure

--- a/sys/mips/pmap.c
+++ b/sys/mips/pmap.c
@@ -48,12 +48,12 @@ static const pte_t vm_prot_map[] = {
 static pmap_t kernel_pmap;
 pde_t *_kernel_pmap_pde;
 static bitstr_t asid_used[bitstr_size(MAX_ASID)] = {0};
-static spin_t *asid_lock = &SPIN_INITIALIZER(0);
+static SPIN_DEFINE(asid_lock, 0);
 
 /* this lock is used to protect the vm_page::pv_list field */
 /* the order of acquiring locks is as follows: firstly pv_list_lock and then
  * pmap_t::mtx */
-static mtx_t *pv_list_lock = &MTX_INITIALIZER(0);
+static MTX_DEFINE(pv_list_lock, 0);
 
 #define PDE_OF(pmap, vaddr) ((pmap)->pde[PDE_INDEX(vaddr)])
 #define PT_BASE(pde) ((pte_t *)(((pde) >> PTE_PFN_SHIFT) << PTE_INDEX_SHIFT))
@@ -121,7 +121,7 @@ pmap_t *pmap_lookup(vaddr_t addr) {
 
 static asid_t alloc_asid(void) {
   int free = 0;
-  WITH_SPIN_LOCK (asid_lock) {
+  WITH_SPIN_LOCK (&asid_lock) {
     bit_ffc(asid_used, MAX_ASID, &free);
     if (free < 0)
       panic("Out of asids!");
@@ -133,7 +133,7 @@ static asid_t alloc_asid(void) {
 
 static void free_asid(asid_t asid) {
   klog("free_asid(%d)", asid);
-  SCOPED_SPIN_LOCK(asid_lock);
+  SCOPED_SPIN_LOCK(&asid_lock);
   bit_clear(asid_used, (unsigned)asid);
   tlb_invalidate_asid(asid);
 }
@@ -143,7 +143,7 @@ static void free_asid(asid_t asid) {
  */
 
 static void pv_add(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
-  assert(mtx_owned(pv_list_lock));
+  assert(mtx_owned(&pv_list_lock));
   pv_entry_t *pv = pool_alloc(P_PV, M_ZERO);
   pv->pmap = pmap;
   pv->va = va;
@@ -152,7 +152,7 @@ static void pv_add(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
 }
 
 static pv_entry_t *pv_find(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
-  assert(mtx_owned(pv_list_lock));
+  assert(mtx_owned(&pv_list_lock));
   pv_entry_t *pv;
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     if (pv->pmap == pmap && pv->va == va)
@@ -162,7 +162,7 @@ static pv_entry_t *pv_find(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
 }
 
 static void pv_remove(pmap_t *pmap, vaddr_t va, vm_page_t *pg) {
-  assert(mtx_owned(pv_list_lock));
+  assert(mtx_owned(&pv_list_lock));
   pv_entry_t *pv = pv_find(pmap, va, pg);
   assert(pv != NULL);
   TAILQ_REMOVE(&pg->pv_list, pv, page_link);
@@ -328,7 +328,7 @@ void pmap_enter(pmap_t *pmap, vaddr_t va, vm_page_t *pg, vm_prot_t prot,
     kern_mapping ? (PTE_VALID | PTE_DIRTY | PTE_SW_FLAGS) : PTE_SW_FLAGS;
   pte_t pte = (vm_prot_map[prot] & mask) | empty_pte(pmap);
 
-  WITH_MTX_LOCK (pv_list_lock) {
+  WITH_MTX_LOCK (&pv_list_lock) {
     WITH_MTX_LOCK (&pmap->mtx) {
       pv_entry_t *pv = pv_find(pmap, va, pg);
       if (pv == NULL)
@@ -348,7 +348,7 @@ void pmap_remove(pmap_t *pmap, vaddr_t start, vaddr_t end) {
 
   klog("Remove page mapping for address range %p-%p", start, end);
 
-  WITH_MTX_LOCK (pv_list_lock) {
+  WITH_MTX_LOCK (&pv_list_lock) {
     WITH_MTX_LOCK (&pmap->mtx) {
       for (vaddr_t va = start; va < end; va += PAGESIZE) {
         paddr_t pa;
@@ -388,7 +388,7 @@ bool pmap_extract(pmap_t *pmap, vaddr_t va, paddr_t *pap) {
 }
 
 void pmap_page_remove(vm_page_t *pg) {
-  SCOPED_MTX_LOCK(pv_list_lock);
+  SCOPED_MTX_LOCK(&pv_list_lock);
   while (!TAILQ_EMPTY(&pg->pv_list)) {
     pv_entry_t *pv = TAILQ_FIRST(&pg->pv_list);
     pmap_t *pmap = pv->pmap;
@@ -411,7 +411,7 @@ void pmap_copy_page(vm_page_t *src, vm_page_t *dst) {
 }
 
 static void pmap_modify_flags(vm_page_t *pg, pte_t set, pte_t clr) {
-  SCOPED_MTX_LOCK(pv_list_lock);
+  SCOPED_MTX_LOCK(&pv_list_lock);
   pv_entry_t *pv;
   TAILQ_FOREACH (pv, &pg->pv_list, page_link) {
     pmap_t *pmap = pv->pmap;
@@ -482,7 +482,7 @@ int pmap_emulate_bits(pmap_t *pmap, vaddr_t va, vm_prot_t prot) {
   vm_page_t *pg = vm_page_find(pa);
   assert(pg != NULL);
 
-  WITH_MTX_LOCK (pv_list_lock) {
+  WITH_MTX_LOCK (&pv_list_lock) {
     /* Kernel non-pageable memory? */
     if (TAILQ_EMPTY(&pg->pv_list))
       return EINVAL;
@@ -530,7 +530,7 @@ void pmap_delete(pmap_t *pmap) {
     paddr_t pa;
     pmap_extract_nolock(pmap, pv->va, &pa);
     pg = vm_page_find(pa);
-    WITH_MTX_LOCK (pv_list_lock)
+    WITH_MTX_LOCK (&pv_list_lock)
       TAILQ_REMOVE(&pg->pv_list, pv, page_link);
     TAILQ_REMOVE(&pmap->pv_list, pv, pmap_link);
     pool_free(P_PV, pv);

--- a/sys/tests/mutex.c
+++ b/sys/tests/mutex.c
@@ -5,7 +5,7 @@
 #include <sys/thread.h>
 #include <sys/ktest.h>
 
-static mtx_t counter_mtx = MTX_INITIALIZER(0);
+static MTX_DEFINE(counter_mtx, 0);
 static volatile int32_t counter_value;
 
 /* Good test to measure context switch time. */
@@ -50,7 +50,7 @@ typedef enum rtn_state {
   ST_DONE
 } rtn_state_t;
 
-static mtx_t simple_mtx = MTX_INITIALIZER(0);
+static MTX_DEFINE(simple_mtx, 0);
 static thread_t *simple_td0;
 /* `simple_status` equals ST_UNLOCKING for a moment but we don't check
  *  it during that time (or rather a check shouldn't happen during that time) */

--- a/sys/tests/turnstile_adjust.c
+++ b/sys/tests/turnstile_adjust.c
@@ -16,7 +16,7 @@
 
 typedef TAILQ_HEAD(td_queue, thread) td_queue_t;
 
-static mtx_t ts_adj_mtx = MTX_INITIALIZER(0);
+static MTX_DEFINE(ts_adj_mtx, 0);
 static thread_t *threads[T];
 
 static void set_prio(thread_t *td, prio_t prio) {

--- a/sys/tests/turnstile_propagate_many.c
+++ b/sys/tests/turnstile_propagate_many.c
@@ -74,7 +74,7 @@ static void starter_routine(void *_arg) {
 
 static int test_turnstile_propagate_many(void) {
   for (int i = 0; i < T + 1; i++)
-    mtx[i] = MTX_INITIALIZER(0);
+    mtx_init(&mtx[i], 0);
 
   for (int i = 1; i <= T; i++) {
     char name[20];

--- a/sys/tests/turnstile_propagate_once.c
+++ b/sys/tests/turnstile_propagate_once.c
@@ -12,7 +12,7 @@
  * High priority task (td2) tries to acquire mutex and blocks, but firstly lends
  * its priority to low priority task (td0) that owns the mutex. */
 
-static mtx_t *mtx = &MTX_INITIALIZER(0);
+static MTX_DEFINE(mtx, 0);
 static thread_t *td[T];
 static volatile bool high_prio_mtx_acquired;
 static prio_t LOW, MED, HIGH;
@@ -30,7 +30,7 @@ static void low_prio_task(void *arg) {
     sched_add(td[1]);
     sched_add(td[2]);
 
-    WITH_MTX_LOCK (mtx) {
+    WITH_MTX_LOCK (&mtx) {
       /* We were the first to take the mutex. */
       assert(high_prio_mtx_acquired == 0);
       thread_yield();
@@ -61,9 +61,9 @@ static void med_prio_task(void *arg) {
 
 /* code executed by td2 */
 static void high_prio_task(void *arg) {
-  assert(mtx_owner(mtx) == td[0]);
+  assert(mtx_owner(&mtx) == td[0]);
 
-  WITH_MTX_LOCK (mtx)
+  WITH_MTX_LOCK (&mtx)
     high_prio_mtx_acquired = 1;
 }
 


### PR DESCRIPTION
This is rather cosmetic change, but required by the lock dependency validator.