### PR TITLE
[RISCV] Introduce BSD RISC-V headers.

### DIFF
--- a/include/riscv/pte.h
+++ b/include/riscv/pte.h
@@ -44,7 +44,6 @@
 
 typedef uint32_t pd_entry_t; /* page directory entry */
 typedef uint32_t pt_entry_t; /* page table entry */
-typedef uint32_t pn_t;       /* page number */
 typedef uint16_t asid_t;     /* address space identifier */
 
 /* Level 0 table, 4MiB per entry */

--- a/include/riscv/pte.h
+++ b/include/riscv/pte.h
@@ -1,0 +1,95 @@
+/*-
+ * Copyright (c) 2014 Andrew Turner
+ * Copyright (c) 2015-2018 Ruslan Bukin <br@bsdpad.com>
+ * All rights reserved.
+ *
+ * Portions of this software were developed by SRI International and the
+ * University of Cambridge Computer Laboratory under DARPA/AFRL contract
+ * FA8750-10-C-0237 ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Portions of this software were developed by the University of Cambridge
+ * Computer Laboratory as part of the CTSRD Project, with support from the
+ * UK Higher Education Innovation Fund (HEIF).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/* MODIFIED */
+
+#ifndef _RISCV_PTE_H_
+#define _RISCV_PTE_H_
+
+#include <stdint.h>
+
+typedef uint32_t pd_entry_t; /* page directory entry */
+typedef uint32_t pt_entry_t; /* page table entry */
+typedef uint32_t pn_t;       /* page number */
+typedef uint16_t asid_t;     /* address space identifier */
+
+/* Level 0 table, 4MiB per entry */
+#define L0_SHIFT 22
+#define L0_SIZE (1 << L0_SHIFT)
+#define L0_OFFSET (L0_SIZE - 1)
+
+/* Level 1 table, 4096B per entry */
+#define L1_SHIFT 12
+#define L1_SIZE (1 << L1_SHIFT)
+#define L1_OFFSET (L1_SIZE - 1)
+
+#define Ln_ENTRIES_SHIFT 10
+#define Ln_ENTRIES (1 << Ln_ENTRIES_SHIFT)
+#define Ln_ADDR_MASK (Ln_ENTRIES - 1)
+
+#define L0_INDEX(va) (((va) >> L0_SHIFT) & Ln_ADDR_MASK)
+#define L1_INDEX(va) (((va) >> L1_SHIFT) & Ln_ADDR_MASK)
+
+/* Bits 9:8 are reserved for software. */
+#define PTE_SW_WRITE (1 << 9)
+#define PTE_SW_READ (1 << 8)
+#define PTE_SW_FLAGS (PTE_SW_WRITE | PTE_SW_READ)
+#define PTE_D (1 << 7) /* Dirty */
+#define PTE_A (1 << 6) /* Accessed */
+#define PTE_G (1 << 5) /* Global */
+#define PTE_U (1 << 4) /* User */
+#define PTE_X (1 << 3) /* Execute */
+#define PTE_W (1 << 2) /* Write */
+#define PTE_R (1 << 1) /* Read */
+#define PTE_V (1 << 0) /* Valid */
+#define PTE_RWX (PTE_R | PTE_W | PTE_X)
+#define PTE_RX (PTE_R | PTE_X)
+#define PTE_KERN                                                               \
+  (PTE_SW_WRITE | PTE_SW_READ | PTE_D | PTE_A | PTE_G | PTE_W | PTE_R | PTE_V)
+#define PTE_KERN_RO (PTE_SW_READ | PTE_A | PTE_G | PTE_R | PTE_V)
+#define PTE_PROT_MASK (PTE_SW_FLAGS | PTE_D | PTE_A | PTE_RWX | PTE_V)
+
+#define PTE_PPN0_S 10
+#define PTE_PPN1_S 20
+#define PTE_SIZE 4
+
+#define PAGE_SHIFT 12
+
+#define PA_TO_PTE(pa) (((pa) >> PAGE_SHIFT) << PTE_PPN0_S)
+#define PTE_TO_PA(pte) (((pte) >> PTE_PPN0_S) << PAGE_SHIFT)
+
+#endif /* !_RISCV_PTE_H_ */

--- a/include/riscv/riscvreg.h
+++ b/include/riscv/riscvreg.h
@@ -1,0 +1,197 @@
+/*-
+ * Copyright (c) 2015-2017 Ruslan Bukin <br@bsdpad.com>
+ * All rights reserved.
+ *
+ * Portions of this software were developed by SRI International and the
+ * University of Cambridge Computer Laboratory under DARPA/AFRL contract
+ * FA8750-10-C-0237 ("CTSRD"), as part of the DARPA CRASH research programme.
+ *
+ * Portions of this software were developed by the University of Cambridge
+ * Computer Laboratory as part of the CTSRD Project, with support from the
+ * UK Higher Education Innovation Fund (HEIF).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/* MODIFIED */
+
+#ifndef _RISCV_RISCVREG_H_
+#define _RISCV_RISCVREG_H_
+
+#if __riscv_xlen == 64
+#define SCAUSE_INTR (1ul << 63)
+#else
+#define SCAUSE_INTR (1 << 31)
+#endif
+#define SCAUSE_CODE (~SCAUSE_INTR)
+#define SCAUSE_INST_MISALIGNED 0
+#define SCAUSE_INST_ACCESS_FAULT 1
+#define SCAUSE_ILLEGAL_INSTRUCTION 2
+#define SCAUSE_BREAKPOINT 3
+#define SCAUSE_LOAD_MISALIGNED 4
+#define SCAUSE_LOAD_ACCESS_FAULT 5
+#define SCAUSE_STORE_MISALIGNED 6
+#define SCAUSE_STORE_ACCESS_FAULT 7
+#define SCAUSE_ECALL_USER 8
+#define SCAUSE_ECALL_SUPERVISOR 9
+#define SCAUSE_INST_PAGE_FAULT 12
+#define SCAUSE_LOAD_PAGE_FAULT 13
+#define SCAUSE_STORE_PAGE_FAULT 15
+
+#define SSTATUS_UIE (1 << 0)
+#define SSTATUS_SIE (1 << 1)
+#define SSTATUS_UPIE (1 << 4)
+#define SSTATUS_SPIE (1 << 5)
+#define SSTATUS_SPIE_SHIFT 5
+#define SSTATUS_SPP_SHIFT 8
+#define SSTATUS_SPP_USER (0 << SSTATUS_SPP_SHIFT)
+#define SSTATUS_SPP_SUPV (1 << SSTATUS_SPP_SHIFT)
+#define SSTATUS_SPP_MASK (1 << SSTATUS_SPP_SHIFT)
+#define SSTATUS_FS_SHIFT 13
+#define SSTATUS_FS_OFF (0x0 << SSTATUS_FS_SHIFT)
+#define SSTATUS_FS_INITIAL (0x1 << SSTATUS_FS_SHIFT)
+#define SSTATUS_FS_CLEAN (0x2 << SSTATUS_FS_SHIFT)
+#define SSTATUS_FS_DIRTY (0x3 << SSTATUS_FS_SHIFT)
+#define SSTATUS_FS_MASK (0x3 << SSTATUS_FS_SHIFT)
+#define SSTATUS_XS_SHIFT 15
+#define SSTATUS_XS_MASK (0x3 << SSTATUS_XS_SHIFT)
+#define SSTATUS_SUM (1 << 18)
+#if __riscv_xlen == 64
+#define SSTATUS_SD (1ul << 63)
+#else
+#define SSTATUS_SD (1 << 31)
+#endif
+
+#define SIE_USIE (1 << 0)
+#define SIE_SSIE (1 << 1)
+#define SIE_UTIE (1 << 4)
+#define SIE_STIE (1 << 5)
+#define SIE_UEIE (1 << 8)
+#define SIE_SEIE (1 << 9)
+
+/* Note: sip register has no SIP_STIP bit in Spike simulator */
+#define SIP_USIP (1 << 0)
+#define SIP_SSIP (1 << 1)
+#define SIP_UTIP (1 << 4)
+#define SIP_STIP (1 << 5)
+#define SIP_UEIP (1 << 8)
+#define SIP_SEIP (1 << 9)
+
+#if __riscv_xlen == 64
+#define SATP_PPN_S 0
+#define SATP_PPN_M (0xfffffffffff << SATP_PPN_S)
+#define SATP_ASID_S 44
+#define SATP_ASID_M (0xffff << SATP_ASID_S)
+#define SATP_MODE_S 60
+#define SATP_MODE_M (0xfULL << SATP_MODE_S)
+#define SATP_MODE_SV39 (8ULL << SATP_MODE_S)
+#define SATP_MODE_SV48 (9ULL << SATP_MODE_S)
+#define MAX_ASID 0xffff
+#else
+#define SATP_PPN_S 0
+#define SATP_PPN_M (0x3fffff << SATP_PPN_S)
+#define SATP_ASID_S 22
+#define SATP_ASID_M (0x1ff << SATP_ASID_S)
+#define SATP_MODE_S 31
+#define SATP_MODE_M (0x1 << SATP_MODE_S)
+#define SATP_MODE_SV32 (1 << SATP_MODE_S)
+#define MAX_ASID 0x01ff
+#endif
+
+#define XLEN __riscv_xlen
+#define XLEN_BYTES (XLEN / 8)
+#define INSN_SIZE 4
+#define INSN_C_SIZE 2
+
+#define CSR_ZIMM(val) (__builtin_constant_p(val) && ((u_long)(val) < 32))
+
+#define csr_swap(csr, val)                                                     \
+  ({                                                                           \
+    if (CSR_ZIMM(val))                                                         \
+      __asm __volatile("csrrwi %0, " #csr ", %1" : "=r"(val) : "i"(val));      \
+    else                                                                       \
+      __asm __volatile("csrrw %0, " #csr ", %1" : "=r"(val) : "r"(val));       \
+    val;                                                                       \
+  })
+
+#define csr_write(csr, val)                                                    \
+  ({                                                                           \
+    if (CSR_ZIMM(val))                                                         \
+      __asm __volatile("csrwi " #csr ", %0" ::"i"(val));                       \
+    else                                                                       \
+      __asm __volatile("csrw " #csr ", %0" ::"r"(val));                        \
+  })
+
+#define csr_set(csr, val)                                                      \
+  ({                                                                           \
+    if (CSR_ZIMM(val))                                                         \
+      __asm __volatile("csrsi " #csr ", %0" ::"i"(val));                       \
+    else                                                                       \
+      __asm __volatile("csrs " #csr ", %0" ::"r"(val));                        \
+  })
+
+#define csr_clear(csr, val)                                                    \
+  ({                                                                           \
+    if (CSR_ZIMM(val))                                                         \
+      __asm __volatile("csrci " #csr ", %0" ::"i"(val));                       \
+    else                                                                       \
+      __asm __volatile("csrc " #csr ", %0" ::"r"(val));                        \
+  })
+
+#define csr_read(csr)                                                          \
+  ({                                                                           \
+    u_long val;                                                                \
+    __asm __volatile("csrr %0, " #csr : "=r"(val));                            \
+    val;                                                                       \
+  })
+
+#if __riscv_xlen == 32
+#define csr_read64(csr)                                                        \
+  ({                                                                           \
+    uint64_t val;                                                              \
+    uint32_t high, low;                                                        \
+    __asm __volatile("1: "                                                     \
+                     "csrr t0, " #csr "h\n"                                    \
+                     "csrr %0, " #csr "\n"                                     \
+                     "csrr %1, " #csr "h\n"                                    \
+                     "bne t0, %1, 1b"                                          \
+                     : "=r"(low), "=r"(high)                                   \
+                     :                                                         \
+                     : "t0");                                                  \
+    val = (low | ((uint64_t)high << 32));                                      \
+    val;                                                                       \
+  })
+#else
+#define csr_read64(csr) ((uint64_t)csr_read(csr))
+#endif
+
+#define rdcycle() csr_read64(cycle)
+#define rdtime() csr_read64(time)
+#define rdinstret() csr_read64(instret)
+#define rdhpmcounter(n) csr_read64(hpmcounter##n)
+
+#define enter_user_access() csr_set(sstatus, SSTATUS_SUM)
+#define exit_user_access() csr_clear(sstatus, SSTATUS_SUM)
+
+#endif /* !_RISCV_RISCVREG_H_ */

--- a/sys/riscv/mcontext.c
+++ b/sys/riscv/mcontext.c
@@ -37,7 +37,7 @@ void mcontext_restart_syscall(mcontext_t *ctx) {
   panic("Not implemented!");
 }
 
-long ctx_switch(thread_t *from, thread_t *to) {
+void ctx_switch(thread_t *from, thread_t *to) {
   panic("Not implemented!");
 }
 


### PR DESCRIPTION
Our RISC-V port relies on the headers taken from FreeBSD with modifications based on the corresponding NetBSD headers.

This PR contains changes from #1215.