### PR TITLE
Fix kmem_map_contig invocation.

### DIFF
--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -143,7 +143,7 @@ vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, unsigned flags) {
   if (pap)
     *pap = pg->paddr;
 
-  return kmem_map_contig(pg->paddr, pg->size, flags);
+  return kmem_map_contig(pg->paddr, size, flags);
 }
 
 void kmem_free(void *ptr, size_t size) {


### PR DESCRIPTION
`kmem_map_contig` doesn't receive `size` in `PAGESIZE` units but rather in bytes, thereby the invocation within `kmem_alloc_contig` has to be changed.