### PR TITLE
vm_boot_alloc(): don't let vm_kernel_end go past _kasan_sanitized_end

### DIFF
--- a/include/sys/kasan.h
+++ b/include/sys/kasan.h
@@ -5,6 +5,8 @@
 
 #include <sys/types.h>
 
+/* This variable marks the top end of the virtual address range
+ * for which shadow memory has been allocated. */
 extern vaddr_t _kasan_sanitized_end;
 
 /* The following codes are part of internal compiler interface:

--- a/include/sys/kasan.h
+++ b/include/sys/kasan.h
@@ -5,6 +5,8 @@
 
 #include <sys/types.h>
 
+extern vaddr_t _kasan_sanitized_end;
+
 /* The following codes are part of internal compiler interface:
  * https://github.com/gcc-mirror/gcc/blob/master/libsanitizer/asan/asan_internal.h
  */

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -6,6 +6,7 @@
 #include <sys/mutex.h>
 #include <sys/pmap.h>
 #include <sys/vm_physmem.h>
+#include <sys/kasan.h>
 
 #define FREELIST(page) (&freelist[log2((page)->size)])
 #define PAGECOUNT(page) (pagecount[log2((page)->size)])
@@ -59,6 +60,9 @@ static void *vm_boot_alloc(size_t n) {
 
   void *begin = align((void *)vm_kernel_end, sizeof(long));
   void *end = align(begin + n, PAGESIZE);
+#if KASAN
+  assert((vaddr_t)end <= _kasan_sanitized_end);
+#endif
 
   vm_physseg_t *seg = TAILQ_FIRST(&seglist);
 

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -61,6 +61,10 @@ static void *vm_boot_alloc(size_t n) {
   void *begin = align((void *)vm_kernel_end, sizeof(long));
   void *end = align(begin + n, PAGESIZE);
 #if KASAN
+  /* We're not ready to call kasan_grow() yet, so this function could
+   * potentially make vm_kernel_end go past _kernel_sanitized_end, which could
+   * lead to KASAN referencing unmapped addresses in the shadow map, causing
+   * a panic. Make sure that doesn't happen. */
   assert((vaddr_t)end <= _kasan_sanitized_end);
 #endif
 

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -64,7 +64,9 @@ static void *vm_boot_alloc(size_t n) {
   /* We're not ready to call kasan_grow() yet, so this function could
    * potentially make vm_kernel_end go past _kernel_sanitized_end, which could
    * lead to KASAN referencing unmapped addresses in the shadow map, causing
-   * a panic. Make sure that doesn't happen. */
+   * a panic. Make sure that doesn't happen.
+   * If this assertion fails, more shadow memory must be allocated when
+   * initializing KASAN.*/
   assert((vaddr_t)end <= _kasan_sanitized_end);
 #endif
 

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -5,6 +5,7 @@
 #include <mips/tlb.h>
 #include <sys/mimiker.h>
 #include <sys/vm.h>
+#include <sys/kasan.h>
 #include <mips/kasan.h>
 
 /* Last address in kseg0 used by kernel for boot allocation. */
@@ -13,7 +14,6 @@ __boot_data void *_bootmem_end;
 extern pde_t *_kernel_pmap_pde;
 /* The boot stack is used before we switch out to thread0. */
 static alignas(PAGESIZE) uint8_t _boot_stack[PAGESIZE];
-extern size_t _kasan_sanitized_end;
 
 /* Allocates pages in kseg0. The argument will be aligned to PAGESIZE. */
 static __boot_text void *bootmem_alloc(size_t bytes) {


### PR DESCRIPTION
If we're not going to expand the shadow map in `vm_boot_alloc()`, at least let's add a check to prevent nasty bugs in the future.