### PR TITLE
[PoC] AArch64: use dtb instead of atags

### DIFF
--- a/include/aarch64/vm_param.h
+++ b/include/aarch64/vm_param.h
@@ -18,4 +18,18 @@
 #define KSTACK_PAGES 2
 #define KSTACK_SIZE (KSTACK_PAGES * PAGESIZE)
 
+/* XXX Raspberry PI 3 specific! */
+#define DMAP_SIZE 0x3c000000
+#define DMAP_BASE 0xffffff8000000000 /* last 512GB */
+
+#define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
+
+#define DMAP_L3_ENTRIES max(1, DMAP_SIZE / PAGESIZE)
+#define DMAP_L2_ENTRIES max(1, DMAP_L3_ENTRIES / PT_ENTRIES)
+#define DMAP_L1_ENTRIES max(1, DMAP_L2_ENTRIES / PT_ENTRIES)
+
+#define DMAP_L1_SIZE roundup(DMAP_L1_ENTRIES * sizeof(pde_t), PAGESIZE)
+#define DMAP_L2_SIZE roundup(DMAP_L2_ENTRIES * sizeof(pde_t), PAGESIZE)
+#define DMAP_L3_SIZE roundup(DMAP_L3_ENTRIES * sizeof(pte_t), PAGESIZE)
+
 #endif /* !_AARCH64_VM_PARAM_H_ */

--- a/launch
+++ b/launch
@@ -99,6 +99,7 @@ CONFIG = {
                 'options': [
                     '-machine', 'raspi3',
                     '-smp', '4',
+                    '-dtb', 'sys/aarch64/rpi3.dtb',
                     '-cpu', 'cortex-a53'],
                 'network_options': [],
                 'uarts': [

--- a/sys/aarch64/Makefile
+++ b/sys/aarch64/Makefile
@@ -21,10 +21,12 @@ SOURCES = boot.c \
 	  tlb.c \
 	  trap.c
 
+BUILD-FILES += $(BOARD).dtb
+
 CFLAGS.boot.c = -mcmodel=large
 CFLAGS.rpi3.c = -mcmodel=large
 
-CLEAN-FILES += assym.h
+CLEAN-FILES += assym.h $(BOARD).dtb
 
 CPPFLAGS += -D_MACHDEP
 

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -37,7 +37,6 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 #define PA_MASK 0xfffffffff000
 #define ADDR_MASK 0x8ffffffff000
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */
-#define PHYS_TO_DMAP(x) ((intptr_t)(x) + DMAP_BASE)
 
 /*
  * This table describes which access bits need to be set in page table entry

--- a/sys/aarch64/rpi3.dts
+++ b/sys/aarch64/rpi3.dts
@@ -1,0 +1,16 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+
+	memory@0 {
+		reg = <0x00 0x3c000000>;
+		device_type = "memory";
+	};
+
+	soc {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+	};
+};

--- a/sys/aarch64/start.S
+++ b/sys/aarch64/start.S
@@ -28,6 +28,8 @@ _ENTRY(_start)
         CMP     x3, #0
         BNE     .
 
+        /* Save pointer to dtb. */
+        mov     x19, x0
         /* Setup initial stack. */
         ADR     x3, __boot_stack_end
         MOV     sp, x3
@@ -42,6 +44,8 @@ _ENTRY(_start)
          * functions from libkern.
          */
         mov     sp, x0
+        /* Restore dtb pointer. */
+        mov     x0, x19
 
         BL      board_stack
         MOV     sp, x0


### PR DESCRIPTION
Use dtb instead of atags for AArch64 bootstrap.