### PR TITLE
build: keep kernel image after compression

### DIFF
--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -26,5 +26,5 @@ else
 endif
 
 ifeq ($(BOARD), rpi3)
-	KERNEL-IMAGE := mimiker.img.gz
+	KERNEL-IMAGES := mimiker.img mimiker.img.gz
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/config.mk
 SUBDIR = aarch64 drv dts kern libkern mips tests
 KLIB = no
 
-BUILD-FILES += $(KERNEL-IMAGE) mimiker.elf cscope.out etags tags
+BUILD-FILES += $(KERNEL-IMAGES) mimiker.elf cscope.out etags tags
 CLEAN-FILES += mimiker.elf.map
 
 include $(TOPDIR)/build/build.kern.mk
@@ -28,7 +28,7 @@ mimiker.img: mimiker.elf
 
 mimiker.img.gz: mimiker.img
 	@echo "[GZIP] Compress kernel image: $@"
-	$(GZIP) -f $^ > $@
+	$(GZIP) -k -f $^ > $@
 
 # Lists of all files that we consider operating system kernel sources.
 SRCDIRS = $(TOPDIR)/include $(TOPDIR)/sys


### PR DESCRIPTION
r.pi3 doesn't play well with compressed image - let's keep uncompressed version.