### PR TITLE
Bump gcc version to 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get install -y --no-install-recommends \
 # socat required by launch
 COPY requirements.txt .
 RUN pip3 install setuptools wheel && pip3 install -r requirements.txt
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.4_amd64.deb && \
-    dpkg -i mipsel-mimiker-elf_1.4_amd64.deb && rm -f mipsel-mimiker-elf_1.4_amd64.deb
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_1.4_amd64.deb && \
-    dpkg -i aarch64-mimiker-elf_1.4_amd64.deb && rm -f aarch64-mimiker-elf_1.4_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.5_amd64.deb && \
+    dpkg -i mipsel-mimiker-elf_1.5_amd64.deb && rm -f mipsel-mimiker-elf_1.5_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_1.5_amd64.deb && \
+    dpkg -i aarch64-mimiker-elf_1.5_amd64.deb && rm -f aarch64-mimiker-elf_1.5_amd64.deb
 RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_4.2.1+mimiker1_amd64.deb && \
     dpkg -i qemu-mimiker_4.2.1+mimiker1_amd64.deb && rm -f qemu-mimiker_4.2.1+mimiker1_amd64.deb

--- a/toolchain/gnu/config.mk
+++ b/toolchain/gnu/config.mk
@@ -1,14 +1,14 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab list:
 
-VERSION = 1.4
+VERSION = 1.5
 
 ISL = isl-0.18
 MPFR = mpfr-4.0.2
 GMP = gmp-6.1.2
 MPC = mpc-1.1.0
 CLOOG = cloog-0.18.4
-BINUTILS = binutils-2.32
-GCC = gcc-9.2.0
+BINUTILS = binutils-2.35
+GCC = gcc-11-20210314
 GDB = gdb-10.1
 
 ISL-URL = "http://isl.gforge.inria.fr/$(ISL).tar.xz"
@@ -17,7 +17,7 @@ GMP-URL = "https://gmplib.org/download/gmp/$(GMP).tar.xz"
 MPC-URL = "https://ftp.gnu.org/gnu/mpc/$(MPC).tar.gz"
 CLOOG-URL = "http://www.bastoul.net/cloog/pages/download/$(CLOOG).tar.gz"
 BINUTILS-URL = "https://ftp.gnu.org/gnu/binutils/$(BINUTILS).tar.xz"
-GCC-URL = "https://ftp.gnu.org/gnu/gcc/$(GCC)/$(GCC).tar.xz"
+GCC-URL = "ftp://ftp.fu-berlin.de/unix/languages/gcc/snapshots/11-20210314/$(GCC).tar.xz"
 GDB-URL = "https://ftp.gnu.org/gnu/gdb/$(GDB).tar.xz"
 
 TARGETS = mipsel aarch64

--- a/toolchain/gnu/config.mk
+++ b/toolchain/gnu/config.mk
@@ -17,6 +17,8 @@ GMP-URL = "https://gmplib.org/download/gmp/$(GMP).tar.xz"
 MPC-URL = "https://ftp.gnu.org/gnu/mpc/$(MPC).tar.gz"
 CLOOG-URL = "http://www.bastoul.net/cloog/pages/download/$(CLOOG).tar.gz"
 BINUTILS-URL = "https://ftp.gnu.org/gnu/binutils/$(BINUTILS).tar.xz"
+#TODO: revert to the old URL when GCC 11 is officially released
+#GCC-URL = "https://ftp.gnu.org/gnu/gcc/$(GCC)/$(GCC).tar.xz"
 GCC-URL = "ftp://ftp.fu-berlin.de/unix/languages/gcc/snapshots/11-20210314/$(GCC).tar.xz"
 GDB-URL = "https://ftp.gnu.org/gnu/gdb/$(GDB).tar.xz"
 


### PR DESCRIPTION
Debian packages are ready to use in my home directory on the server (`/home/jurb/`).

#999 is required to compile Mimiker under the new GCC version.