### PR TITLE
[RISCV] Fix FP defines.

### DIFF
--- a/include/riscv/asm.h
+++ b/include/riscv/asm.h
@@ -63,12 +63,12 @@
   PTR_LA gp, __global_pointer$;                                                \
   .option pop
 
-#ifdef __riscv_f
-#define FP_L flw
-#define FP_S fsw
-#elif defined(__riscv_d)
+#ifdef __riscv_d
 #define FP_L fld
 #define FP_S fsd
+#elif defined(__riscv_f)
+#define FP_L flw
+#define FP_S fsw
 #endif
 
 /*

--- a/include/riscv/mcontext.h
+++ b/include/riscv/mcontext.h
@@ -39,12 +39,13 @@
 #define _NGREG 35 /* GR1-31, PC, SR, TVAL, CAUSE */
 #define _NFREG 33 /* F0-31, FCSR */
 
+/* NOTE: the following struct will be empty if `FPU` = 0. */
 typedef union __fpreg {
   fpregister_t r;
-#ifdef __riscv_f
-  float f;
-#elif defined(__riscv_d)
+#ifdef __riscv_d
   double d;
+#elif defined(__riscv_f)
+  float f;
 #endif
 } __fpreg_t;
 

--- a/include/riscv/types.h
+++ b/include/riscv/types.h
@@ -4,10 +4,10 @@
 #include <stdint.h>
 
 typedef int32_t register_t;
-#ifdef __riscv_f
-typedef int32_t fpregister_t;
-#elif defined(__riscv_d)
+#ifdef __riscv_d
 typedef int64_t fpregister_t;
+#elif defined(__riscv_f)
+typedef int32_t fpregister_t;
 #else
 typedef struct {
 } fpregister_t;


### PR DESCRIPTION
Current RISC-V headers don't respect the fact that if double FP extension is supported then both `__riscv_f` and `__riscv_d` are defined.