### PR TITLE
Add assertion in kgprof.c

### DIFF
--- a/sys/kern/kgprof.c
+++ b/sys/kern/kgprof.c
@@ -47,6 +47,8 @@ void init_kgprof(void) {
 }
 
 void kgprof_tick(void) {
+  assert(intr_disabled());
+
   uintptr_t pc, instr;
   gmonparam_t *g = &_gmonparam;
   thread_t *td = thread_self();


### PR DESCRIPTION
This one assertion will help understanding entry conditions in `kgprof_tick`. We make here access to `_gmonparam` without taking a lock and it was confusing without knowing that this function is called under interrupts disabled.