### PR TITLE
dtb: fix absolutely shitty behavior of bootloaders

### DIFF
--- a/sys/kern/dtb.c
+++ b/sys/kern/dtb.c
@@ -5,6 +5,13 @@
 #include <sys/kmem.h>
 #include <sys/vm.h>
 
+/*
+ * offset of dtb on first page that contains device tree blob
+ *
+ * NOTE: dtb can be loaded into middle of page so we need to adjust start of vm
+ * mapping for that page.
+ */
+static uintptr_t _dtb_offset = 0;
 /* root of dtb in va */
 static void *_dtb_root = NULL;
 /* phys addr of dtb_root */
@@ -14,17 +21,18 @@ static size_t _dtb_size = 0;
 
 paddr_t dtb_early_root(void) {
   assert(_dtb_root_pa != 0);
-  return _dtb_root_pa;
+  return _dtb_root_pa + _dtb_offset;
 }
 
 void dtb_early_init(paddr_t dtb, size_t size) {
-  _dtb_root_pa = dtb;
-  _dtb_size = size;
+  _dtb_root_pa = rounddown(dtb, PAGESIZE);
+  _dtb_offset = dtb - _dtb_root_pa;
+  _dtb_size = size + _dtb_offset;
 }
 
 void *dtb_root(void) {
   assert(_dtb_root != NULL);
-  return _dtb_root;
+  return _dtb_root + _dtb_offset;
 }
 
 void dtb_init(void) {


### PR DESCRIPTION
Bootloader can decide to load dtb into middle of random physical page and we need to deal with that inside kernel. For that purpose we can store offset of dtb for first phys page.

- store offset of dtb
- calculate mapping size for dtb including gap at the first page