### PR TITLE
Timer stop & start functions fix

### DIFF
--- a/include/sys/timer.h
+++ b/include/sys/timer.h
@@ -81,9 +81,6 @@ int tm_stop(timer_t *tm);
 /*! \brief Used by interrupt filter routine to trigger a callback. */
 void tm_trigger(timer_t *tm);
 
-/*! \brief Select timer used as a main time source (for binuptime, etc.) */
-void tm_select(timer_t *tm);
-
 #endif /* !_KERNEL */
 
 #endif /* !_SYS_TIMER_H_ */

--- a/sys/aarch64/timer.c
+++ b/sys/aarch64/timer.c
@@ -86,8 +86,7 @@ static int arm_timer_attach(device_t *dev) {
   state->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
 
   tm_register(&state->timer);
-  tm_select(&state->timer);
-
+  
   bus_intr_setup(dev, state->irq_res, arm_timer_intr, NULL, dev,
                  "ARM CPU timer");
 

--- a/sys/aarch64/timer.c
+++ b/sys/aarch64/timer.c
@@ -86,7 +86,7 @@ static int arm_timer_attach(device_t *dev) {
   state->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
 
   tm_register(&state->timer);
-  
+
   bus_intr_setup(dev, state->irq_res, arm_timer_intr, NULL, dev,
                  "ARM CPU timer");
 

--- a/sys/kern/time.c
+++ b/sys/kern/time.c
@@ -128,7 +128,7 @@ time_t tm2sec(tm_t *t) {
   const int32_t year_scale_s = 31536000, day_scale_s = 86400,
                 hour_scale_s = 3600, min_scale_s = 60;
   time_t res = 0;
-  static const int month_in_days[13] = {0,   31,  59,  90,  120, 151,
+  static const int month_in_days[12] = {0,   31,  59,  90,  120, 151,
                                         181, 212, 243, 273, 304, 334};
 
   res += (time_t)month_in_days[t->tm_mon] * day_scale_s;

--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -169,10 +169,6 @@ void tm_trigger(timer_t *tm) {
   tm->tm_event_cb(tm, tm->tm_arg);
 }
 
-void tm_select(timer_t *tm) {
-  time_source = tm;
-}
-
 bintime_t binuptime(void) {
   /* XXX: probably a race condition here */
   timer_t *tm = time_source;

--- a/sys/mips/timer.c
+++ b/sys/mips/timer.c
@@ -52,7 +52,7 @@ static int set_next_tick(mips_timer_state_t *state) {
   /* calculate next value of compare register based on timer period */
   do {
     state->compare.val += state->period_cntr;
-    mips32_set_c0(C0_COMPARE, state->compare.lo);
+    mips32_setcompare(state->compare.lo);
     (void)read_count(state);
     ticks++;
   } while (state->compare.val <= state->count.val);
@@ -74,26 +74,17 @@ static int mips_timer_start(timer_t *tm, unsigned flags, const bintime_t start,
   assert(flags & TMF_PERIODIC);
   assert(!(flags & TMF_ONESHOT));
 
-  mips32_setcount(0);
-
   device_t *dev = tm->tm_priv;
   mips_timer_state_t *state = dev->state;
-  state->sec = 0;
-  state->cntr_modulo = 0;
-  state->last_count_lo = 0;
   state->period_cntr = bintime_mul(period, tm->tm_frequency).sec;
   state->compare.val = read_count(state);
 
   set_next_tick(state);
-  bus_intr_setup(dev, state->irq_res, mips_timer_intr, NULL, dev,
-                 "MIPS CPU timer");
   return 0;
 }
 
-static int mips_timer_stop(timer_t *tm) {
-  device_t *dev = tm->tm_priv;
-  mips_timer_state_t *state = dev->state;
-  bus_intr_teardown(dev, state->irq_res);
+static inline int mips_timer_stop(timer_t *tm) {
+  mips32_setcompare(0xffffffff);
   return 0;
 }
 
@@ -119,7 +110,14 @@ static int mips_timer_probe(device_t *dev) {
 static int mips_timer_attach(device_t *dev) {
   mips_timer_state_t *state = dev->state;
 
+  mips32_setcount(0);
+
+  state->sec = 0;
+  state->cntr_modulo = 0;
+  state->last_count_lo = 0;
   state->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
+
+  mips_timer_stop(&state->timer);
 
   state->timer = (timer_t){
     .tm_name = "mips-cpu-timer",
@@ -135,6 +133,9 @@ static int mips_timer_attach(device_t *dev) {
   };
 
   tm_register(&state->timer);
+
+  bus_intr_setup(dev, state->irq_res, mips_timer_intr, NULL, dev,
+                 "MIPS CPU timer");
 
   return 0;
 }


### PR DESCRIPTION
We want to set up the interrupts while attaching a timer and eventually stop it from invoking interrupts.
Removing unnecessary function `tm_select` (choosing time source is doing while setting up timers in clock.c).
Typo in rtc.c.