### PR TITLE
Kgmon fix

### DIFF
--- a/sys/debug/kgmon.py
+++ b/sys/debug/kgmon.py
@@ -32,9 +32,10 @@ def gmon_write(path):
         size = calcsize(tos_rep)
         tos_array = unpack(tos_rep * int(gparam.tossize/size), memory)
 
-        fromindex = 0
+        fromindex = -1
         froms_el_size = int(gdb.parse_and_eval('sizeof(*_gmonparam.froms)'))
         for from_val in froms_array:
+            fromindex += 1
             # Nothing has been called from this function
             if from_val == 0:
                 continue
@@ -50,7 +51,6 @@ def gmon_write(path):
                 count = tos_array[toindex * tos_rep_len + 1]
                 toindex = tos_array[toindex * tos_rep_len + 2]
                 of.write(pack('IIi', frompc, selfpc, count))
-            fromindex += 1
 
 
 class Kgmon(SimpleCommand):


### PR DESCRIPTION
Fixing omitting incrementing index while the from_val value is 0.
Fromindex is a hash for a function (the caller) it invoked other functions (callee) stored in to_struct.
Not incrementing the fromindex for functions, which didn't call a function (`from_val == 0`) will assign the called functions to the previous hashes - the call graph is not reliable.