### PR TITLE
Toolchain: bump binutils & gcc, remove x86

### DIFF
--- a/toolchain/gnu/config.mk
+++ b/toolchain/gnu/config.mk
@@ -1,6 +1,6 @@
 # vim: tabstop=8 shiftwidth=8 noexpandtab list:
 
-VERSION = 1.5.1
+VERSION = 1.5.2
 
 # Libraries required to build the toolchain.
 ISL = isl-0.18
@@ -10,8 +10,8 @@ MPC = mpc-1.1.0
 CLOOG = cloog-0.18.4
 
 # The toolchain is comprised of following packages:
-BINUTILS = binutils-2.35
-GCC = gcc-11.1.0
+BINUTILS = binutils-2.37
+GCC = gcc-11.2.0
 GDB = gdb-10.2
 
 ISL-URL = "http://isl.gforge.inria.fr/$(ISL).tar.xz"
@@ -23,4 +23,4 @@ BINUTILS-URL = "https://ftp.gnu.org/gnu/binutils/$(BINUTILS).tar.xz"
 GCC-URL = "https://ftp.gnu.org/gnu/gcc/$(GCC)/$(GCC).tar.xz"
 GDB-URL = "https://ftp.gnu.org/gnu/gdb/$(GDB).tar.xz"
 
-TARGETS = mipsel aarch64 amd64
+TARGETS = mipsel aarch64

--- a/toolchain/qemu-mimiker/Makefile
+++ b/toolchain/qemu-mimiker/Makefile
@@ -44,7 +44,7 @@ configure-stamp: patch-stamp
 		--disable-bzip2 \
 		--disable-tpm \
 		--disable-linux-aio \
-	    	--target-list=mipsel-softmmu,aarch64-softmmu,x86_64-softmmu \
+	    	--target-list=mipsel-softmmu,aarch64-softmmu \
 		--with-suffix=qemu-mimiker
 	touch $@
 
@@ -58,8 +58,7 @@ install-stamp: build-stamp
 	cd qemu-build && make install DESTDIR=$(PWD)/debian/tmp
 	cd $(PWD)/debian/tmp && \
 	mv usr/bin/qemu-system-mipsel usr/bin/qemu-mimiker-mipsel && \
-	    mv usr/bin/qemu-system-aarch64 usr/bin/qemu-mimiker-aarch64 && \
-	    mv usr/bin/qemu-system-x86_64 usr/bin/qemu-mimiker-x86_64
+	mv usr/bin/qemu-system-aarch64 usr/bin/qemu-mimiker-aarch64 && \
 	touch $@
 
 binary: binary-stamp


### PR DESCRIPTION
* New toolchain version - 1.5.2
* Update gcc to 11.2.0
* Update binutils to 2.37
* Remove support to x86

x86 toolchain is not used by Mimiker since we don't support that architecture - let's remove support for that toolchain and reduce complexity and build time of tools.

Signed-off-by: Paweł Jasiak <pawel@jasiak.dev>