### PR TITLE
MInor fixes and maintenance around VM.

### DIFF
--- a/include/sys/vm.h
+++ b/include/sys/vm.h
@@ -26,7 +26,7 @@ typedef enum {
   VM_PROT_NONE = 0,
   VM_PROT_READ = 1,  /* can read page */
   VM_PROT_WRITE = 2, /* can write page */
-  VM_PROT_EXEC = 4   /* can execute page */
+  VM_PROT_EXEC = 4,  /* can execute page */
 } vm_prot_t;
 
 #define VM_PROT_MASK (VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC)

--- a/include/sys/vm_map.h
+++ b/include/sys/vm_map.h
@@ -1,10 +1,8 @@
 #ifndef _SYS_VM_MAP_H_
 #define _SYS_VM_MAP_H_
 
-#include <sys/queue.h>
-#include <sys/pmap.h>
 #include <sys/vm.h>
-#include <sys/mutex.h>
+#include <sys/thread.h>
 
 typedef struct vm_map vm_map_t;
 typedef struct vm_segment vm_segment_t;
@@ -43,7 +41,6 @@ void vm_map_delete(vm_map_t *vm_map);
 
 vm_segment_t *vm_segment_alloc(vm_object_t *obj, vaddr_t start, vaddr_t end,
                                vm_prot_t prot, vm_seg_flags_t flags);
-void vm_segment_destroy(vm_map_t *map, vm_segment_t *seg);
 void vm_segment_destroy_range(vm_map_t *map, vm_segment_t *seg, vaddr_t start,
                               vaddr_t end);
 
@@ -51,7 +48,7 @@ vm_segment_t *vm_map_find_segment(vm_map_t *vm_map, vaddr_t vaddr);
 
 void vm_map_protect(vm_map_t *map, vaddr_t start, vaddr_t end, vm_prot_t prot);
 
-/*! \brief Insert given \a segment into the \a map. */
+/*! \brief Inserts given \a segment into the \a map. */
 int vm_map_insert(vm_map_t *map, vm_segment_t *segment, vm_flags_t flags);
 
 /*! \brief Can address \a addr be mapped by this \a map? */
@@ -75,7 +72,7 @@ vaddr_t vm_segment_end(vm_segment_t *seg);
  */
 int vm_map_findspace(vm_map_t *map, vaddr_t /*inout*/ *start_p, size_t length);
 
-/*! \brief Allocates segment and associate anonymous memory object with it. */
+/*! \brief Allocates segment and associates anonymous memory object with it. */
 int vm_map_alloc_segment(vm_map_t *map, vaddr_t addr, size_t length,
                          vm_prot_t prot, vm_flags_t flags,
                          vm_segment_t **seg_p);

--- a/include/sys/vm_object.h
+++ b/include/sys/vm_object.h
@@ -18,7 +18,7 @@ typedef struct vm_object {
   vm_pagelist_t list;   /* (@) List of pages */
   size_t npages;        /* (@) Number of pages */
   vm_pager_t *pager;    /* Pager type and page fault function for object */
-  refcnt_t ref_counter; /* (a) How many objects refer to this object? */
+  refcnt_t ref_counter; /* (a) How many segments refer to this object? */
 } vm_object_t;
 
 vm_object_t *vm_object_alloc(vm_pgr_type_t type);
@@ -27,6 +27,6 @@ void vm_object_add_page(vm_object_t *obj, vm_offset_t off, vm_page_t *pg);
 void vm_object_remove_pages(vm_object_t *obj, vm_offset_t off, size_t len);
 vm_page_t *vm_object_find_page(vm_object_t *obj, vm_offset_t off);
 vm_object_t *vm_object_clone(vm_object_t *obj);
-void vm_map_object_dump(vm_object_t *obj);
+void vm_object_dump(vm_object_t *obj);
 
 #endif /* !_SYS_VM_OBJECT_H_ */

--- a/include/sys/vm_pager.h
+++ b/include/sys/vm_pager.h
@@ -3,12 +3,9 @@
 
 #include <sys/vm.h>
 
-typedef enum {
-  VM_DUMMY,
-  VM_ANONYMOUS,
-} vm_pgr_type_t;
+typedef enum { VM_PGR_DUMMY, VM_PGR_ANONYMOUS, VM_PGR_COUNT } vm_pgr_type_t;
 
-typedef vm_page_t *vm_pgr_fault_t(vm_object_t *obj, off_t offset);
+typedef vm_page_t *vm_pgr_fault_t(vm_object_t *obj, vm_offset_t offset);
 
 typedef struct vm_pager {
   vm_pgr_type_t pgr_type;

--- a/sys/kern/exec.c
+++ b/sys/kern/exec.c
@@ -281,7 +281,7 @@ static void enter_new_vmspace(proc_t *p, exec_vmspace_t *saved,
    */
   *stack_top_p = USER_STACK_TOP;
 
-  vm_object_t *stack_obj = vm_object_alloc(VM_ANONYMOUS);
+  vm_object_t *stack_obj = vm_object_alloc(VM_PGR_ANONYMOUS);
   /* FTTB stack has to be executable since kernel copies sigcode onto stack
    * when context is set to signal handler code. This code is run when user
    * returns from signal handler. */

--- a/sys/kern/exec_elf.c
+++ b/sys/kern/exec_elf.c
@@ -104,7 +104,7 @@ static int load_elf_segment(proc_t *p, vnode_t *vn, Elf_Phdr *ph) {
   vaddr_t end = roundup(ph->p_vaddr + ph->p_memsz, PAGESIZE);
 
   /* Temporarily permissive protection. */
-  vm_object_t *obj = vm_object_alloc(VM_ANONYMOUS);
+  vm_object_t *obj = vm_object_alloc(VM_PGR_ANONYMOUS);
   vm_segment_t *seg = vm_segment_alloc(
     obj, start, end, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXEC,
     VM_SEG_PRIVATE);

--- a/sys/kern/sbrk.c
+++ b/sys/kern/sbrk.c
@@ -21,7 +21,7 @@ void sbrk_attach(proc_t *p) {
 
   /* Initially allocate one page for brk segment. */
   vaddr_t addr = SBRK_START;
-  vm_object_t *obj = vm_object_alloc(VM_ANONYMOUS);
+  vm_object_t *obj = vm_object_alloc(VM_PGR_ANONYMOUS);
   vm_segment_t *seg = vm_segment_alloc(
     obj, addr, addr + PAGESIZE, VM_PROT_READ | VM_PROT_WRITE, VM_SEG_PRIVATE);
   if (vm_map_insert(map, seg, VM_FIXED))

--- a/sys/kern/vm_pager.c
+++ b/sys/kern/vm_pager.c
@@ -18,7 +18,14 @@ static vm_page_t *anon_pager_fault(vm_object_t *obj, vm_offset_t offset) {
 }
 
 vm_pager_t pagers[] = {
-  [VM_PGR_DUMMY] = {.pgr_type = VM_PGR_DUMMY, .pgr_fault = dummy_pager_fault},
-  [VM_PGR_ANONYMOUS] = {.pgr_type = VM_PGR_ANONYMOUS,
-                        .pgr_fault = anon_pager_fault},
+  [VM_PGR_DUMMY] =
+    {
+      .pgr_type = VM_PGR_DUMMY,
+      .pgr_fault = dummy_pager_fault,
+    },
+  [VM_PGR_ANONYMOUS] =
+    {
+      .pgr_type = VM_PGR_ANONYMOUS,
+      .pgr_fault = anon_pager_fault,
+    },
 };

--- a/sys/kern/vm_pager.c
+++ b/sys/kern/vm_pager.c
@@ -4,11 +4,11 @@
 #include <sys/vm_pager.h>
 #include <sys/vm_physmem.h>
 
-static vm_page_t *dummy_pager_fault(vm_object_t *obj, off_t offset) {
+static vm_page_t *dummy_pager_fault(vm_object_t *obj, vm_offset_t offset) {
   return NULL;
 }
 
-static vm_page_t *anon_pager_fault(vm_object_t *obj, off_t offset) {
+static vm_page_t *anon_pager_fault(vm_object_t *obj, vm_offset_t offset) {
   assert(obj != NULL);
 
   vm_page_t *new_pg = vm_page_alloc(1);
@@ -18,6 +18,7 @@ static vm_page_t *anon_pager_fault(vm_object_t *obj, off_t offset) {
 }
 
 vm_pager_t pagers[] = {
-  [VM_DUMMY] = {.pgr_fault = dummy_pager_fault},
-  [VM_ANONYMOUS] = {.pgr_fault = anon_pager_fault},
+  [VM_PGR_DUMMY] = {.pgr_type = VM_PGR_DUMMY, .pgr_fault = dummy_pager_fault},
+  [VM_PGR_ANONYMOUS] = {.pgr_type = VM_PGR_ANONYMOUS,
+                        .pgr_fault = anon_pager_fault},
 };

--- a/sys/tests/vm_map.c
+++ b/sys/tests/vm_map.c
@@ -41,7 +41,7 @@ static int paging_on_demand_and_memory_protection_demo(void) {
 
   /* preceding redzone segment */
   {
-    vm_object_t *obj = vm_object_alloc(VM_DUMMY);
+    vm_object_t *obj = vm_object_alloc(VM_PGR_DUMMY);
     vm_segment_t *seg =
       vm_segment_alloc(obj, pre_start, start, VM_PROT_NONE, VM_SEG_PRIVATE);
     n = vm_map_insert(umap, seg, VM_FIXED);
@@ -50,7 +50,7 @@ static int paging_on_demand_and_memory_protection_demo(void) {
 
   /* data segment */
   {
-    vm_object_t *obj = vm_object_alloc(VM_ANONYMOUS);
+    vm_object_t *obj = vm_object_alloc(VM_PGR_ANONYMOUS);
     vm_segment_t *seg = vm_segment_alloc(
       obj, start, end, VM_PROT_READ | VM_PROT_WRITE, VM_SEG_PRIVATE);
     n = vm_map_insert(umap, seg, VM_FIXED);
@@ -59,7 +59,7 @@ static int paging_on_demand_and_memory_protection_demo(void) {
 
   /* succeeding redzone segment */
   {
-    vm_object_t *obj = vm_object_alloc(VM_DUMMY);
+    vm_object_t *obj = vm_object_alloc(VM_PGR_DUMMY);
     vm_segment_t *seg =
       vm_segment_alloc(obj, end, post_end, VM_PROT_NONE, VM_SEG_PRIVATE);
     n = vm_map_insert(umap, seg, VM_FIXED);


### PR DESCRIPTION
Changes:
- delete unnecessary header inclusions.
- fix some typos.
- change the `vm_pgr_type_t` flags prefix form `VM_*` to `VM_PGR_*` (`VM_*` is already used by `vm_flags_t`).
- make `vm_segment_destroy` static as it's only called within the `vm_map` module and it's tricky to use due to the absence of any pmap calls inside the function.
- fix the `vm_map_insert_after` invocation in `vm_segment_destroy_range`.
- pass `0` instead of `VM_SEG_SHARED` in the call to ` vm_segment_alloc` inside ` vm_map_alloc_segment` (note that the following call to `vm_map_insert` will reset the segment's flags based on the `flags` argument anyway).
- rename `vm_map_object_dump` to `vm_object_dump` as it's part of the `vm_object` namespace.
- add counter in `vm_pgr_type_t` to control references to `pagers`.
- add and fix assertions.
- fill the `pgr_type` fields in `pagres`.
- use `vm_offset_t` instead of `off_t`.

