### PR TITLE
Clean vm_object interface

### DIFF
--- a/include/sys/vm.h
+++ b/include/sys/vm.h
@@ -55,11 +55,9 @@ typedef uintptr_t vm_offset_t;
 
 struct vm_page {
   union {
-    TAILQ_ENTRY(vm_page) freeq; /* (P) list of free pages for buddy system */
-    TAILQ_ENTRY(vm_page) pageq; /* used to group allocated pages */
-    struct {
-      TAILQ_ENTRY(vm_page) list;
-    } obj;        /* (O) list of pages in vm_object */
+    TAILQ_ENTRY(vm_page) freeq;    /* (P) list of free pages for buddy system */
+    TAILQ_ENTRY(vm_page) pageq;    /* used to group allocated pages */
+    TAILQ_ENTRY(vm_page) objpages; /* (O) list of pages in vm_object */
     slab_t *slab; /* active when page is used by pool allocator */
   };
   TAILQ_HEAD(, pv_entry) pv_list; /* (@) where this page is mapped? */

--- a/include/sys/vm_object.h
+++ b/include/sys/vm_object.h
@@ -22,7 +22,8 @@ typedef struct vm_object {
 } vm_object_t;
 
 vm_object_t *vm_object_alloc(vm_pgr_type_t type);
-void vm_object_free(vm_object_t *obj);
+void vm_object_hold(vm_object_t *obj);
+void vm_object_drop(vm_object_t *obj);
 void vm_object_add_page(vm_object_t *obj, vm_offset_t off, vm_page_t *pg);
 void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len);
 vm_page_t *vm_object_find_page(vm_object_t *obj, vm_offset_t off);

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -129,7 +129,7 @@ vm_segment_t *vm_segment_alloc(vm_object_t *obj, vaddr_t start, vaddr_t end,
 static void vm_segment_free(vm_segment_t *seg) {
   /* we assume no other segment points to this object */
   if (seg->object)
-    vm_object_free(seg->object);
+    vm_object_drop(seg->object);
   pool_free(P_VMSEG, seg);
 }
 
@@ -373,7 +373,7 @@ vm_map_t *vm_map_clone(vm_map_t *map) {
       vm_segment_t *seg;
 
       if (it->flags & VM_SEG_SHARED) {
-        refcnt_acquire(&it->object->ref_counter);
+        vm_object_hold(it->object);
         obj = it->object;
       } else {
         /* vm_object_clone will clone the data from the vm_object_t

--- a/sys/kern/vm_object.c
+++ b/sys/kern/vm_object.c
@@ -81,19 +81,17 @@ void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len) {
 }
 
 #define vm_object_remove_all_pages(obj)                                        \
-  vm_object_remove_pages_nolock((obj), 0, (size_t)(-PAGESIZE))
+  vm_object_remove_pages((obj), 0, (size_t)(-PAGESIZE))
 
 void vm_object_hold(vm_object_t *obj) {
   refcnt_acquire(&obj->ref_counter);
 }
 
 void vm_object_drop(vm_object_t *obj) {
-  WITH_MTX_LOCK (&obj->mtx) {
-    if (!refcnt_release(&obj->ref_counter))
-      return;
+  if (!refcnt_release(&obj->ref_counter))
+    return;
 
-    vm_object_remove_all_pages(obj);
-  }
+  vm_object_remove_all_pages(obj);
   pool_free(P_VMOBJ, obj);
 }
 


### PR DESCRIPTION
* Added `vm_object_hold` function to hide reference counter and renamed `vm_object_free` to `..._drop`.
* Renamed (and removed anonymous struct) entry on `vm_object`'s page list in `vm_page`.