### PR TITLE
Do not double timers on the timers list.

### DIFF
--- a/sys/kern/timer.c
+++ b/sys/kern/timer.c
@@ -99,10 +99,8 @@ int tm_release(timer_t *tm) {
   if (is_active(tm))
     return EBUSY;
 
-  WITH_MTX_LOCK (&timers_mtx) {
-    TAILQ_INSERT_TAIL(&timers, tm, tm_link);
+  WITH_MTX_LOCK (&timers_mtx)
     tm->tm_flags &= ~(TMF_INITIALIZED | TMF_RESERVED);
-  }
 
   return 0;
 }


### PR DESCRIPTION
In `tm_release`, there's no need to insert a timer to `timers` as the timer hasn't been removed yet.
A timer is removed from `timers` only upon deregistration.