### PR TITLE
aarch64/bcopy: remove not aligned access to memory

### DIFF
--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -11,6 +11,8 @@ CLANG_ABIFLAGS := -target aarch64-elf
 ELFTYPE := elf64-littleaarch64
 ELFARCH := aarch64
 
+CPPFLAGS += -DSTRICT_ALIGNMENT=1
+
 ifeq ($(KERNEL), 1)
 	CFLAGS += -mcpu=cortex-a53+nofp -march=armv8-a+nofp -mgeneral-regs-only
 	ifeq ($(KASAN), 1)

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -12,9 +12,9 @@ ELFTYPE := elf64-littleaarch64
 ELFARCH := aarch64
 
 # NOTE(pj): We set A, SA, SA0 bits for SCTLR_EL1 register (sys/aarch64/boot.c)
-# as a result not aligned access to memory causes exception. It's okay but
-# user-space (stolen from NetBSD) doesn't care about that by default. It
-# requies STRICT_ALIGNMENT to be defined. It's also important for kernel
+# as a result not aligned access to memory causes an exception. It's okay but
+# user-space (taken from NetBSD) doesn't care about that by default. It
+# requies STRICT_ALIGNMENT to be defined. It's also important for the kernel
 # because we share bcopy (memcpy) implementation with user-space.
 CPPFLAGS += -DSTRICT_ALIGNMENT=1
 

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -11,6 +11,11 @@ CLANG_ABIFLAGS := -target aarch64-elf
 ELFTYPE := elf64-littleaarch64
 ELFARCH := aarch64
 
+# NOTE(pj): We set A, SA, SA0 bits for SCTLR_EL1 register (sys/aarch64/boot.c)
+# as a result not aligned access to memory causes exception. It's okay but
+# user-space (stolen from NetBSD) doesn't care about that by default. It
+# requies STRICT_ALIGNMENT to be defined. It's also important for kernel
+# because we share bcopy (memcpy) implementation with user-space.
 CPPFLAGS += -DSTRICT_ALIGNMENT=1
 
 ifeq ($(KERNEL), 1)


### PR DESCRIPTION
bcopy: remove not alignment access to memory for AArch64.

Fixes #1097.