### PR TITLE
ksh/history.c: silence warning during compilation with -O2

### DIFF
--- a/bin/ksh/Makefile
+++ b/bin/ksh/Makefile
@@ -26,4 +26,6 @@ emacs.out: emacs.c
 	./emacs-gen.sh $(CURDIR)/emacs.c > emacs.out.tmp \
 	    && mv emacs.out.tmp emacs.out
 
+history.CFLAGS += -Wno-stringop-overflow
+
 include $(TOPDIR)/build/build.prog.mk


### PR DESCRIPTION
```
/mimiker/bin/ksh/history.c: In function 'hist_execute':
/mimiker/bin/ksh/history.c:317:31: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  317 |                         q[-1] = '\n';
      |                         ~~~~~~^~~~~~
/mimiker/bin/ksh/history.c:303:26: note: destination object of size [0, 9223372036854775807] allocated by 'strchr'
  303 |                 if ((q = strchr(p, '\n'))) {
      |                          ^~~~~~~~~~~~~~~
```