### PR TITLE
[USB] Build bus driver unconditionally.

### DIFF
--- a/sys/drv/Makefile
+++ b/sys/drv/Makefile
@@ -4,7 +4,8 @@ TOPDIR = $(realpath ../..)
 
 SOURCES = \
 	dev_cons.c \
-	uart.c
+	uart.c \
+	usb.c
 
 SOURCES-MIPS = \
 	82371AB.c \
@@ -23,8 +24,7 @@ SOURCES-MIPS = \
 	pit.c \
 	stdvga.c \
 	uart_cbus.c \
-	uhci.c \
-	usb.c
+	uhci.c
 
 SOURCES-AARCH64 = \
 	bcm2835_gpio.c \


### PR DESCRIPTION
USB bus driver should be build unconditionally as we assume all boards to support it.