### PR TITLE
build: fix KASAN build

### DIFF
--- a/sys/kern/Makefile
+++ b/sys/kern/Makefile
@@ -32,6 +32,8 @@ SOURCES = \
 	initrd.c \
 	interrupt.c \
 	isa.c \
+	kasan.c \
+	kasan_quar.c \
 	kenv.c \
 	klog.c \
 	kmem.c \
@@ -79,14 +81,8 @@ SOURCES = \
 	vm_physmem.c \
 	vmem.c
 
-ifeq ($(KASAN), 1)
-SOURCES += kasan.c kasan_quar.c
 # KASAN's run-time library mustn't be sanitized!
 kasan.o : CFLAGS_KASAN =
-else
-# Clean dependencies without having to pass `KASAN=1` to `make clean`.
-CLEAN-FILES += .kasan.D .kasan_quar.D
-endif
 
 FORMAT-EXCLUDE = sysent.h
 

--- a/sys/kern/kasan.c
+++ b/sys/kern/kasan.c
@@ -1,3 +1,9 @@
+/* build system hack */
+#ifdef KASAN
+#undef KASAN
+#endif /* KASAN */
+#define KASAN 1
+
 #include <sys/vm.h>
 #include <sys/pmap.h>
 #include <sys/param.h>

--- a/sys/kern/kasan_quar.c
+++ b/sys/kern/kasan_quar.c
@@ -1,3 +1,9 @@
+/* build system hack */
+#ifdef KASAN
+#undef KASAN
+#endif /* KASAN */
+#define KASAN 1
+
 #include <sys/klog.h>
 #include <sys/kasan.h>
 


### PR DESCRIPTION
Fix #1070 

`sys/kern/Makefile` do operations on `KASAN` variable before it is defined. As a result following ifeq is always false:

```make
ifeq ($(KASAN), 1)
SOURCES += kasan.c kasan_quar.c
# KASAN's run-time library mustn't be sanitized!
kasan.o : CFLAGS_KASAN =
else
# Clean dependencies without having to pass `KASAN=1` to `make clean`.
CLEAN-FILES += .kasan.D .kasan_quar.D
endif
```

The only solution for make `KASAN` build is passing KASAN=1 directly from cmdline.
We can avoid that by removing ifeq from Makefile and compiling kasan*.c always.

To do that we need to modify these .c files because they require to have
`KASAN=1`.

It's not the best solution but works with minimal effort.