### PR TITLE
Run mimiker without the debug option.

### DIFF
--- a/launch
+++ b/launch
@@ -74,7 +74,7 @@ CONFIG = {
             '-rtc', 'clock=vm',
             '-kernel', '{kernel}',
             '-initrd', '{initrd}',
-            '-S', '-gdb', 'tcp:127.0.0.1:{gdbport},server,wait',
+            '-gdb', 'tcp:127.0.0.1:{gdbport},server,wait',
             '-serial', 'none'],
         'board': {
             'malta': {


### PR DESCRIPTION
'-S' option shouldn't be supplied regardless of the command line options as is done now in `qemu: { options: {...`. Instead, it should only be included if the debug option ('-d') is supplied (as is done in `if getvar('config.debug'): self.options += ['-S']`. For now, '-S' is always present and thus `launch` doesn't work without '-d' (because the gdb window doesn't appear).