### PR TITLE
Add filesystem source support for mount

### DIFF
--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -71,6 +71,7 @@ typedef struct mount {
   vfsops_t *mnt_vfsops;      /* Filesystem operations */
   vfsconf_t *mnt_vfc;        /* Link to filesystem info */
   vnode_t *mnt_vnodecovered; /* The vnode covered by this mount */
+  vnode_t *mnt_source;       /* The source of filesystem's underlying data */
 
   refcnt_t mnt_refcnt; /* Reference count */
   mtx_t mnt_mtx;
@@ -103,11 +104,12 @@ vfsconf_t *vfs_get_by_name(const char *name);
 /* Allocates and initializes a new mount struct, using filesystem vfc, covering
  * vnode v. Does not modify v. Does not insert new mount onto the all mounts
  * list. */
-mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc);
+mount_t *vfs_mount_alloc(vnode_t *vdst, vnode_t *vsrc, vfsconf_t *vfc);
 
-/* Mount a new instance of the filesystem vfc at the vnode v. Does not support
- * remounting. TODO: Additional filesystem-specific arguments. */
-int vfs_domount(vfsconf_t *vfc, vnode_t *v);
+/* Mount a new instance of the filesystem vfc at the vnode vdst. Does not
+ * support remounting. Use vsrc as a source for fs data if not NULL.
+ *TODO: Additional filesystem-specific arguments. */
+int vfs_domount(vfsconf_t *vfc, vnode_t *vdst, vnode_t *vsrc);
 
 #else /* !_KERNEL */
 #include <sys/cdefs.h>

--- a/include/sys/syscallargs.h
+++ b/include/sys/syscallargs.h
@@ -78,6 +78,7 @@ typedef struct {
 } mmap_args_t;
 
 typedef struct {
+  SYSCALLARG(const char *) source;
   SYSCALLARG(const char *) type;
   SYSCALLARG(const char *) path;
 } mount_args_t;

--- a/include/sys/vfs.h
+++ b/include/sys/vfs.h
@@ -105,7 +105,7 @@ int do_futimens(proc_t *p, int fd, timespec_t *times);
 int do_utimensat(proc_t *p, int fd, char *path, timespec_t *times, int flag);
 
 /* Mount a new instance of the filesystem named fs at the requested path. */
-int do_mount(proc_t *p, const char *fs, const char *path);
+int do_mount(proc_t *p, const char *source, const char *fs, const char *path);
 int do_getdents(proc_t *p, int fd, uio_t *uio);
 int do_statvfs(proc_t *p, char *path, statvfs_t *buf);
 int do_fstatvfs(proc_t *p, int fd, statvfs_t *buf);

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -33,9 +33,9 @@
    userspace init program. */
 static void mount_fs(void) {
   proc_t *p = &proc0;
-  do_mount(p, "initrd", "/");
-  do_mount(p, "devfs", "/dev");
-  do_mount(p, "tmpfs", "/tmp");
+  do_mount(p, NULL, "initrd", "/");
+  do_mount(p, NULL, "devfs", "/dev");
+  do_mount(p, NULL, "tmpfs", "/tmp");
   do_fchmodat(p, AT_FDCWD, "/tmp", ACCESSPERMS | S_ISTXT, 0);
 }
 

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -23,7 +23,7 @@
 12  { void *sys_sbrk(intptr_t increment); }
 13  { void *sys_mmap(void *addr, size_t len, int prot, int flags, \
                      int fd, off_t pos); }
-14  { int sys_mount(const char *type, const char *path); }
+14  { int sys_mount(const char *source, const char *type, const char *path); }
 15  { int sys_getdents(int fd, void *buf, size_t len); }
 16  { int sys_dup(int fd); }
 17  { int sys_dup2(int from, int to); }

--- a/sys/kern/sysent.h
+++ b/sys/kern/sysent.h
@@ -107,7 +107,7 @@ struct sysent sysent[] = {
   [SYS_fstat] = { .nargs = 2, .call = (syscall_t *)sys_fstat },
   [SYS_sbrk] = { .nargs = 1, .call = (syscall_t *)sys_sbrk },
   [SYS_mmap] = { .nargs = 6, .call = (syscall_t *)sys_mmap },
-  [SYS_mount] = { .nargs = 2, .call = (syscall_t *)sys_mount },
+  [SYS_mount] = { .nargs = 3, .call = (syscall_t *)sys_mount },
   [SYS_getdents] = { .nargs = 3, .call = (syscall_t *)sys_getdents },
   [SYS_dup] = { .nargs = 1, .call = (syscall_t *)sys_dup },
   [SYS_dup2] = { .nargs = 2, .call = (syscall_t *)sys_dup2 },

--- a/sys/kern/vfs.c
+++ b/sys/kern/vfs.c
@@ -115,7 +115,7 @@ static int vfs_default_init(vfsconf_t *vfc) {
   return 0;
 }
 
-mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc) {
+mount_t *vfs_mount_alloc(vnode_t *vdst, vnode_t *vsrc, vfsconf_t *vfc) {
   mount_t *m = kmalloc(M_VFS, sizeof(mount_t), M_ZERO);
 
   m->mnt_vfc = vfc;
@@ -123,7 +123,8 @@ mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc) {
   vfc->vfc_mountcnt++; /* TODO: vfc_mtx? */
   m->mnt_data = NULL;
 
-  m->mnt_vnodecovered = v;
+  m->mnt_vnodecovered = vdst;
+  m->mnt_source = vsrc;
 
   m->mnt_refcnt = 0;
   mtx_init(&m->mnt_mtx, 0);
@@ -131,24 +132,24 @@ mount_t *vfs_mount_alloc(vnode_t *v, vfsconf_t *vfc) {
   return m;
 }
 
-int vfs_domount(vfsconf_t *vfc, vnode_t *v) {
+int vfs_domount(vfsconf_t *vfc, vnode_t *vdst, vnode_t *vsrc) {
   int error;
 
   /* Start by checking whether this vnode can be used for mounting */
-  if (v->v_type != V_DIR)
+  if (vdst->v_type != V_DIR)
     return ENOTDIR;
-  if (is_mountpoint(v))
+  if (is_mountpoint(vdst))
     return EBUSY;
 
   /* TODO: Mark the vnode is in-progress of mounting? See VI_MOUNT in FreeBSD */
 
-  mount_t *m = vfs_mount_alloc(v, vfc);
+  mount_t *m = vfs_mount_alloc(vdst, vsrc, vfc);
 
   /* Mount the filesystem. */
   if ((error = VFS_MOUNT(m)))
     return error;
 
-  v->v_mountedhere = m;
+  vdst->v_mountedhere = m;
 
   WITH_MTX_LOCK (&mount_list_mtx)
     TAILQ_INSERT_TAIL(&mount_list, m, mnt_list);

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -214,17 +214,19 @@ int do_fstatat(proc_t *p, int fd, char *path, stat_t *sb, int flag) {
   return error;
 }
 
-int do_mount(proc_t *p, const char *fs, const char *path) {
+int do_mount(proc_t *p, const char *source, const char *fs, const char *path) {
   vfsconf_t *vfs;
-  vnode_t *v;
+  vnode_t *vdest, *vsource = NULL;
   int error;
 
   if (!(vfs = vfs_get_by_name(fs)))
     return EINVAL;
-  if ((error = vfs_namelookup(path, &v, &p->p_cred)))
+  if ((error = vfs_namelookup(path, &vdest, &p->p_cred)))
+    return error;
+  if (source && (error = vfs_namelookup(source, &vsource, &p->p_cred)))
     return error;
 
-  return vfs_domount(vfs, v);
+  return vfs_domount(vfs, vdest, vsource);
 }
 
 int do_getdents(proc_t *p, int fd, uio_t *uio) {


### PR DESCRIPTION
Up until now, mounting filestetms required only a filesystem type and a destination path. However, given the incoming block device  support, it will be also necessary to be able to specify the source of filesystem's underlying data in order to be able to mount filesystems that reside on external storage units.