### PR TITLE
[csu] Fix ELF entry point description.

### DIFF
--- a/lib/csu/aarch64/crt0.S
+++ b/lib/csu/aarch64/crt0.S
@@ -5,7 +5,7 @@
 # This is the starting procedude for user ELF images, used as their
 # entry point. It takes care of preparing argc and argc for main().
 # For details about environment in which this procedure starts, refer
-# to prepare_program_stack in exec.c.
+# to `exec_args_copyout` in `sys/kern/exec.c`.
 
 ENTRY(_start)
         # Grab argc from stack.

--- a/lib/csu/mips/crt0.S
+++ b/lib/csu/mips/crt0.S
@@ -7,7 +7,7 @@
 # This is the starting procedude for user ELF images, used as their
 # entry point. It takes care of preparing argc and argc for main().
 # For details about environment in which this procedure starts, refer
-# to prepare_program_stack in exec.c.
+# to `exec_args_copyout` in `sys/kern/exec.c`.
 
 NESTED(_start, CALLFRAME_SIZ, ra)
         # Adhere to calling convention wrt return address so that GDB can


### PR DESCRIPTION
Both MIPS and Aarch64 refer to the nonexistent `prepare_program_stack` procedure as a reference to setting the program's environment.
