### PR TITLE
Introduce USB interfaces.

### DIFF
--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -375,10 +375,11 @@ int usb_unhalt_endpt(device_t *dev, usb_transfer_t transfer,
  *
  * Used in driver's configuration phase.
  *
- * - `dev` - USB device
+ * Arguments:
+ *  - `dev`: USB device
  *
  * error codes:
- * - EIO - an error has been encountered during the transfer
+ *  - EIO: an error has been encountered during the transfer
  */
 int usb_hid_set_idle(device_t *dev);
 
@@ -387,10 +388,11 @@ int usb_hid_set_idle(device_t *dev);
  *
  * Used by drivers which don't implement HID descriptor parsing.
  *
- * - `dev` - USB device
+ * Arguments:
+ *  - `dev`: USB device
  *
  * error codes:
- * - EIO - an error has been encountered during the transfer
+ *  - EIO: an error has been encountered during the transfer
  */
 int usb_hid_set_boot_protocol(device_t *dev);
 
@@ -405,23 +407,25 @@ int usb_hid_set_boot_protocol(device_t *dev);
 /*
  * Retrives the maximum Logical Unit Number of a device.
  *
- * - `dev` - USB device
- * - `maxlun` - destination address
+ * Arguments:
+ *  - `dev`: USB device
+ *  - `maxlun_p`: destination address
  *
  * error codes:
- * - EIO - an error has been encountered during the transfer
+ *  - EIO: an error has been encountered during the transfer
  */
-int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun);
+int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun_p);
 
 /*
  * Resets USB mass storage device.
  *
  * Used in recovery process.
  *
- * - `dev` - USB device
+ * Arguments:
+ *  - `dev`: USB device
  *
  * error codes:
- * - EIO - an error has been encountered during the transfer
+ *  - EIO: an error has been encountered during the transfer
  */
 int usb_bbb_reset(device_t *dev);
 

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -252,16 +252,16 @@ usb_buf_t *usb_buf_alloc(void);
 /* Releases a previously allocated buffer. */
 void usb_buf_free(usb_buf_t *buf);
 
-/* Returns true if the transfer in which `buf` is being used in is peridoc. */
+/* Returns true if the transfer described by `buf` is periodic. */
 bool usb_buf_periodic(usb_buf_t *buf);
 
-/* Waits until the transfer in which `buf` is being used in completes, or
- * until an error is encountered. If an error is returned, further information
- * may be obtained through `buf->error`. */
+/* Waits until the transfer described by `buf` completes, or until an error is
+ * encountered. If an error is returned, further information may be obtained
+ * through `buf::error`. */
 int usb_buf_wait(usb_buf_t *buf);
 
-/* Processes data `data` received in transfer in which `buf` was used,
- * or processes error `error` encountered during the transfer.
+/* When the transfer request finishes the `data` or `error` are available.
+ * We need to update `buf` to reflect that change.
  * Only for host controller driver internal use! */
 void usb_buf_process(usb_buf_t *buf, void *data, usb_error_t error);
 
@@ -278,11 +278,10 @@ int usb_enumerate(device_t *hcdev);
 /*
  * USB standard interface.
  *
- * The following interface provides basic USB transfers: control,
- * and data stage only transfers. Although control transfers are supplied,
- * if a need to perform some standard request form a device driver arises,
- * the request should be added to the USB bus standard requests interface
- * instead of using control transfers directly.
+ * The following interface provides basic USB transfers: control and data stage
+ * only transfers. If you need to create a new function that performs a new
+ * type of request, as specified by the standard, **avoid** adding it to
+ * `usb_methods`. Just write a new function that uses the interface.
  */
 
 typedef void (*usb_control_transfer_t)(device_t *dev, usb_buf_t *buf,
@@ -302,16 +301,16 @@ static inline usb_methods_t *usb_methods(device_t *dev) {
 }
 
 /*
- * Issues a control transfer.
+ * Issues a control transfer asynchronously.
  *
- * This is an asynchronous function. In order to wait for the transfer to
- * complete, use `usb_buf_wait` with `buf` as the argument.
+ * Pass `buf` to `usb_buf_wait` to wait for the transfer to complete.
  *
- * - `dev`  - device requesting the transfer
- * - `buf`  - USB buffer used for transaction
- * - `data` - data to transfer, or destination address
- * - `dir`  - transfer direction
- * - `req`  - USB device request
+ * Arguments:
+ *  - `dev`: device requesting the transfer
+ *  - `buf`: USB buffer used for transaction
+ *  - `data`: data to transfer, or destination address
+ *  - `dir`: transfer direction
+ *  - `req`: USB device request
  */
 static inline void usb_control_transfer(device_t *dev, usb_buf_t *buf,
                                         void *data, usb_direction_t dir,
@@ -320,17 +319,17 @@ static inline void usb_control_transfer(device_t *dev, usb_buf_t *buf,
 }
 
 /*
- * Issues a data stage only transfer.
+ * Issues a data stage only transfer asynchronously.
  *
- * This is an asynchronous function. In order to wait for the transfer to
- * complete, use `usb_buf_wait` with `buf` as the argument.
+ * Pass `buf` to `usb_buf_wait` to wait for the transfer to complete.
  *
- * - `dev`  - device requesting the transfer
- * - `buf`  - USB buffer used for transaction
- * - `data` - data to transfer, or destination address
- * - `size` - transfer size
- * - `transfer` - `USB_TFR_INTERRUPT` or `USB_TFR_BULK`
- * - `dir`  - transfer direction
+ * Arguments:
+ *  - `dev`: device requesting the transfer
+ *  - `buf`: USB buffer used for transaction
+ *  - `data`: data to transfer, or destination address
+ *  - `size`: transfer size
+ *  - `transfer`: `USB_TFR_INTERRUPT` or `USB_TFR_BULK`
+ *  - `dir`: transfer direction
  */
 static inline void usb_data_transfer(device_t *dev, usb_buf_t *buf, void *data,
                                      uint16_t size, usb_transfer_t transfer,
@@ -344,8 +343,8 @@ static inline void usb_data_transfer(device_t *dev, usb_buf_t *buf, void *data,
  * The following functions implement standard USB requests. Requests used for
  * device identification and configuration aren't exposed since USB bus
  * driver identifies and configures each device automatically during enumeration
- * process. It is suggested to add a new function to the presented set instead
- * of using `usb_control_transfer` request if a need occurs.
+ * process. Consider adding a new function to the following set instead of using
+ * `usb_control_transfer` request directly.
  */
 
 /*
@@ -353,12 +352,13 @@ static inline void usb_data_transfer(device_t *dev, usb_buf_t *buf, void *data,
  *
  * Used in recovery process.
  *
- * - `dev` - USB device
- * - (`transfer`, `dir`) - identifies device's endpoint
+ * Arguments:
+ *  - `dev`: USB device
+ *  - `transfer` + `dir`: identifies device's endpoint
  *
- * error codes:
- * - EINVAL - (`transfer`, `dir`) doesn't identify a `dev`'s endpoint
- * - EIO - an error has been encountered during the transfer
+ * Error codes:
+ *  - EINVAL: `transfer` + `dir` doesn't identify a `dev` endpoint
+ *  - EIO: an error has been encountered during the transfer
  */
 int usb_unhalt_endpt(device_t *dev, usb_transfer_t transfer,
                      usb_direction_t dir);

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -355,6 +355,10 @@ static inline void usb_data_transfer(device_t *dev, usb_buf_t *buf, void *data,
  *
  * - `dev` - USB device
  * - (`transfer`, `dir`) - identifies device's endpoint
+ *
+ * error codes:
+ * - EINVAL - (`transfer`, `dir`) doesn't identify a `dev`'s endpoint
+ * - EIO - an error has been encountered during the transfer
  */
 int usb_unhalt_endpt(device_t *dev, usb_transfer_t transfer,
                      usb_direction_t dir);
@@ -372,6 +376,9 @@ int usb_unhalt_endpt(device_t *dev, usb_transfer_t transfer,
  * Used in driver's configuration phase.
  *
  * - `dev` - USB device
+ *
+ * error codes:
+ * - EIO - an error has been encountered during the transfer
  */
 int usb_hid_set_idle(device_t *dev);
 
@@ -381,6 +388,9 @@ int usb_hid_set_idle(device_t *dev);
  * Used by drivers which don't implement HID descriptor parsing.
  *
  * - `dev` - USB device
+ *
+ * error codes:
+ * - EIO - an error has been encountered during the transfer
  */
 int usb_hid_set_boot_protocol(device_t *dev);
 
@@ -397,6 +407,9 @@ int usb_hid_set_boot_protocol(device_t *dev);
  *
  * - `dev` - USB device
  * - `maxlun` - destination address
+ *
+ * error codes:
+ * - EIO - an error has been encountered during the transfer
  */
 int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun);
 
@@ -406,6 +419,9 @@ int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun);
  * Used in recovery process.
  *
  * - `dev` - USB device
+ *
+ * error codes:
+ * - EIO - an error has been encountered during the transfer
  */
 int usb_bbb_reset(device_t *dev);
 

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -378,7 +378,7 @@ int usb_unhalt_endpt(device_t *dev, usb_transfer_t transfer,
  * Arguments:
  *  - `dev`: USB device
  *
- * error codes:
+ * Error codes:
  *  - EIO: an error has been encountered during the transfer
  */
 int usb_hid_set_idle(device_t *dev);
@@ -391,7 +391,7 @@ int usb_hid_set_idle(device_t *dev);
  * Arguments:
  *  - `dev`: USB device
  *
- * error codes:
+ * Error codes:
  *  - EIO: an error has been encountered during the transfer
  */
 int usb_hid_set_boot_protocol(device_t *dev);
@@ -411,7 +411,7 @@ int usb_hid_set_boot_protocol(device_t *dev);
  *  - `dev`: USB device
  *  - `maxlun_p`: destination address
  *
- * error codes:
+ * Error codes:
  *  - EIO: an error has been encountered during the transfer
  */
 int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun_p);
@@ -424,7 +424,7 @@ int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun_p);
  * Arguments:
  *  - `dev`: USB device
  *
- * error codes:
+ * Error codes:
  *  - EIO: an error has been encountered during the transfer
  */
 int usb_bbb_reset(device_t *dev);

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -4,7 +4,6 @@
 #ifndef _DEV_USB_H_
 #define _DEV_USB_H_
 
-#include <sys/ringbuf.h>
 #include <sys/condvar.h>
 #include <sys/spinlock.h>
 #include <sys/device.h>

--- a/include/dev/usb.h
+++ b/include/dev/usb.h
@@ -4,6 +4,11 @@
 #ifndef _DEV_USB_H_
 #define _DEV_USB_H_
 
+#include <sys/ringbuf.h>
+#include <sys/condvar.h>
+#include <sys/spinlock.h>
+#include <sys/device.h>
+
 /*
  * Constructs defined by the USB specification.
  */
@@ -16,13 +21,16 @@
 #define USB_PORT_ROOT_RESET_DELAY_SPEC 50 /* ms */
 #define USB_PORT_RESET_RECOVERY_SPEC 10   /* ms */
 
-typedef struct usb_device_request {
+/*
+ * USB device request.
+ */
+typedef struct usb_dev_req {
   uint8_t bmRequestType;
   uint8_t bRequest;
   uint16_t wValue;
   uint16_t wIndex;
   uint16_t wLength;
-} __packed usb_device_request_t;
+} __packed usb_dev_req_t;
 
 #define UT_WRITE 0x00
 #define UT_READ 0x80
@@ -58,7 +66,10 @@ typedef struct usb_device_request {
 
 #define UV_MAKE(d, i) ((d) << 8 | (i))
 
-typedef struct usb_device_descriptor {
+/*
+ * USB device descriptor.
+ */
+typedef struct usb_dev_dsc {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint16_t bcdUSB;
@@ -74,27 +85,36 @@ typedef struct usb_device_descriptor {
   uint8_t iProduct;
   uint8_t iSerialNumber;
   uint8_t bNumConfigurations;
-} __packed usb_device_descriptor_t;
+} __packed usb_dev_dsc_t;
 
 #define US_DATASIZE 63
 
-typedef struct usb_string_descriptor {
+/*
+ * USB string descriptor.
+ */
+typedef struct usb_str_dsc {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint16_t bString[US_DATASIZE];
   uint8_t bUnused;
-} __packed usb_string_descriptor_t;
+} __packed usb_str_dsc_t;
 
-typedef struct usb_string_lang {
+/*
+ * USB string language descriptor.
+ */
+typedef struct usb_str_lang {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint16_t bData[US_DATASIZE];
-} __packed usb_string_lang_t;
+} __packed usb_str_lang_t;
 
 #define US_ENG_LID 0x0409
 #define US_ENG_STR "English (United States)"
 
-typedef struct usb_config_descriptor {
+/*
+ * USB configuration descriptor.
+ */
+typedef struct usb_config_dsc {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint16_t wTotalLength;
@@ -103,9 +123,12 @@ typedef struct usb_config_descriptor {
   uint8_t iConfiguration;
   uint8_t bmAttributes;
   uint8_t bMaxPower; /* max current in 2 mA units */
-} __packed usb_config_descriptor_t;
+} __packed usb_config_dsc_t;
 
-typedef struct usb_interface_descriptor {
+/*
+ * USB interface descriptor.
+ */
+typedef struct usb_if_dsc {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint8_t bInterfaceNumber;
@@ -115,7 +138,7 @@ typedef struct usb_interface_descriptor {
   uint8_t bInterfaceSubClass;
   uint8_t bInterfaceProtocol;
   uint8_t iInterface;
-} __packed usb_interface_descriptor_t;
+} __packed usb_if_dsc_t;
 
 /* Interface class codes */
 #define UICLASS_HID 0x03
@@ -127,14 +150,17 @@ typedef struct usb_interface_descriptor {
 #define UISUBCLASS_SCSI 6
 #define UIPROTO_MASS_BBB 80
 
-typedef struct usb_endpoint_descriptor {
+/*
+ * USB endpoint descriptor.
+ */
+typedef struct usb_endp_dsc {
   uint8_t bLength;
   uint8_t bDescriptorType;
   uint8_t bEndpointAddress;
   uint8_t bmAttributes;
   uint16_t wMaxPacketSize;
   uint8_t bInterval;
-} __packed usb_endpoint_descriptor_t;
+} __packed usb_endp_dsc_t;
 
 #define UE_ADDR 0x0f
 #define UE_DIR_IN 0x80  /* IN-token endpoint */
@@ -156,30 +182,45 @@ typedef struct usb_endpoint_descriptor {
 typedef enum usb_error {
   USB_ERR_STALLED = 1, /* STALL condition encountered */
   USB_ERR_OTHER = 2,   /* errors other than STALL */
-} usb_error_t;
+} __packed usb_error_t;
 
+/* Don't alter the following values! */
 typedef enum usb_transfer {
-  USB_TFR_NONE,
-  USB_TFR_CONTROL,
-  USB_TFR_INTERRUPT,
-  USB_TFR_BULK,
-} usb_transfer_t;
+  USB_TFR_NONE = 0,
+  USB_TFR_CONTROL = 1,
+  USB_TFR_ISOCHRONOUS = 2,
+  USB_TFR_BULK = 3,
+  USB_TFR_INTERRUPT = 4,
+} __packed usb_transfer_t;
 
 typedef enum usb_direction {
   USB_DIR_INPUT,
   USB_DIR_OUTPUT,
-} usb_direction_t;
+} __packed usb_direction_t;
 
-/* USB buffer used for USB transfers. */
-typedef struct usb_buf {
-  ringbuf_t buf;           /* write source or read destination */
-  condvar_t cv;            /* wait for the transfer to complete */
-  spin_t lock;             /* buffer guard */
-  usb_error_t error;       /* errors encountered during transfer */
-  usb_transfer_t transfer; /* what kind of transfer is this ? */
-  usb_direction_t dir;     /* transfer direction */
-  uint16_t transfer_size;  /* size of the transfer */
-} usb_buf_t;
+typedef struct usb_endp {
+  TAILQ_ENTRY(usb_endp) link; /* entry on device's endpoint list */
+  uint16_t maxpkt;            /* max packet size */
+  uint8_t addr;               /* address within a device */
+  usb_transfer_t transfer;    /* transfer type */
+  usb_direction_t dir;        /* transfer direction */
+  uint8_t interval;           /* interval for polling data transfers */
+} usb_endp_t;
+
+/* USB device software representation. */
+typedef struct usb_device {
+  TAILQ_HEAD(, usb_endp) endps; /* endpoints provided by the device */
+  uint8_t addr;                 /* address of the device */
+  uint8_t port;                 /* root hub port number */
+  uint8_t ifnum;                /* current interface number */
+  uint8_t class_code;           /* device class code */
+  uint8_t subclass_code;        /* device subclass code */
+  uint8_t protocol_code;        /* protocol code */
+  uint16_t vendor_id;           /* vendor ID */
+  uint16_t product_id;          /* product ID */
+} usb_device_t;
+
+typedef struct usb_buf usb_buf_t;
 
 static inline usb_device_t *usb_device_of(device_t *dev) {
   return dev->bus == DEV_BUS_USB ? dev->instance : NULL;
@@ -187,6 +228,210 @@ static inline usb_device_t *usb_device_of(device_t *dev) {
 
 static inline device_t *usb_bus_of(device_t *dev) {
   return dev->bus == DEV_BUS_USB ? dev->parent : TAILQ_FIRST(&dev->children);
+}
+
+/* Copies data bytes form `src` to buffer `buf`'s internal buffer.
+ * Before copying, the internal buffer is reseted. This function should
+ * be used before performing output transfers on a buffer. */
+void usb_buf_copyin(usb_buf_t *buf, void *src, size_t size);
+
+/* Copies data bytes contained in `buf` to designated area `dst`.
+ * Data is copied from the beginning of an internal buffer and isn't mark
+ * as readed. For reading data form a buffer use `usb_buf_read` instead. */
+void usb_buf_copyout(usb_buf_t *buf, void *dst, size_t size);
+
+/* Allocate a USB buffer with internal buffer of size `size`. */
+usb_buf_t *usb_buf_alloc(size_t size);
+
+/* Releases a previously allocated buffer. */
+void usb_buf_free(usb_buf_t *buf);
+
+/* Returns current `buf`'s transfer direction. */
+usb_direction_t usb_buf_dir(usb_buf_t *buf);
+
+/* Returns current `buf`'s transfer data stage size. */
+uint16_t usb_buf_transfer_size(usb_buf_t *buf);
+
+/* Processes data `data` received in transfer in which `buf` is used,
+ * or processes error `error` encountered during the transfer. */
+void usb_buf_process(usb_buf_t *buf, void *data, usb_error_t error);
+
+/* Returns true if the transfer in which `buf` is being used in is peridoc. */
+bool usb_buf_periodic(usb_buf_t *buf);
+
+/* Returns `buf`'s error status. The error status is always cleared upon
+ * passing `buf` to any USB transfer function (as that means the buffer is
+ * beaing reused). */
+usb_error_t usb_buf_error(usb_buf_t *buf);
+
+/* Reads bytes received in lates `buf`'s transfer, or waits for the data
+ * to arrive. The only supported value of `flags` is `IO_NONBLOCK`.
+ * If data isn't ready yet, and `IO_NONBLOCK` is specified, the function
+ * immediately returns with `EAGAIN`. If an error other than `EAGAIN`
+ * is returned, further information may be obtained through `usb_buf_error`. */
+int usb_buf_read(usb_buf_t *buf, void *dst, int flags);
+
+/* Waits for the data involved in `buf`'s latest transfer to be written
+ * to the destioation device. The only supported value of `flags`
+ * is `IO_NONBLOCK`. If data isn't already written, and `IO_NONBLOCK`
+ * is specified, the function immediately returns with `EAGAIN`.
+ * If an error other than `EAGAIN` is returned, further information
+ * may be obtained through `usb_buf_error`. */
+int usb_buf_write(usb_buf_t *buf, int flags);
+
+/* Returns direction for the STATUS stage of a transfer.
+ * Should only be used by USB host controller drivers. */
+usb_direction_t usb_status_dir(usb_direction_t dir, uint16_t transfer_size);
+
+/* Initializes the underlying USB bus of the host controller `hcdev`. */
+void usb_init(device_t *hcdev);
+
+/* Enumerates and configures all devices attached to root hub `hcdev`. */
+int usb_enumerate(device_t *hcdev);
+
+/*
+ * USB standard interface.
+ *
+ * The following interface provides basic USB transfers: control, interrupt,
+ * and bulk. Although control transfers are supplied, if there is a need to
+ * perform some standard request form a device driver, it should be added to
+ * USB bus standard requests interface.
+ */
+
+typedef void (*usb_control_transfer_t)(device_t *dev, usb_buf_t *buf,
+                                       usb_direction_t dir, usb_dev_req_t *req);
+typedef void (*usb_interrupt_transfer_t)(device_t *dev, usb_buf_t *buf,
+                                         usb_direction_t dir, uint16_t size);
+typedef void (*usb_bulk_transfer_t)(device_t *dev, usb_buf_t *buf,
+                                    usb_direction_t dir, uint16_t size);
+
+typedef struct usb_methods {
+  usb_control_transfer_t control_transfer;
+  usb_interrupt_transfer_t interrupt_transfer;
+  usb_bulk_transfer_t bulk_transfer;
+} usb_methods_t;
+
+static inline usb_methods_t *usb_methods(device_t *dev) {
+  return (usb_methods_t *)dev->driver->interfaces[DIF_USB];
+}
+
+/* Issues a control transfer of direction `dir`, with device request `req`
+ * using buffer `buf`. This is an asynchronous function. In order to receive
+ * involved data use `usb_buf_read`. To wait for the data to be written
+ * use `usb_buf_write`. All encountered errors will be reflected in `buf`'s
+ * error status (see `usb_buf_error`). */
+static inline void usb_control_transfer(device_t *dev, usb_buf_t *buf,
+                                        usb_direction_t dir,
+                                        usb_dev_req_t *req) {
+  usb_methods(dev->parent)->control_transfer(dev, buf, dir, req);
+}
+
+/* Issues an interrupt transfer of direction `dir`, using buffer `buf`.
+ * This is an asynchronous function. In order to receive involved data use
+ * `usb_buf_read`. To wait for the data to be written use `usb_buf_write`.
+ * All encountered errors will be reflected in `buf`'s error status
+ * (see `usb_buf_error`). Input interrupt transfers are periodic, thus
+ * `usb_buf_read` can be called multiple times. */
+static inline void usb_interrupt_transfer(device_t *dev, usb_buf_t *buf,
+                                          usb_direction_t dir, size_t size) {
+  usb_methods(dev->parent)->interrupt_transfer(dev, buf, dir, size);
+}
+
+/* Issues a bulk transfer of direction `dir`, using buffer `buf`.
+ * This is an asynchronous function. In order to receive involved data use
+ * `usb_buf_read`. To wait for the data to be written use `usb_buf_write`.
+ * All encountered errors will be reflected in `buf`'s  error status
+ * (see `usb_buf_error`). */
+static inline void usb_bulk_transfer(device_t *dev, usb_buf_t *buf,
+                                     usb_direction_t dir, size_t size) {
+  usb_methods(dev->parent)->bulk_transfer(dev, buf, dir, size);
+}
+
+/*
+ * USB standard requests interface.
+ *
+ * The following interface provides standard USB requests. Requests used for
+ * device identification and configuration aren't supplied since USB bus
+ * driver identifies and configures each device automatically during enumeration
+ * process. It is suggested to add a new method to this interface instead of
+ * using `usb_control_transfer` request if a need occurs.
+ */
+
+typedef int (*usb_unhalt_endp_t)(device_t *dev, usb_transfer_t transfer,
+                                 usb_direction_t dir);
+
+typedef struct usb_req_methods {
+  usb_unhalt_endp_t unhalt_endp;
+} usb_req_methods_t;
+
+static inline usb_req_methods_t *usb_req_methods(device_t *dev) {
+  return (usb_req_methods_t *)dev->driver->interfaces[DIF_USB_REQ];
+}
+
+/* Unhalts endpoint of device `dev` which implements transfer type `transfer`
+ * with direction `dir`. */
+static inline int usb_unhalt_endp(device_t *dev, usb_transfer_t transfer,
+                                  usb_direction_t dir) {
+  return usb_req_methods(dev->parent)->unhalt_endp(dev, transfer, dir);
+}
+
+/*
+ * USB HID specific standard requests interface.
+ *
+ * The following interface provides standard USB request specific to
+ * HID device class.
+ */
+
+typedef int (*usb_hid_set_idle_t)(device_t *dev);
+typedef int (*usb_hid_set_boot_protocol_t)(device_t *dev);
+
+typedef struct usb_hid_methods {
+  usb_hid_set_idle_t set_idle;
+  usb_hid_set_boot_protocol_t set_boot_protocol;
+} usb_hid_methods_t;
+
+static inline usb_hid_methods_t *usb_hid_methods(device_t *dev) {
+  return (usb_hid_methods_t *)dev->driver->interfaces[DIF_USB_HID];
+}
+
+/* Tells device `dev` to inhibit all reports until a report changes. */
+static inline int usb_hid_set_idle(device_t *dev) {
+  return usb_hid_methods(dev->parent)->set_idle(dev);
+}
+
+/* Sets `dev`'s report format to the boot interface report format. */
+static inline int usb_hid_set_boot_protocol(device_t *dev) {
+  return usb_hid_methods(dev->parent)->set_boot_protocol(dev);
+}
+
+/*
+ * USB Bulk-Only specific standard requests interface.
+ *
+ * The following interface provides standard USB request specific to
+ * devices which rely on the Bulk-Only protocol.
+ * BBB refers Bulk/Bulk/Bulk for Command/Data/Status phases.
+ */
+
+typedef int (*usb_bbb_get_max_lun_t)(device_t *dev, uint8_t *maxlun);
+typedef int (*usb_bbb_reset_t)(device_t *dev);
+
+typedef struct usb_bbb_methods {
+  usb_bbb_get_max_lun_t get_max_lun;
+  usb_bbb_reset_t reset;
+} usb_bbb_methods_t;
+
+static inline usb_bbb_methods_t *usb_bbb_methods(device_t *dev) {
+  return (usb_bbb_methods_t *)dev->driver->interfaces[DIF_USB_BBB];
+}
+
+/* Retrives the maximum Logical Unit Number of device `dev`. */
+static inline int usb_bbb_get_max_lun(device_t *dev, uint8_t *maxlun) {
+  return usb_bbb_methods(dev->parent)->get_max_lun(dev, maxlun);
+}
+
+/* Resets mass storage device `dev`. */
+static inline int usb_bbb_reset(device_t *dev) {
+  return usb_bbb_methods(dev->parent)->reset(dev);
 }
 
 #endif /* _DEV_USB_H_ */

--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -26,6 +26,10 @@ typedef enum {
   DIF_UART,
   DIF_EMMC,
   DIF_USBHC,
+  DIF_USB,
+  DIF_USB_REQ,
+  DIF_USB_HID,
+  DIF_USB_BBB,
   DIF_COUNT /* this must be the last item */
 } drv_if_t;
 
@@ -90,6 +94,7 @@ static inline bool device_bus(device_t *dev) {
 
 device_t *device_alloc(int unit);
 device_t *device_add_child(device_t *parent, int unit);
+void device_remove_child(device_t *parent, int uint);
 int device_probe(device_t *dev);
 int device_attach(device_t *dev);
 int device_detach(device_t *dev);

--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -94,7 +94,6 @@ static inline bool device_bus(device_t *dev) {
 
 device_t *device_alloc(int unit);
 device_t *device_add_child(device_t *parent, int unit);
-void device_remove_child(device_t *parent, int uint);
 int device_probe(device_t *dev);
 int device_attach(device_t *dev);
 int device_detach(device_t *dev);


### PR DESCRIPTION
Introduce USB interfaces to implement by a USB bus driver.
The interfaces include:
- USB standard interface (i.e. standard transfer typed),
- USB standard requests interface,
- USB HID specific standard requests interface,
- USB Bulk-Only specific standard requests interface.

This PR contains changes introduced in #1112.