### PR TITLE
Do not use kernel translation tables to resolve user VM addresses.

### DIFF
--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -36,6 +36,7 @@ static POOL_DEFINE(P_VM_MAPENT, "vm_map_entry", sizeof(vm_map_entry_t));
 static vm_map_t *kspace = &(vm_map_t){};
 
 void vm_map_activate(vm_map_t *map) {
+  assert(map != kspace);
   SCOPED_NO_PREEMPTION();
 
   PCPU_SET(uspace, map);

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -108,7 +108,6 @@ static void vm_map_setup(vm_map_t *map) {
 void init_vm_map(void) {
   vm_map_setup(kspace);
   kspace->pmap = pmap_kernel();
-  vm_map_activate(kspace);
 }
 
 vm_map_t *vm_map_new(void) {


### PR DESCRIPTION
If we invoke `vm_map_activate` for kernel VM map, we will effectively start translating user VM accesses using kernel translation tables. `vm_map_activate` should be only invoked for user VM maps (during ctx switch). (Nevertheless, it is feasible to use kernel translation tables for user virtual memory at the very first steps of the kernel (when switching form physical memory to virtual memory (see e.g. AArch64 boot.c) by directly manipulating MSRs. But `vm_map_activate` is meant to be invoked much later.)