### PR TITLE
[Aarch64][libc] Fix missing syscall handling.

### DIFF
--- a/lib/libc/sys/aarch64/sc_missing.S
+++ b/lib/libc/sys/aarch64/sc_missing.S
@@ -4,5 +4,5 @@
 ENTRY(__sc_missing)
         mov     x0, #-1
         mov     x1, #ENOSYS
-        ret
+        b _C_LABEL(__sc_error)
 END(__sc_missing)

--- a/lib/libc/sys/aarch64/sc_missing.S
+++ b/lib/libc/sys/aarch64/sc_missing.S
@@ -2,7 +2,7 @@
 #include <sys/errno.h>
 
 ENTRY(__sc_missing)
-        mov     x0, #-1
-        mov     x1, #ENOSYS
-        b _C_LABEL(__sc_error)
+	mov	x0, #-1
+	mov	x1, #ENOSYS
+	b	_C_LABEL(__sc_error)
 END(__sc_missing)


### PR DESCRIPTION
`__sc_error` should behave as if the syscall returned `ENOSYS`.