### PR TITLE
signal(): restart interrupted system calls by default

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -66,6 +66,7 @@ int sigsuspend(const sigset_t *);
  */
 
 int killpg(int pgrp, int sig);
+int siginterrupt(int sig, int flag);
 
 /*
  * Mimiker specific stuff.

--- a/lib/libc/gen/siginterrupt.c
+++ b/lib/libc/gen/siginterrupt.c
@@ -1,0 +1,19 @@
+#include <signal.h>
+
+sigset_t __sigintr;
+
+int siginterrupt(int sig, int flag) {
+  int ret;
+  struct sigaction act;
+
+  if ((ret = sigaction(sig, NULL, &act)))
+    return ret;
+  if (flag) {
+    act.sa_flags &= ~SA_RESTART;
+    __sigaddset(&__sigintr, sig);
+  } else {
+    act.sa_flags |= SA_RESTART;
+    __sigdelset(&__sigintr, sig);
+  }
+  return sigaction(sig, &act, NULL);
+}

--- a/lib/libc/gen/siginterrupt.c
+++ b/lib/libc/gen/siginterrupt.c
@@ -37,20 +37,18 @@ extern sigset_t __sigintr;
  * Set signal state to prevent restart of system calls
  * after an instance of the indicated signal.
  */
-int
-siginterrupt(int sig, int flag)
-{
-	struct sigaction sa;
-	int ret;
+int siginterrupt(int sig, int flag) {
+  struct sigaction sa;
+  int ret;
 
-	if ((ret = sigaction(sig, (struct sigaction *)0, &sa)) < 0)
-		return (ret);
-	if (flag) {
-		sigaddset(&__sigintr, sig);
-		sa.sa_flags &= ~SA_RESTART;
-	} else {
-		sigdelset(&__sigintr, sig);
-		sa.sa_flags |= SA_RESTART;
-	}
-	return (sigaction(sig, &sa, (struct sigaction *)0));
+  if ((ret = sigaction(sig, (struct sigaction *)0, &sa)) < 0)
+    return (ret);
+  if (flag) {
+    sigaddset(&__sigintr, sig);
+    sa.sa_flags &= ~SA_RESTART;
+  } else {
+    sigdelset(&__sigintr, sig);
+    sa.sa_flags |= SA_RESTART;
+  }
+  return (sigaction(sig, &sa, (struct sigaction *)0));
 }

--- a/lib/libc/gen/siginterrupt.c
+++ b/lib/libc/gen/siginterrupt.c
@@ -1,19 +1,56 @@
+/*	$NetBSD: siginterrupt.c,v 1.13 2012/06/25 22:32:43 abs Exp $	*/
+
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
 #include <signal.h>
 
-sigset_t __sigintr;
+extern sigset_t __sigintr;
+/*
+ * Set signal state to prevent restart of system calls
+ * after an instance of the indicated signal.
+ */
+int
+siginterrupt(int sig, int flag)
+{
+	struct sigaction sa;
+	int ret;
 
-int siginterrupt(int sig, int flag) {
-  int ret;
-  struct sigaction act;
-
-  if ((ret = sigaction(sig, NULL, &act)))
-    return ret;
-  if (flag) {
-    act.sa_flags &= ~SA_RESTART;
-    __sigaddset(&__sigintr, sig);
-  } else {
-    act.sa_flags |= SA_RESTART;
-    __sigdelset(&__sigintr, sig);
-  }
-  return sigaction(sig, &act, NULL);
+	if ((ret = sigaction(sig, (struct sigaction *)0, &sa)) < 0)
+		return (ret);
+	if (flag) {
+		sigaddset(&__sigintr, sig);
+		sa.sa_flags &= ~SA_RESTART;
+	} else {
+		sigdelset(&__sigintr, sig);
+		sa.sa_flags |= SA_RESTART;
+	}
+	return (sigaction(sig, &sa, (struct sigaction *)0));
 }

--- a/lib/libc/sys/signal.c
+++ b/lib/libc/sys/signal.c
@@ -1,16 +1,18 @@
 #include <errno.h>
+#include <string.h>
 #include <signal.h>
 
 extern sigset_t __sigintr; /* Shared with siginterrupt() */
 
 sig_t signal(int sig, sig_t handler) {
-  sigaction_t act = {0}, oldact;
+  sigaction_t act, oldact;
 
   if (handler == SIG_ERR || sig < 1 || sig >= NSIG) {
     errno = EINVAL;
     return SIG_ERR;
   }
 
+  memset(&act, 0, sizeof(sigaction_t));
   act.sa_handler = handler;
   if (!__sigismember(&__sigintr, sig))
     act.sa_flags |= SA_RESTART;

--- a/lib/libc/sys/signal.c
+++ b/lib/libc/sys/signal.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <signal.h>
 
-extern sigset_t __sigintr; /* Shared with siginterrupt() */
+sigset_t __sigintr; /* Shared with siginterrupt() */
 
 sig_t signal(int sig, sig_t handler) {
   sigaction_t act, oldact;

--- a/lib/libc/sys/signal.c
+++ b/lib/libc/sys/signal.c
@@ -1,8 +1,10 @@
 #include <errno.h>
 #include <signal.h>
 
+extern sigset_t __sigintr; /* Shared with siginterrupt() */
+
 sig_t signal(int sig, sig_t handler) {
-  sigaction_t act, oldact;
+  sigaction_t act = {0}, oldact;
 
   if (handler == SIG_ERR || sig < 1 || sig >= NSIG) {
     errno = EINVAL;
@@ -10,6 +12,8 @@ sig_t signal(int sig, sig_t handler) {
   }
 
   act.sa_handler = handler;
+  if (!__sigismember(&__sigintr, sig))
+    act.sa_flags |= SA_RESTART;
   if (sigaction(sig, &act, &oldact) != 0)
     return SIG_ERR;
 


### PR DESCRIPTION
On Linux, FreeBSD and NetBSD (I haven't checked others) signal handlers set up using `signal()` do not interrupt system calls (i.e. make them return with `EINTR`). Instead, the system call is restarted after the signal handler runs (unless the system call has some data to return, in that case it just returns that data). The behavior can be changed using the `siginterrupt()` function.