### PR TITLE
[klog] fix klog format for tid_t

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -827,7 +827,7 @@ void proc_stop(signo_t sig) {
   assert(mtx_owned(&p->p_lock));
   assert(p->p_state == PS_NORMAL);
 
-  klog("Stopping thread %lu in process PID(%d)", td->td_tid, p->p_pid);
+  klog("Stopping thread %u in process PID(%d)", td->td_tid, p->p_pid);
   p->p_stopsig = sig;
   p->p_state = PS_STOPPED;
   p->p_flags |= PF_STATE_CHANGED;
@@ -857,7 +857,7 @@ void proc_continue(proc_t *p) {
   assert(mtx_owned(&p->p_lock));
   assert(p->p_state == PS_STOPPED);
 
-  klog("Continuing thread %lu in process PID(%d)", td->td_tid, p->p_pid);
+  klog("Continuing thread %u in process PID(%d)", td->td_tid, p->p_pid);
 
   p->p_state = PS_NORMAL;
   p->p_flags |= PF_STATE_CHANGED;

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -503,7 +503,7 @@ void sig_post(ksiginfo_t *ksi) {
 
   assert(handler != SIG_IGN);
 
-  klog("Post signal %s (handler %p) to thread %lu in process PID(%d)",
+  klog("Post signal %s (handler %p) to thread %u in process PID(%d)",
        sig_name[sig], handler, td->td_tid, p->p_pid);
 
   sigset_t *return_mask;

--- a/sys/kern/sleepq.c
+++ b/sys/kern/sleepq.c
@@ -116,7 +116,7 @@ static void sq_enter(thread_t *td, sleepq_chain_t *sc, void *wchan,
   assert(sc_owned(sc));
   assert(spin_owned(td->td_lock));
 
-  klog("Thread %ld goes to sleep on %p at pc=%p", td->td_tid, wchan, waitpt);
+  klog("Thread %u goes to sleep on %p at pc=%p", td->td_tid, wchan, waitpt);
 
   assert(td->td_wchan == NULL);
   assert(td->td_waitpt == NULL);
@@ -154,7 +154,7 @@ static void sq_enter(thread_t *td, sleepq_chain_t *sc, void *wchan,
 }
 
 static void sq_leave(thread_t *td, sleepq_chain_t *sc, sleepq_t *sq) {
-  klog("Wakeup thread %ld from %p at pc=%p", td->td_tid, td->td_wchan,
+  klog("Wakeup thread %u from %p at pc=%p", td->td_tid, td->td_wchan,
        td->td_waitpt);
 
   assert(sc_owned(sc));

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -105,7 +105,7 @@ thread_t *thread_create(const char *name, void (*fn)(void *), void *arg,
   WITH_MTX_LOCK (&threads_lock)
     TAILQ_INSERT_TAIL(&all_threads, td, td_all);
 
-  klog("Thread %ld {%p} has been created", td->td_tid, td);
+  klog("Thread %u {%p} has been created", td->td_tid, td);
 
   return td;
 }
@@ -115,7 +115,7 @@ void thread_delete(thread_t *td) {
   assert(td->td_sleepqueue != NULL);
   assert(td->td_turnstile != NULL);
 
-  klog("Freeing up thread %ld {%p}", td->td_tid, td);
+  klog("Freeing up thread %u {%p}", td->td_tid, td);
 
   WITH_MTX_LOCK (&threads_lock)
     TAILQ_REMOVE(&all_threads, td, td_all);
@@ -145,7 +145,7 @@ __no_profile __no_kcsan_sanitize thread_t *thread_self(void) {
 __noreturn void thread_exit(void) {
   thread_t *td = thread_self();
 
-  klog("Thread %ld {%p} has finished", td->td_tid, td);
+  klog("Thread %u {%p} has finished", td->td_tid, td);
 
   /* Thread must not exit while having interrupts disabled! However, we can't
    * use assert here, because assert also calls thread_exit. Thus, in case this
@@ -180,7 +180,7 @@ __noreturn void thread_exit(void) {
 void thread_join(thread_t *otd) {
   thread_t *td = thread_self();
 
-  klog("Join %ld {%p} with %ld {%p}", td->td_tid, td, otd->td_tid, otd);
+  klog("Join %u {%p} with %u {%p}", td->td_tid, td, otd->td_tid, otd);
 
   WITH_SPIN_LOCK (otd->td_lock) {
     while (!td_is_dead(otd))


### PR DESCRIPTION
`tid_t` is `uint32_t` aka `unsigned int` which uses `%u` as specifier for `printf`-like functions.