### PR TITLE
Set window size on shell startup only if it isn't already set

### DIFF
--- a/etc/.kshrc
+++ b/etc/.kshrc
@@ -1,2 +1,4 @@
 export TERM=xterm
-setwinsize
+if [ "$(stty size)" == "0 0" ]; then
+  setwinsize
+fi


### PR DESCRIPTION
This prevent `setwinsize` from running when recording a terminal session with `script`. 
We don't want it to run because if we do, then when playing the session back, the terminal will send us an escape sequence containing the cursor position, but since `setwinsize` isn't actually running (only the recording of its output), the escape sequence gets echoed by the shell after playback is finished, which looks ugly.