### PR TITLE
[thread] introduce dedicated functions for locks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -48,7 +48,7 @@ ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ TAILQ_FOREACH, SPLAY_FOREACH, RB_FOREACH, WITH_MTX_LOCK,
                    WITH_SPIN_LOCK, WITH_RW_LOCK, SET_FOREACH, LIST_FOREACH,
                    TAILQ_FOREACH_REVERSE, TAILQ_FOREACH_SAFE,
-                   LIST_FOREACH_SAFE, WITH_VM_MAP_LOCK ]
+                   LIST_FOREACH_SAFE, WITH_VM_MAP_LOCK, WITH_THREAD_LOCK ]
 IncludeCategories: 
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2

--- a/include/sys/thread.h
+++ b/include/sys/thread.h
@@ -214,6 +214,26 @@ void thread_reap(void);
  * Must be called with acquired td_lock. */
 void thread_continue(thread_t *td);
 
+/*
+ * Acquire td::td_lock
+ */
+void thread_lock(thread_t *td);
+
+/*
+ * Release td::td_lock
+ */
+void thread_unlock(thread_t *td);
+
+DEFINE_CLEANUP_FUNCTION(thread_t *, thread_unlock);
+
+#define WITH_THREAD_LOCK(td)                                                   \
+  WITH_STMT(thread_t, thread_lock, CLEANUP_FUNCTION(thread_unlock), td)
+
+/*
+ * Return true if td::td_lock is owned by caller.
+ */
+bool thread_owned(thread_t *td);
+
 /* Please use following functions to read state of a thread! */
 static inline bool td_is_ready(thread_t *td) {
   return td->td_state == TDS_READY;

--- a/sys/kern/exception.c
+++ b/sys/kern/exception.c
@@ -15,7 +15,7 @@ void on_exc_leave(void) {
 
   thread_t *td = thread_self();
   if (td->td_flags & TDF_NEEDSWITCH) {
-    spin_lock(td->td_lock);
+    thread_lock(td);
     td->td_state = TDS_READY;
     sched_switch();
   }

--- a/sys/kern/sched.c
+++ b/sys/kern/sched.c
@@ -25,12 +25,12 @@ void init_sched(void) {
 void sched_add(thread_t *td) {
   klog("Add thread %ld {%p} to scheduler", td->td_tid, td);
 
-  WITH_SPIN_LOCK (td->td_lock)
+  WITH_THREAD_LOCK (td)
     sched_wakeup(td, 0);
 }
 
 void sched_wakeup(thread_t *td, long reason) {
-  assert(spin_owned(td->td_lock));
+  assert(thread_owned(td));
   assert(td != thread_self());
   assert(!td_is_running(td));
 
@@ -57,7 +57,7 @@ void sched_wakeup(thread_t *td, long reason) {
  * \note Must be called with \a td_spin acquired!
  */
 static void sched_set_active_prio(thread_t *td, prio_t prio) {
-  assert(spin_owned(td->td_lock));
+  assert(thread_owned(td));
 
   if (prio_eq(td->td_prio, prio))
     return;
@@ -73,7 +73,7 @@ static void sched_set_active_prio(thread_t *td, prio_t prio) {
 }
 
 void sched_set_prio(thread_t *td, prio_t prio) {
-  assert(spin_owned(td->td_lock));
+  assert(thread_owned(td));
 
   td->td_base_prio = prio;
 
@@ -91,7 +91,7 @@ void sched_set_prio(thread_t *td, prio_t prio) {
 }
 
 void sched_lend_prio(thread_t *td, prio_t prio) {
-  assert(spin_owned(td->td_lock));
+  assert(thread_owned(td));
   assert(prio_lt(td->td_prio, prio));
 
   td->td_flags |= TDF_BORROWING;
@@ -99,7 +99,7 @@ void sched_lend_prio(thread_t *td, prio_t prio) {
 }
 
 void sched_unlend_prio(thread_t *td, prio_t prio) {
-  assert(spin_owned(td->td_lock));
+  assert(thread_owned(td));
 
   if (prio_le(prio, td->td_base_prio)) {
     td->td_flags &= ~TDF_BORROWING;
@@ -128,7 +128,7 @@ long sched_switch(void) {
   if (!sched_active)
     goto noswitch;
 
-  assert(spin_owned(td->td_lock));
+  assert(thread_owned(td));
   assert(!td_is_running(td));
 
   td->td_flags &= ~(TDF_SLICEEND | TDF_NEEDSWITCH);
@@ -161,13 +161,13 @@ long sched_switch(void) {
     panic("Switching context while interrupts are disabled is forbidden!");
 
   WITH_INTR_DISABLED {
-    spin_unlock(td->td_lock);
+    thread_unlock(td);
     return ctx_switch(td, newtd);
     /* XXX Right now all local variables belong to thread we switched to! */
   }
 
 noswitch:
-  spin_unlock(td->td_lock);
+  thread_unlock(td);
   return 0;
 }
 
@@ -177,7 +177,7 @@ void sched_clock(void) {
   thread_t *td = thread_self();
 
   if (td != PCPU_GET(idle_thread)) {
-    WITH_SPIN_LOCK (td->td_lock) {
+    WITH_THREAD_LOCK (td) {
       if (--td->td_slice <= 0)
         td->td_flags |= TDF_NEEDSWITCH | TDF_SLICEEND;
     }
@@ -198,7 +198,7 @@ __noreturn void sched_run(void) {
   sched_active = true;
 
   while (true) {
-    WITH_SPIN_LOCK (td->td_lock)
+    WITH_THREAD_LOCK (td)
       td->td_flags |= TDF_NEEDSWITCH;
   }
 }
@@ -209,12 +209,12 @@ void sched_maybe_preempt(void) {
 
   thread_t *td = thread_self();
 
-  spin_lock(td->td_lock);
+  thread_lock(td);
   if (td->td_flags & TDF_NEEDSWITCH) {
     td->td_state = TDS_READY;
     sched_switch();
   } else {
-    spin_unlock(td->td_lock);
+    thread_unlock(td);
   }
 }
 

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -174,7 +174,7 @@ int do_sigprocmask(int how, const sigset_t *set, sigset_t *oset) {
   }
 
   if (sig_pending(td)) {
-    WITH_SPIN_LOCK (td->td_lock)
+    WITH_THREAD_LOCK (td)
       td->td_flags |= TDF_NEEDSIGCHK;
   }
 
@@ -390,15 +390,15 @@ void sig_kill(proc_t *p, ksiginfo_t *ksi) {
   if (__sigismember(&td->td_sigmask, sig))
     return;
 
-  WITH_SPIN_LOCK (td->td_lock) {
+  WITH_THREAD_LOCK (td) {
     td->td_flags |= TDF_NEEDSIGCHK;
     /* If the thread is sleeping interruptibly (!), wake it up, so that it
      * continues execution and the signal gets delivered soon. */
     if (td_is_interruptible(td)) {
       /* XXX Maybe TDF_NEEDSIGCHK should be protected by a different lock? */
-      spin_unlock(td->td_lock);
+      thread_unlock(td);
       sleepq_abort(td); /* Locks & unlocks td_lock */
-      spin_lock(td->td_lock);
+      thread_lock(td);
     }
   }
 }
@@ -484,7 +484,7 @@ int sig_check(thread_t *td, ksiginfo_t *out) {
   }
 
   /* No pending signals, signal checking done. */
-  WITH_SPIN_LOCK (td->td_lock)
+  WITH_THREAD_LOCK (td)
     td->td_flags &= ~TDF_NEEDSIGCHK;
   return 0;
 }

--- a/sys/tests/turnstile_adjust.c
+++ b/sys/tests/turnstile_adjust.c
@@ -20,7 +20,7 @@ static MTX_DEFINE(ts_adj_mtx, 0);
 static thread_t *threads[T];
 
 static void set_prio(thread_t *td, prio_t prio) {
-  WITH_SPIN_LOCK (td->td_lock)
+  WITH_THREAD_LOCK (td)
     sched_set_prio(td, prio);
 }
 


### PR DESCRIPTION
- `thread_lock(td)` - acquire `td::td_lock`
- `thread_unlock(td)` - release `td::td_lock`
- `thread_owned(td)` - return `spin_owned(td->td_lock)`