### PR TITLE
Remove MD bus definitions.

### DIFF
--- a/include/aarch64/bus_defs.h
+++ b/include/aarch64/bus_defs.h
@@ -1,1 +1,0 @@
-#include <sys/common_bus_defs.h>

--- a/include/mips/bus_defs.h
+++ b/include/mips/bus_defs.h
@@ -1,1 +1,0 @@
-#include <sys/common_bus_defs.h>

--- a/include/sys/bus.h
+++ b/include/sys/bus.h
@@ -1,7 +1,7 @@
 #ifndef _SYS_BUS_H_
 #define _SYS_BUS_H_
 
-#include <machine/bus_defs.h>
+#include <sys/bus_defs.h>
 #include <sys/device.h>
 #include <sys/interrupt.h>
 

--- a/include/sys/bus_defs.h
+++ b/include/sys/bus_defs.h
@@ -1,5 +1,5 @@
-#ifndef _SYS_COMMON_BUS_DEFS_H_
-#define _SYS_COMMON_BUS_DEFS_H_
+#ifndef _SYS_BUS_DEFS_H_
+#define _SYS_BUS_DEFS_H_
 
 #include <sys/types.h>
 
@@ -13,4 +13,4 @@ typedef uintptr_t bus_size_t;
 typedef bus_space_t *bus_space_tag_t;
 typedef bus_addr_t bus_space_handle_t;
 
-#endif
+#endif /* !_SYS_BUS_DEFS_H_ */

--- a/include/sys/rman.h
+++ b/include/sys/rman.h
@@ -4,7 +4,7 @@
 #include <sys/cdefs.h>
 #include <sys/mutex.h>
 #include <sys/queue.h>
-#include <machine/bus_defs.h>
+#include <sys/bus_defs.h>
 
 #define RMAN_ADDR_MAX UINTPTR_MAX
 #define RMAN_SIZE_MAX UINTPTR_MAX

--- a/launch
+++ b/launch
@@ -74,7 +74,7 @@ CONFIG = {
             '-rtc', 'clock=vm',
             '-kernel', '{kernel}',
             '-initrd', '{initrd}',
-            '-gdb', 'tcp:127.0.0.1:{gdbport},server,wait',
+            '-S', '-gdb', 'tcp:127.0.0.1:{gdbport},server,wait',
             '-serial', 'none'],
         'board': {
             'malta': {

--- a/launch
+++ b/launch
@@ -74,7 +74,7 @@ CONFIG = {
             '-rtc', 'clock=vm',
             '-kernel', '{kernel}',
             '-initrd', '{initrd}',
-            '-S', '-gdb', 'tcp:127.0.0.1:{gdbport},server,wait',
+            '-gdb', 'tcp:127.0.0.1:{gdbport},server,wait',
             '-serial', 'none'],
         'board': {
             'malta': {


### PR DESCRIPTION
`include/$(ARCH)/bus_defs.h` only includes `include/sys/common_bus_defs.h` regardless of the value of `$(ARCH)`, therefore I've deleted these files and rename `include/sys/common_bus_defs.h` to `include/sys/bus_defs.h`. This solution is less ambiguous.