### PR TITLE
[RISCV] The simulated LiteX VexRiscv platform doesn't use the floating-point extension.

### DIFF
--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -17,7 +17,7 @@ ELFARCH := riscv
 ifeq ($(BOARD), litex-riscv)
 	KERNEL_PHYS := 0x40000000
 	KERNEL-IMAGES := mimiker.img
-	CPPFLAGS += -DFPU=1
+	CPPFLAGS += -DFPU=0
 endif
 
 ifeq ($(KERNEL), 1)


### PR DESCRIPTION
The simulated LiteX VexRiscv hardware platform doesn't support any floating-point extension.