### PR TITLE
Move ioflags from VOP_READ/WRITE arguments into uio::uio_ioflags

### DIFF
--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -21,12 +21,7 @@ typedef int fo_seek_t(file_t *f, off_t offset, int whence, off_t *newoffp);
 typedef int fo_stat_t(file_t *f, stat_t *sb);
 typedef int fo_ioctl_t(file_t *f, u_long cmd, void *data);
 
-typedef enum {
-  FOF_SEEKABLE = 1, /* file has cursor */
-} fo_flags_t;
-
 typedef struct {
-  fo_flags_t fo_flags;
   fo_read_t *fo_read;
   fo_write_t *fo_write;
   fo_close_t *fo_close;
@@ -34,6 +29,12 @@ typedef struct {
   fo_stat_t *fo_stat;
   fo_ioctl_t *fo_ioctl;
 } fileops_t;
+
+/* Put `nowrite` into `fo_write` if a file doesn't support writes. */
+int nowrite(file_t *f, uio_t *uio);
+
+/* Put `noseek` into `fo_seek` if a file is not seekable. */
+int noseek(file_t *f, off_t offset, int whence, off_t *newoffp);
 
 typedef enum filetype {
   FT_VNODE = 1, /* regular file */

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -35,6 +35,7 @@ typedef struct uio {
   size_t uio_resid;      /* remaining bytes to process */
   uio_op_t uio_op;       /* operation */
   vm_map_t *uio_vmspace; /* destination address space */
+  unsigned uio_ioflags;  /* IO_* flags associated with this operation */
 } uio_t;
 
 #define UIO_SINGLE(op, vm_map, offset, buf, buflen)                            \

--- a/include/sys/vnode.h
+++ b/include/sys/vnode.h
@@ -34,8 +34,8 @@ typedef int vnode_lookup_t(vnode_t *dv, componentname_t *cn, vnode_t **vp);
 typedef int vnode_readdir_t(vnode_t *dv, uio_t *uio);
 typedef int vnode_open_t(vnode_t *v, int mode, file_t *fp);
 typedef int vnode_close_t(vnode_t *v, file_t *fp);
-typedef int vnode_read_t(vnode_t *v, uio_t *uio, int ioflag);
-typedef int vnode_write_t(vnode_t *v, uio_t *uio, int ioflag);
+typedef int vnode_read_t(vnode_t *v, uio_t *uio);
+typedef int vnode_write_t(vnode_t *v, uio_t *uio);
 typedef int vnode_seek_t(vnode_t *v, off_t oldoff, off_t newoff);
 typedef int vnode_getattr_t(vnode_t *v, vattr_t *va);
 typedef int vnode_setattr_t(vnode_t *v, vattr_t *va, cred_t *cred);
@@ -121,11 +121,6 @@ typedef struct vattr {
 void vattr_null(vattr_t *va);
 void vattr_convert(vattr_t *va, stat_t *sb);
 
-/*
- * Flags for ioflag.
- */
-#define IO_APPEND 0x00020 /* append write to end */
-
 #define VOP_CALL(op, v, ...)                                                   \
   ((v)->v_ops->v_##op) ? ((v)->v_ops->v_##op(v, ##__VA_ARGS__)) : ENOTSUP
 
@@ -146,12 +141,12 @@ static inline int VOP_CLOSE(vnode_t *v, file_t *fp) {
   return VOP_CALL(close, v, fp);
 }
 
-static inline int VOP_READ(vnode_t *v, uio_t *uio, int ioflag) {
-  return VOP_CALL(read, v, uio, ioflag);
+static inline int VOP_READ(vnode_t *v, uio_t *uio) {
+  return VOP_CALL(read, v, uio);
 }
 
-static inline int VOP_WRITE(vnode_t *v, uio_t *uio, int ioflag) {
-  return VOP_CALL(write, v, uio, ioflag);
+static inline int VOP_WRITE(vnode_t *v, uio_t *uio) {
+  return VOP_CALL(write, v, uio);
 }
 
 static inline int VOP_SEEK(vnode_t *v, off_t oldoff, off_t newoff) {

--- a/sys/drv/dev_cons.c
+++ b/sys/drv/dev_cons.c
@@ -8,7 +8,7 @@
 
 #define UART_BUF_MAX 100
 
-static int dev_cons_write(vnode_t *t, uio_t *uio, int ioflag) {
+static int dev_cons_write(vnode_t *t, uio_t *uio) {
   char buffer[UART_BUF_MAX];
   size_t n = uio->uio_resid;
   int res = uiomove(buffer, UART_BUF_MAX - 1, uio);
@@ -19,7 +19,7 @@ static int dev_cons_write(vnode_t *t, uio_t *uio, int ioflag) {
   return 0;
 }
 
-static int dev_cons_read(vnode_t *t, uio_t *uio, int ioflag) {
+static int dev_cons_read(vnode_t *t, uio_t *uio) {
   char buffer[UART_BUF_MAX];
   unsigned curr = 0;
   while (curr < UART_BUF_MAX && curr < uio->uio_resid) {

--- a/sys/drv/evdev.c
+++ b/sys/drv/evdev.c
@@ -442,7 +442,9 @@ static int evdev_ioctl(file_t *f, u_long cmd, void *data) {
 
 static fileops_t evdev_fileops = {
   .fo_read = evdev_read,
+  .fo_write = nowrite,
   .fo_close = default_vnclose,
+  .fo_seek = noseek,
   .fo_stat = default_vnstat,
   .fo_ioctl = evdev_ioctl,
 };

--- a/sys/drv/rtc.c
+++ b/sys/drv/rtc.c
@@ -74,7 +74,7 @@ static intr_filter_t rtc_intr(void *data) {
   return IF_STRAY;
 }
 
-static int rtc_time_read(vnode_t *v, uio_t *uio, int ioflag) {
+static int rtc_time_read(vnode_t *v, uio_t *uio) {
   rtc_state_t *rtc = devfs_node_data(v);
   tm_t t;
 

--- a/sys/drv/stdvga.c
+++ b/sys/drv/stdvga.c
@@ -151,7 +151,7 @@ static int stdvga_close(vnode_t *v, file_t *fp) {
   return 0;
 }
 
-static int stdvga_write(vnode_t *v, uio_t *uio, int ioflag) {
+static int stdvga_write(vnode_t *v, uio_t *uio) {
   stdvga_state_t *vga = devfs_node_data(v);
   size_t size = FB_SIZE(&vga->fb_info);
 

--- a/sys/kern/dev_null.c
+++ b/sys/kern/dev_null.c
@@ -6,16 +6,16 @@
 
 static void *zero_page, *junk_page;
 
-static int dev_null_write(vnode_t *v, uio_t *uio, int ioflag) {
+static int dev_null_write(vnode_t *v, uio_t *uio) {
   uio->uio_resid = 0;
   return 0;
 }
 
-static int dev_null_read(vnode_t *v, uio_t *uio, int ioflag) {
+static int dev_null_read(vnode_t *v, uio_t *uio) {
   return 0;
 }
 
-static int dev_zero_write(vnode_t *v, uio_t *uio, int ioflag) {
+static int dev_zero_write(vnode_t *v, uio_t *uio) {
   /* We might just discard the data, but to demonstrate using uiomove for
    * writing, store the data into a junkyard page. */
   int error = 0;
@@ -28,7 +28,7 @@ static int dev_zero_write(vnode_t *v, uio_t *uio, int ioflag) {
   return error;
 }
 
-static int dev_zero_read(vnode_t *v, uio_t *uio, int ioflag) {
+static int dev_zero_read(vnode_t *v, uio_t *uio) {
   int error = 0;
   while (uio->uio_resid && !error) {
     size_t len = uio->uio_resid;

--- a/sys/kern/dev_procstat.c
+++ b/sys/kern/dev_procstat.c
@@ -72,7 +72,9 @@ static int dev_procstat_open(vnode_t *v, int mode, file_t *fp);
 
 static fileops_t dev_procstat_fileops = {
   .fo_read = dev_procstat_read,
+  .fo_write = nowrite,
   .fo_close = default_vnclose,
+  .fo_seek = noseek,
   .fo_stat = default_vnstat,
   .fo_ioctl = default_vnioctl,
 };

--- a/sys/kern/exec_elf.c
+++ b/sys/kern/exec_elf.c
@@ -24,7 +24,7 @@ int exec_elf_inspect(vnode_t *vn, Elf_Ehdr *eh) {
 
   klog("User ELF size: %u", attr.va_size);
   uio_t uio = UIO_SINGLE_KERNEL(UIO_READ, 0, eh, sizeof(Elf_Ehdr));
-  if ((error = VOP_READ(vn, &uio, 0))) {
+  if ((error = VOP_READ(vn, &uio))) {
     klog("Exec failed: Reading ELF header failed.");
     return error;
   }
@@ -121,7 +121,7 @@ static int load_elf_segment(proc_t *p, vnode_t *vn, Elf_Phdr *ph) {
      */
     uio_t uio =
       UIO_SINGLE_USER(UIO_READ, ph->p_offset, (char *)start, ph->p_filesz);
-    if ((error = VOP_READ(vn, &uio, 0))) {
+    if ((error = VOP_READ(vn, &uio))) {
       klog("Exec failed: Reading ELF segment failed.");
       return error;
     }
@@ -153,7 +153,7 @@ int exec_elf_load(proc_t *p, vnode_t *vn, Elf_Ehdr *eh) {
   size_t phs_size = eh->e_phnum * eh->e_phentsize;
   char *phs = kmalloc(M_TEMP, phs_size, 0);
   uio_t uio = UIO_SINGLE_KERNEL(UIO_READ, eh->e_phoff, phs, phs_size);
-  if ((error = VOP_READ(vn, &uio, 0))) {
+  if ((error = VOP_READ(vn, &uio))) {
     klog("Exec failed: Reading program headers failed.");
     goto fail;
   }

--- a/sys/kern/exec_shebang.c
+++ b/sys/kern/exec_shebang.c
@@ -23,7 +23,7 @@ int exec_shebang_inspect(vnode_t *vn) {
     return ENOEXEC;
 
   uio_t uio = UIO_SINGLE_KERNEL(UIO_READ, 0, sig, 2);
-  if ((error = VOP_READ(vn, &uio, 0))) {
+  if ((error = VOP_READ(vn, &uio))) {
     klog("Failed to read shebang!");
     return error;
   }
@@ -58,7 +58,7 @@ int exec_shebang_load(vnode_t *vn, exec_args_t *args) {
   int error;
 
   uio_t uio = UIO_SINGLE_KERNEL(UIO_READ, 2, interp, PATH_MAX);
-  if ((error = VOP_READ(vn, &uio, 0)))
+  if ((error = VOP_READ(vn, &uio)))
     goto fail;
 
   /* Make sure there's a terminator in user data. */

--- a/sys/kern/file.c
+++ b/sys/kern/file.c
@@ -61,9 +61,12 @@ static int badfo_ioctl(file_t *f, u_long cmd, void *data) {
   return EOPNOTSUPP;
 }
 
-fileops_t badfileops = {.fo_read = badfo_read,
-                        .fo_write = badfo_write,
-                        .fo_close = badfo_close,
-                        .fo_stat = badfo_stat,
-                        .fo_seek = badfo_seek,
-                        .fo_ioctl = badfo_ioctl};
+fileops_t badfileops = {
+  .fo_flags = FOF_SEEKABLE,
+  .fo_read = badfo_read,
+  .fo_write = badfo_write,
+  .fo_close = badfo_close,
+  .fo_stat = badfo_stat,
+  .fo_seek = badfo_seek,
+  .fo_ioctl = badfo_ioctl,
+};

--- a/sys/kern/file.c
+++ b/sys/kern/file.c
@@ -36,6 +36,14 @@ void file_drop(file_t *f) {
     file_destroy(f);
 }
 
+int nowrite(file_t *f, uio_t *uio) {
+  return EBADF;
+}
+
+int noseek(file_t *f, off_t offset, int whence, off_t *newoffp) {
+  return ESPIPE;
+}
+
 /* Operations on invalid file descriptors */
 static int badfo_read(file_t *f, uio_t *uio) {
   return EOPNOTSUPP;
@@ -62,7 +70,6 @@ static int badfo_ioctl(file_t *f, u_long cmd, void *data) {
 }
 
 fileops_t badfileops = {
-  .fo_flags = FOF_SEEKABLE,
   .fo_read = badfo_read,
   .fo_write = badfo_write,
   .fo_close = badfo_close,

--- a/sys/kern/file_syscalls.c
+++ b/sys/kern/file_syscalls.c
@@ -43,12 +43,7 @@ int do_lseek(proc_t *p, int fd, off_t offset, int whence, off_t *newoffp) {
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
     return error;
-
-  if (f->f_ops->fo_flags & FOF_SEEKABLE)
-    error = FOP_SEEK(f, offset, whence, newoffp);
-  else
-    error = ESPIPE;
-
+  error = FOP_SEEK(f, offset, whence, newoffp);
   file_drop(f);
   return error;
 }

--- a/sys/kern/file_syscalls.c
+++ b/sys/kern/file_syscalls.c
@@ -17,6 +17,8 @@ int do_read(proc_t *p, int fd, uio_t *uio) {
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_READ, &f)))
     return error;
+
+  uio->uio_ioflags |= f->f_flags & IO_MASK;
   error = FOP_READ(f, uio);
   file_drop(f);
   return error;
@@ -28,19 +30,25 @@ int do_write(proc_t *p, int fd, uio_t *uio) {
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, FF_WRITE, &f)))
     return error;
+
+  uio->uio_ioflags |= f->f_flags & IO_MASK;
   error = FOP_WRITE(f, uio);
   file_drop(f);
   return error;
 }
 
 int do_lseek(proc_t *p, int fd, off_t offset, int whence, off_t *newoffp) {
-  /* TODO: RW file flag! For now we just file_get_read */
   file_t *f;
   int error;
 
   if ((error = fdtab_get_file(p->p_fdtable, fd, 0, &f)))
     return error;
-  error = FOP_SEEK(f, offset, whence, newoffp);
+
+  if (f->f_ops->fo_flags & FOF_SEEKABLE)
+    error = FOP_SEEK(f, offset, whence, newoffp);
+  else
+    error = ESPIPE;
+
   file_drop(f);
   return error;
 }
@@ -122,14 +130,18 @@ int do_fcntl(proc_t *p, int fd, int cmd, int arg, int *resp) {
         if (f->f_flags & FF_WRITE)
           flags |= O_WRONLY;
       }
-      if (f->f_flags & FF_APPEND)
+      if (f->f_flags & IO_APPEND)
         flags |= O_APPEND;
+      if (f->f_flags & IO_NONBLOCK)
+        flags |= O_NONBLOCK;
       *resp = flags;
       break;
 
     case F_SETFL:
       if (arg & O_APPEND)
-        flags |= FF_APPEND;
+        flags |= IO_APPEND;
+      if (arg & O_NONBLOCK)
+        flags |= IO_NONBLOCK;
       f->f_flags = flags;
       break;
 

--- a/sys/kern/initrd.c
+++ b/sys/kern/initrd.c
@@ -242,7 +242,7 @@ static int initrd_vnode_lookup(vnode_t *vdir, componentname_t *cn,
   return ENOENT;
 }
 
-static int initrd_vnode_read(vnode_t *v, uio_t *uio, int ioflag) {
+static int initrd_vnode_read(vnode_t *v, uio_t *uio) {
   cpio_node_t *cn = (cpio_node_t *)v->v_data;
   return uiomove_frombuf(cn->c_data, cn->c_size, uio);
 }

--- a/sys/kern/pipe.c
+++ b/sys/kern/pipe.c
@@ -154,6 +154,7 @@ static fileops_t pipeops = {
   .fo_read = pipe_read,
   .fo_write = pipe_write,
   .fo_close = pipe_close,
+  .fo_seek = noseek,
   .fo_stat = pipe_stat,
   .fo_ioctl = pipe_ioctl,
 };

--- a/sys/kern/pipe.c
+++ b/sys/kern/pipe.c
@@ -146,20 +146,17 @@ static int pipe_stat(file_t *f, stat_t *sb) {
   return EOPNOTSUPP;
 }
 
-static int pipe_seek(file_t *f, off_t offset, int whence, off_t *newoffp) {
-  return ESPIPE;
-}
-
 static int pipe_ioctl(file_t *f, u_long cmd, void *data) {
   return EOPNOTSUPP;
 }
 
-static fileops_t pipeops = {.fo_read = pipe_read,
-                            .fo_write = pipe_write,
-                            .fo_close = pipe_close,
-                            .fo_seek = pipe_seek,
-                            .fo_stat = pipe_stat,
-                            .fo_ioctl = pipe_ioctl};
+static fileops_t pipeops = {
+  .fo_read = pipe_read,
+  .fo_write = pipe_write,
+  .fo_close = pipe_close,
+  .fo_stat = pipe_stat,
+  .fo_ioctl = pipe_ioctl,
+};
 
 static file_t *make_pipe_file(pipe_end_t *end) {
   file_t *file = file_alloc();

--- a/sys/kern/pty.c
+++ b/sys/kern/pty.c
@@ -192,6 +192,7 @@ static fileops_t pty_fileops = {
   .fo_read = pty_read,
   .fo_write = pty_write,
   .fo_close = pty_close,
+  .fo_seek = noseek,
   .fo_stat = pty_stat,
   .fo_ioctl = pty_ioctl,
 };

--- a/sys/kern/pty.c
+++ b/sys/kern/pty.c
@@ -134,10 +134,6 @@ static int pty_close(file_t *f) {
   return 0;
 }
 
-static int pty_seek(file_t *f, off_t offset, int whence, off_t *newoffp) {
-  return ESPIPE;
-}
-
 static int pty_stat(file_t *f, stat_t *sb) {
   /* Delegate to the slave tty.
    * We can't call default_vnstat() because we don't have a file_t pointing to
@@ -192,12 +188,13 @@ static int pty_ioctl(file_t *f, u_long cmd, void *data) {
   return tty_ioctl(f, cmd, data);
 }
 
-static fileops_t pty_fileops = {.fo_read = pty_read,
-                                .fo_write = pty_write,
-                                .fo_close = pty_close,
-                                .fo_seek = pty_seek,
-                                .fo_stat = pty_stat,
-                                .fo_ioctl = pty_ioctl};
+static fileops_t pty_fileops = {
+  .fo_read = pty_read,
+  .fo_write = pty_write,
+  .fo_close = pty_close,
+  .fo_stat = pty_stat,
+  .fo_ioctl = pty_ioctl,
+};
 
 static void pty_notify_out(tty_t *tty) {
   pty_t *pty = tty->t_data;

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -398,7 +398,7 @@ static int tmpfs_uiomove(tmpfs_node_t *node, uio_t *uio, size_t n) {
   return uiomove(blk + blkoff, len, uio);
 }
 
-static int tmpfs_vop_read(vnode_t *v, uio_t *uio, int ioflag) {
+static int tmpfs_vop_read(vnode_t *v, uio_t *uio) {
   tmpfs_node_t *node = TMPFS_NODE_OF(v);
   size_t remaining;
   int error = 0;
@@ -420,7 +420,7 @@ static int tmpfs_vop_read(vnode_t *v, uio_t *uio, int ioflag) {
   return error;
 }
 
-static int tmpfs_vop_write(vnode_t *v, uio_t *uio, int ioflag) {
+static int tmpfs_vop_write(vnode_t *v, uio_t *uio) {
   tmpfs_mount_t *tfm = TMPFS_ROOT_OF(v->v_mount);
   tmpfs_node_t *node = TMPFS_NODE_OF(v);
   int error = 0;
@@ -430,7 +430,7 @@ static int tmpfs_vop_write(vnode_t *v, uio_t *uio, int ioflag) {
   if (node->tfn_type != V_REG)
     return EOPNOTSUPP;
 
-  if (ioflag & IO_APPEND)
+  if (uio->uio_ioflags & IO_APPEND)
     uio->uio_offset = node->tfn_size;
 
   if (uio->uio_offset + uio->uio_resid > node->tfn_size)

--- a/sys/kern/vfs_vnode.c
+++ b/sys/kern/vfs_vnode.c
@@ -184,7 +184,7 @@ int default_vnread(file_t *f, uio_t *uio) {
   int error = 0;
   vnode_lock(v);
   uio->uio_offset = f->f_offset;
-  error = VOP_READ(f->f_vnode, uio, 0);
+  error = VOP_READ(f->f_vnode, uio);
   f->f_offset = uio->uio_offset;
   vnode_unlock(v);
   return error;
@@ -192,12 +192,10 @@ int default_vnread(file_t *f, uio_t *uio) {
 
 int default_vnwrite(file_t *f, uio_t *uio) {
   vnode_t *v = f->f_vnode;
-  int error = 0, ioflag = 0;
-  if (f->f_flags & FF_APPEND)
-    ioflag |= IO_APPEND;
+  int error = 0;
   vnode_lock(v);
   uio->uio_offset = f->f_offset;
-  error = VOP_WRITE(f->f_vnode, uio, ioflag);
+  error = VOP_WRITE(f->f_vnode, uio);
   f->f_offset = uio->uio_offset;
   vnode_unlock(v);
   return error;
@@ -292,6 +290,7 @@ int default_vnioctl(file_t *f, u_long cmd, void *data) {
 }
 
 static fileops_t default_vnode_fileops = {
+  .fo_flags = FOF_SEEKABLE,
   .fo_read = default_vnread,
   .fo_write = default_vnwrite,
   .fo_close = default_vnclose,
@@ -305,6 +304,7 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
   fp->f_ops = &default_vnode_fileops;
   fp->f_type = FT_VNODE;
   fp->f_vnode = v;
+
   switch (mode & O_ACCMODE) {
     case O_RDONLY:
       fp->f_flags = FF_READ;
@@ -318,7 +318,10 @@ int vnode_open_generic(vnode_t *v, int mode, file_t *fp) {
   }
 
   if (mode & O_APPEND)
-    fp->f_flags |= FF_APPEND;
+    fp->f_flags |= IO_APPEND;
+
+  if (mode & O_NONBLOCK)
+    fp->f_flags |= IO_NONBLOCK;
 
   return 0;
 }

--- a/sys/kern/vfs_vnode.c
+++ b/sys/kern/vfs_vnode.c
@@ -290,7 +290,6 @@ int default_vnioctl(file_t *f, u_long cmd, void *data) {
 }
 
 static fileops_t default_vnode_fileops = {
-  .fo_flags = FOF_SEEKABLE,
   .fo_read = default_vnread,
   .fo_write = default_vnwrite,
   .fo_close = default_vnclose,

--- a/sys/tests/vfs.c
+++ b/sys/tests/vfs.c
@@ -61,7 +61,7 @@ static int test_vfs(void) {
 
   /* Perform a READ test on /dev/zero, cleaning buffer. */
   uio = UIO_SINGLE_KERNEL(UIO_READ, 0, buffer, sizeof(buffer));
-  res = VOP_READ(dev_zero, &uio, 0);
+  res = VOP_READ(dev_zero, &uio);
   assert(res == 0);
   assert(buffer[1] == 0 && buffer[10] == 0);
   assert(uio.uio_resid == 0);
@@ -69,7 +69,7 @@ static int test_vfs(void) {
   /* Now write some data to /dev/null */
   assert(dev_null != 0);
   uio = UIO_SINGLE_KERNEL(UIO_WRITE, 0, buffer, sizeof(buffer));
-  res = VOP_WRITE(dev_null, &uio, 0);
+  res = VOP_WRITE(dev_null, &uio);
   assert(res == 0);
   assert(uio.uio_resid == 0);
 
@@ -80,7 +80,7 @@ static int test_vfs(void) {
   char *str = "Some string for testing UART write\n";
 
   uio = UIO_SINGLE_KERNEL(UIO_WRITE, 0, str, strlen(str));
-  res = VOP_WRITE(dev_cons, &uio, 0);
+  res = VOP_WRITE(dev_cons, &uio);
   assert(res == 0);
 
   return KTEST_SUCCESS;


### PR DESCRIPTION
 * Clean up file flags: they express allowed operations and I/O operation flags (nonblocking, append, ...)

Changes extracted from #1103.