### PR TITLE
[DEV] Remove redundant argument from root interrupt handler.

### DIFF
--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -85,9 +85,9 @@ intr_handler_t *intr_event_add_handler(intr_event_t *ie, ih_filter_t *filter,
 void intr_event_remove_handler(intr_handler_t *ih);
 void intr_event_run_handlers(intr_event_t *ie);
 
-typedef void (*intr_root_filter_t)(ctx_t *ctx, device_t *dev, void *arg);
+typedef void (*intr_root_filter_t)(ctx_t *ctx, device_t *dev);
 
-void intr_root_claim(intr_root_filter_t filter, device_t *dev, void *arg);
+void intr_root_claim(intr_root_filter_t filter, device_t *dev);
 void intr_root_handler(ctx_t *ctx) __no_profile;
 
 #endif /* !_SYS_INTERRUPT_H_ */

--- a/sys/drv/bcm2835_rootdev.c
+++ b/sys/drv/bcm2835_rootdev.c
@@ -168,7 +168,7 @@ static void bcm2835_intr_handle(bus_space_handle_t irq_base, bus_size_t offset,
   }
 }
 
-static void rootdev_intr_handler(ctx_t *ctx, device_t *dev, void *arg) {
+static void rootdev_intr_handler(ctx_t *ctx, device_t *dev) {
   assert(dev != NULL);
   rootdev_t *rd = dev->state;
 
@@ -215,7 +215,7 @@ static int rootdev_attach(device_t *bus) {
     kmem_map_contig(BCM2835_PERIPHERALS_BUS_TO_PHYS(BCM2835_ARM_BASE),
                     BCM2835_ARM_SIZE, PMAP_NOCACHE);
 
-  intr_root_claim(rootdev_intr_handler, bus, NULL);
+  intr_root_claim(rootdev_intr_handler, bus);
 
   device_t *dev;
 

--- a/sys/drv/malta_rootdev.c
+++ b/sys/drv/malta_rootdev.c
@@ -113,7 +113,7 @@ static void rootdev_deactivate_resource(device_t *dev, resource_t *r) {
   /* TODO: unmap mapped resources. */
 }
 
-static void rootdev_intr_handler(ctx_t *ctx, device_t *dev, void *arg) {
+static void rootdev_intr_handler(ctx_t *ctx, device_t *dev) {
   rootdev_t *rd = dev->state;
   unsigned pending = (_REG(ctx, CAUSE) & _REG(ctx, SR)) & CR_IP_MASK;
 
@@ -144,7 +144,7 @@ static int rootdev_attach(device_t *bus) {
   rman_init(&rd->irq, "MIPS interrupts");
   rman_manage_region(&rd->irq, 0, MIPS_NIRQ);
 
-  intr_root_claim(rootdev_intr_handler, bus, NULL);
+  intr_root_claim(rootdev_intr_handler, bus);
 
   /* Create MIPS timer device and assign resources to it. */
   device_t *dev = device_add_child(bus, 0);

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -156,14 +156,12 @@ void intr_event_remove_handler(intr_handler_t *ih) {
 
 static intr_root_filter_t ir_filter;
 static device_t *ir_dev;
-static void *ir_arg;
 
-void intr_root_claim(intr_root_filter_t filter, device_t *dev, void *arg) {
+void intr_root_claim(intr_root_filter_t filter, device_t *dev) {
   assert(filter != NULL);
 
   ir_filter = filter;
   ir_dev = dev;
-  ir_arg = arg;
 }
 
 __no_profile void intr_root_handler(ctx_t *ctx) {
@@ -179,7 +177,7 @@ __no_profile void intr_root_handler(ctx_t *ctx) {
   /* Explicitely disallow switching out to another thread. */
   PCPU_SET(no_switch, true);
   if (ir_filter != NULL)
-    ir_filter(ctx, ir_dev, ir_arg);
+    ir_filter(ctx, ir_dev);
   PCPU_SET(no_switch, false);
 
   /* If filter routine requested a context switch it's now time to handle it. */


### PR DESCRIPTION
`intr_root_filter` routine contains a redundant argument `arg`. It's completely needless (and not used) as a rootdev driver can pass any needed data through its state (accessed through `driver_t` structure).