### PR TITLE
Introduce uio_peek() and uio_advance()

### DIFF
--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -54,6 +54,8 @@ typedef struct uio {
   UIO_VECTOR(op, vm_map_user(), iov, iovcnt, len)
 
 int uiomove(void *buf, size_t n, uio_t *uio);
+int uio_peek(void *buf, size_t n, uio_t *uio);
+void uio_advance(uio_t *uio, size_t n);
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio);
 int iovec_length(const iovec_t *iov, int iovcnt, size_t *lengthp);
 

--- a/sys/kern/pty.c
+++ b/sys/kern/pty.c
@@ -104,13 +104,11 @@ static int pty_write(file_t *f, uio_t *uio) {
   SCOPED_MTX_LOCK(&tty->t_lock);
 
   while (uio->uio_resid > 0) {
-    if ((error = uiomove(&c, 1, uio)))
+    if ((error = uio_peek(&c, 1, uio)))
       break;
-    if ((error = pty_putc_sleep(tty, pty, c))) {
-      /* Undo the last uiomove(). */
-      uio->uio_resid++;
+    if ((error = pty_putc_sleep(tty, pty, c)))
       break;
-    }
+    uio_advance(uio, 1);
   }
 
   /* Don't report errors on partial writes. */

--- a/sys/kern/uio.c
+++ b/sys/kern/uio.c
@@ -6,8 +6,8 @@
 #include <sys/errno.h>
 
 typedef enum {
-  UIOMOVE_NO_IO = 0x1,          /* Don't actually transfer any data */
-  UIOMOVE_NO_MODIFY = 0x2,      /* Don't modify uio structure */
+  UIOMOVE_NO_IO = 0x1,     /* Don't actually transfer any data */
+  UIOMOVE_NO_MODIFY = 0x2, /* Don't modify uio structure */
 } uiomove_flags_t;
 
 static int copyin_vmspace(vm_map_t *vm, const void *restrict udaddr,
@@ -56,7 +56,8 @@ static int _uiomove(void *buf, size_t n, uio_t *uio, uiomove_flags_t flags) {
     size_t cnt = iov->iov_len - iov_off;
 
     if (cnt == 0) {
-      /* If no data left to move in this vector, proceed to the next io vector. */
+      /* If no data left to move in this vector, proceed to the next io vector.
+       */
       assert(iov_idx < uio->uio_iovcnt);
       iov_idx++;
       iov_off = 0;

--- a/sys/kern/uio.c
+++ b/sys/kern/uio.c
@@ -5,6 +5,11 @@
 #include <sys/malloc.h>
 #include <sys/errno.h>
 
+typedef enum {
+  UIOMOVE_NO_IO = 0x1,          /* Don't actually transfer any data */
+  UIOMOVE_NO_MODIFY = 0x2,      /* Don't modify uio structure */
+} uiomove_flags_t;
+
 static int copyin_vmspace(vm_map_t *vm, const void *restrict udaddr,
                           void *restrict kaddr, size_t len) {
   if (vm == vm_map_kernel()) {
@@ -33,52 +38,78 @@ static int copyout_vmspace(vm_map_t *vm, const void *restrict kaddr,
 
 /* Heavily inspired by NetBSD's uiomove */
 /* This function modifies uio to reflect on the progress. */
-int uiomove(void *buf, size_t n, uio_t *uio) {
+static int _uiomove(void *buf, size_t n, uio_t *uio, uiomove_flags_t flags) {
   /* Calling uiomove from critical section (no interrupts or no preemption)
    * is not allowed since it may be copying from pageable memory. */
   assert(!intr_disabled() && !preempt_disabled());
 
   char *cbuf = buf;
   int error = 0;
+  size_t done = 0;
+  size_t iov_off = 0;
+  int iov_idx = 0;
 
   assert(uio->uio_op == UIO_READ || uio->uio_op == UIO_WRITE);
 
-  while (n > 0 && uio->uio_resid > 0) {
-    /* Take the first io vector */
-    iovec_t *iov = uio->uio_iov;
-    size_t cnt = iov->iov_len;
+  while (n > 0 && done < uio->uio_resid) {
+    iovec_t *iov = &uio->uio_iov[iov_idx];
+    size_t cnt = iov->iov_len - iov_off;
 
     if (cnt == 0) {
-      /* If no data left to move in this vector, proceed to the next io vector,
-         or finish moving data if this was the last vector. */
-      if (uio->uio_iovcnt == 0)
-        break;
-      uio->uio_iov++;
-      uio->uio_iovcnt--;
+      /* If no data left to move in this vector, proceed to the next io vector. */
+      assert(iov_idx < uio->uio_iovcnt);
+      iov_idx++;
+      iov_off = 0;
       continue;
     }
     if (cnt > n)
       cnt = n;
-    /* Perform copyout/copyin. */
-    if (uio->uio_op == UIO_READ)
-      error = copyout_vmspace(uio->uio_vmspace, cbuf, iov->iov_base, cnt);
-    else
-      error = copyin_vmspace(uio->uio_vmspace, iov->iov_base, cbuf, cnt);
-    /* Exit immediately if there was a problem with moving data */
-    if (error)
-      break;
 
-    /* Store progress on current io vector */
-    iov->iov_base = (char *)iov->iov_base + cnt;
-    iov->iov_len -= cnt;
-    uio->uio_resid -= cnt;
-    uio->uio_offset += cnt;
-    cbuf += cnt;
+    if (!(flags & UIOMOVE_NO_IO)) {
+      /* Perform copyout/copyin. */
+      if (uio->uio_op == UIO_READ)
+        error = copyout_vmspace(uio->uio_vmspace, cbuf, iov->iov_base, cnt);
+      else
+        error = copyin_vmspace(uio->uio_vmspace, iov->iov_base, cbuf, cnt);
+      /* Exit immediately if there was a problem with moving data */
+      if (error)
+        break;
+
+      cbuf += cnt;
+    }
+
+    iov_off += cnt;
+    done += cnt;
     n -= cnt;
+  }
+
+  if (!(flags & UIOMOVE_NO_MODIFY)) {
+    uio->uio_resid -= done;
+    uio->uio_offset += done;
+    uio->uio_iov += iov_idx;
+    uio->uio_iovcnt -= iov_idx;
+    if (uio->uio_iovcnt > 0) {
+      uio->uio_iov->iov_base += iov_off;
+      uio->uio_iov->iov_len -= iov_off;
+    }
   }
 
   /* Invert error sign, because copy routines use negative error codes */
   return error;
+}
+
+int uiomove(void *buf, size_t n, uio_t *uio) {
+  return _uiomove(buf, n, uio, 0);
+}
+
+int uio_peek(void *buf, size_t n, uio_t *uio) {
+  if (uio->uio_op != UIO_WRITE)
+    return EINVAL;
+  return _uiomove(buf, n, uio, UIOMOVE_NO_MODIFY);
+}
+
+void uio_advance(uio_t *uio, size_t n) {
+  _uiomove(NULL, n, uio, UIOMOVE_NO_IO);
 }
 
 int uiomove_frombuf(void *buf, size_t buflen, struct uio *uio) {


### PR DESCRIPTION
This PR attempts to solve the same issue that #998 attempts to solve, but in a different way.
The issue is that we might read some data from an `uio` in order to do some processing on it, and then find out that we can't actually do the processing, so we need to return an error and make it appear as though no data was transferred from the `uio`.
With `uio_peek()`, we can read data without modifying the `uio` structure, so if we encounter an error later, we can just return the error without having to do anything. If we don't encounter an error, we need to "commit" the read we did earlier using `uio_advance()`.