### PR TITLE
[RISCV] Fix ctx_switch signature.

### DIFF
--- a/sys/riscv/mcontext.c
+++ b/sys/riscv/mcontext.c
@@ -37,7 +37,7 @@ void mcontext_restart_syscall(mcontext_t *ctx) {
   panic("Not implemented!");
 }
 
-long ctx_switch(thread_t *from, thread_t *to) {
+void ctx_switch(thread_t *from, thread_t *to) {
   panic("Not implemented!");
 }
 


### PR DESCRIPTION
The signature of the context switching routine has changed. Unfortunately, the RISC-V implementation hasn't been adapted yet.