### PR TITLE
Process kernel linker scripts using CPP.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 *.img
 *.img.gz
 
+# Kernel linker script
+kernel.ld
+
 # Ramdisk
 *.cpio
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@
 *.img
 *.img.gz
 
-# Kernel linker script
-kernel.ld
-
 # Ramdisk
 *.cpio
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -58,6 +58,10 @@ assym.h: genassym.cf
 	@echo "[ASSYM] $(DSTPATH)"
 	$(GENASSYM) $(CC) $(ASSYM_CFLAGS) $(CFLAGS) $(CPPFLAGS) < $^ > $@
 
+%.ld: %.ld.in
+	@echo "[CPP] $(DIR)$< -> $(DIR)$@"
+	$(CPP) $(CPPFLAGS) -I$(TOPDIR)/include -P -o $@ $<
+
 include $(TOPDIR)/config.mk
 include $(TOPDIR)/build/arch.$(ARCH).mk
 include $(TOPDIR)/build/tools.mk

--- a/build/common.mk
+++ b/build/common.mk
@@ -59,7 +59,7 @@ assym.h: genassym.cf
 	$(GENASSYM) $(CC) $(ASSYM_CFLAGS) $(CFLAGS) $(CPPFLAGS) < $^ > $@
 
 %.ld: %.ld.in
-	@echo "[CPP] $(DIR)$< -> $(DIR)$@"
+	@echo "[CPP] $(SRCPATH) -> $(DSTPATH)"
 	$(CPP) $(CPPFLAGS) -I$(TOPDIR)/include -P -o $@ $<
 
 include $(TOPDIR)/config.mk

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -33,7 +33,7 @@ endif
 CC       = $(TARGET_CC)
 AS       = $(TARGET_CC)
 LD       = $(TARGET)-gcc $(GCC_ABIFLAGS) -g
-CPP      = $(TARGET)-gcc -E
+CPP      = $(TARGET)-cpp
 AR       = $(TARGET)-ar
 NM       = $(TARGET)-nm
 GDB      = $(TARGET)-gdb

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -33,6 +33,7 @@ endif
 CC       = $(TARGET_CC)
 AS       = $(TARGET_CC)
 LD       = $(TARGET)-gcc $(GCC_ABIFLAGS) -g
+CPP      = $(TARGET)-gcc -E
 AR       = $(TARGET)-ar
 NM       = $(TARGET)-nm
 GDB      = $(TARGET)-gdb

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -12,22 +12,14 @@ CLEAN-FILES += mimiker.elf.map
 
 include $(TOPDIR)/build/build.kern.mk
 
-LDFLAGS += -T $(TOPDIR)/sys/kernel.ld
+LDSCRIPT = $(TOPDIR)/sys/$(ARCH)/$(ARCH).ld
+LDFLAGS += -T $(LDSCRIPT)
 LDLIBS	= -Wl,--start-group \
 	    -Wl,--whole-archive $(KLIBLIST) -Wl,--no-whole-archive \
             -lgcc \
           -Wl,--end-group
 
-kernel.ld: $(ARCH)/$(ARCH).ld
-	@echo "[CPP] $(DIR)$< -> $(DIR)$@"
-ifeq ($(CPPLDSCRIPT), 1)
-	$(CPP) $(CPPFLAGS) -I$(TOPDIR)/include $< | grep -v '^#' | \
-		grep -v '^$$' > $@
-else
-	$(CP) $< $@
-endif
-
-mimiker.elf: $(KLIBDEPS) kernel.ld
+mimiker.elf: $(KLIBDEPS) $(LDSCRIPT)
 	@echo "[LD] Linking kernel image: $@"
 	$(LD) $(LDFLAGS) -Wl,-Map=$@.map $(LDLIBS) -o $@
 
@@ -57,4 +49,4 @@ etags tags:
 	$(CTAGS) --language-force=asm -aef etags $(SRCFILES_ASM)
 
 BUILD-FILES += cscope.out etags tags
-CLEAN-FILES += *.taghl kernel.ld
+CLEAN-FILES += *.taghl

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -12,8 +12,8 @@ CLEAN-FILES += mimiker.elf.map
 
 include $(TOPDIR)/build/build.kern.mk
 
-LDSCRIPT = $(TOPDIR)/sys/$(ARCH)/$(ARCH).ld
-LDFLAGS += -T $(LDSCRIPT)
+LDSCRIPT = $(ARCH)/$(ARCH).ld
+LDFLAGS += -T $(TOPDIR)/sys/$(LDSCRIPT)
 LDLIBS	= -Wl,--start-group \
 	    -Wl,--whole-archive $(KLIBLIST) -Wl,--no-whole-archive \
             -lgcc \

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -12,13 +12,22 @@ CLEAN-FILES += mimiker.elf.map
 
 include $(TOPDIR)/build/build.kern.mk
 
-LDFLAGS += -T $(TOPDIR)/sys/$(ARCH)/$(ARCH).ld
+LDFLAGS += -T $(TOPDIR)/sys/kernel.ld
 LDLIBS	= -Wl,--start-group \
 	    -Wl,--whole-archive $(KLIBLIST) -Wl,--no-whole-archive \
             -lgcc \
           -Wl,--end-group
 
-mimiker.elf: $(KLIBDEPS)
+kernel.ld: $(ARCH)/$(ARCH).ld
+	@echo "[CPP] $(DIR)$< -> $(DIR)$@"
+ifeq ($(CPPLDSCRIPT), 1)
+	$(CPP) $(CPPFLAGS) -I$(TOPDIR)/include $< | grep -v '^#' | \
+		grep -v '^$$' > $@
+else
+	$(CP) $< $@
+endif
+
+mimiker.elf: $(KLIBDEPS) kernel.ld
 	@echo "[LD] Linking kernel image: $@"
 	$(LD) $(LDFLAGS) -Wl,-Map=$@.map $(LDLIBS) -o $@
 
@@ -48,4 +57,4 @@ etags tags:
 	$(CTAGS) --language-force=asm -aef etags $(SRCFILES_ASM)
 
 BUILD-FILES += cscope.out etags tags
-CLEAN-FILES += *.taghl
+CLEAN-FILES += *.taghl kernel.ld


### PR DESCRIPTION
Required by #1176.

We would like to support several (RISC-V, platform) setups having a single linker script for the kernel. To achieve this goal we can parametrize linker scripts whit constants exposed by genassym (see http://bxr.su/NetBSD/sys/arch/riscv/conf/kern.ldscript).