### PR TITLE
Install etc/shells in sysroot.

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -2,7 +2,7 @@
 
 TOPDIR = $(realpath ..)
 
-FILES = group master.passwd .kshrc
+FILES = group master.passwd .kshrc shells
 INSTALL-FILES = $(addprefix $(SYSROOT)/etc/, $(FILES))
 
 all: build


### PR DESCRIPTION
`mimiker/etc/shells` should be copied to `sysroot/etc` along with the other files from this directory.