### PR TITLE
Delete PMAP_* boundaries and use defines from vm_params instead.

### DIFF
--- a/include/aarch64/pmap.h
+++ b/include/aarch64/pmap.h
@@ -11,12 +11,6 @@ typedef struct pmap pmap_t;
 /* Number of page table entries. */
 #define PT_ENTRIES (PAGESIZE / (int)sizeof(pte_t))
 
-#define PMAP_KERNEL_BEGIN 0xffff000000000000L
-#define PMAP_KERNEL_END 0xffffffffffffffffL
-
-#define PMAP_USER_BEGIN 0x0000000000400000L
-#define PMAP_USER_END 0x0000800000000000L
-
 /* XXX Raspberry PI 3 specific! */
 #define DMAP_SIZE 0x3c000000
 #define DMAP_BASE 0xffffff8000000000 /* last 512GB */

--- a/include/mips/pmap.h
+++ b/include/mips/pmap.h
@@ -41,12 +41,7 @@ static_assert(PT_ENTRIES == 1 << 10,
 
 /* Base addresses of active user and kernel page directory tables.
  * UPD_BASE must begin at 8KiB boundary. */
-#define UPD_BASE (PMAP_KERNEL_END + PAGESIZE * 0)
-#define KPD_BASE (PMAP_KERNEL_END + PAGESIZE * 1)
-
-#define PMAP_KERNEL_BEGIN 0xc0000000 /* kseg2 & kseg3 */
-#define PMAP_KERNEL_END 0xffffe000
-#define PMAP_USER_BEGIN 0x00001000
-#define PMAP_USER_END 0x80000000
+#define UPD_BASE (KERNEL_SPACE_END + PAGESIZE * 0)
+#define KPD_BASE (KERNEL_SPACE_END + PAGESIZE * 1)
 
 #endif /* !_MIPS_PMAP_H_ */

--- a/sys/aarch64/pmap.c
+++ b/sys/aarch64/pmap.c
@@ -93,19 +93,19 @@ static MTX_DEFINE(pv_list_lock, 0);
  * Helper functions.
  */
 static bool user_addr_p(vaddr_t addr) {
-  return (addr >= PMAP_USER_BEGIN) && (addr < PMAP_USER_END);
+  return (addr >= USER_SPACE_BEGIN) && (addr < USER_SPACE_END);
 }
 
 static bool kern_addr_p(vaddr_t addr) {
-  return (addr >= PMAP_KERNEL_BEGIN) && (addr < PMAP_KERNEL_END);
+  return (addr >= KERNEL_SPACE_BEGIN) && (addr < KERNEL_SPACE_END);
 }
 
 inline vaddr_t pmap_start(pmap_t *pmap) {
-  return pmap->asid ? PMAP_USER_BEGIN : PMAP_KERNEL_BEGIN;
+  return pmap->asid ? USER_SPACE_BEGIN : KERNEL_SPACE_BEGIN;
 }
 
 inline vaddr_t pmap_end(pmap_t *pmap) {
-  return pmap->asid ? PMAP_USER_END : PMAP_KERNEL_END;
+  return pmap->asid ? USER_SPACE_END : KERNEL_SPACE_END;
 }
 
 inline bool pmap_address_p(pmap_t *pmap, vaddr_t va) {

--- a/sys/mips/pmap.c
+++ b/sys/mips/pmap.c
@@ -77,19 +77,19 @@ static inline pte_t empty_pte(pmap_t *pmap) {
 }
 
 static bool user_addr_p(vaddr_t addr) {
-  return (addr >= PMAP_USER_BEGIN) && (addr < PMAP_USER_END);
+  return (addr >= USER_SPACE_BEGIN) && (addr < USER_SPACE_END);
 }
 
 static bool kern_addr_p(vaddr_t addr) {
-  return (addr >= PMAP_KERNEL_BEGIN) && (addr < PMAP_KERNEL_END);
+  return (addr >= KERNEL_SPACE_BEGIN) && (addr < KERNEL_SPACE_END);
 }
 
 inline vaddr_t pmap_start(pmap_t *pmap) {
-  return pmap->asid ? PMAP_USER_BEGIN : PMAP_KERNEL_BEGIN;
+  return pmap->asid ? USER_SPACE_BEGIN : KERNEL_SPACE_BEGIN;
 }
 
 inline vaddr_t pmap_end(pmap_t *pmap) {
-  return pmap->asid ? PMAP_USER_END : PMAP_KERNEL_END;
+  return pmap->asid ? USER_SPACE_END : KERNEL_SPACE_END;
 }
 
 inline bool pmap_address_p(pmap_t *pmap, vaddr_t va) {


### PR DESCRIPTION
pmap.h files define `PMAP_*` boundaries for user and kernel address spaces but these values are already defined (and used by the `vm_map` module) in vm_params.h.