### PR TITLE
[dev] Interrupt controller interface.

### DIFF
--- a/include/sys/bus.h
+++ b/include/sys/bus.h
@@ -134,9 +134,6 @@ extern bus_space_t *generic_bus_space;
 #define bus_space_map(t, a, s, hp) (*(t)->bs_map)((a), (s), (hp))
 
 struct bus_methods {
-  void (*intr_setup)(device_t *dev, resource_t *irq, ih_filter_t *filter,
-                     ih_service_t *service, void *arg, const char *name);
-  void (*intr_teardown)(device_t *dev, resource_t *irq);
   resource_t *(*alloc_resource)(device_t *dev, res_type_t type, int rid,
                                 rman_addr_t start, rman_addr_t end, size_t size,
                                 rman_flags_t flags);
@@ -153,11 +150,6 @@ static inline bus_methods_t *bus_methods(device_t *dev) {
  * above `device_method_provider` in include/sys/device.c */
 #define BUS_METHOD_PROVIDER(dev, method)                                       \
   (device_method_provider((dev), DIF_BUS, offsetof(struct bus_methods, method)))
-
-void bus_intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
-                    ih_service_t *service, void *arg, const char *name);
-
-void bus_intr_teardown(device_t *dev, resource_t *irq);
 
 /*! \brief Allocates a resource of type \a type and size \a size between
  * \a start and \a end for a device \a dev.

--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -22,7 +22,7 @@ typedef int (*d_detach_t)(device_t *dev);
 /* Update this section if you add any new driver interface */
 typedef enum {
   DIF_BUS,
-  DIF_IC,
+  DIF_PIC,
   DIF_PCI_BUS,
   DIF_UART,
   DIF_EMMC,
@@ -72,7 +72,7 @@ typedef enum {
 struct device {
   /* Device hierarchy. */
   device_t *parent; /* parent node (bus?) or null (root or pseudo-dev) */
-  device_t *ic;     /* device's interrupt controller */
+  device_t *pic;    /* device's interrupt controller */
   TAILQ_ENTRY(device) link; /* node on list of siblings */
   device_list_t children;   /* head of children devices */
 

--- a/include/sys/device.h
+++ b/include/sys/device.h
@@ -22,6 +22,7 @@ typedef int (*d_detach_t)(device_t *dev);
 /* Update this section if you add any new driver interface */
 typedef enum {
   DIF_BUS,
+  DIF_IC,
   DIF_PCI_BUS,
   DIF_UART,
   DIF_EMMC,
@@ -71,6 +72,7 @@ typedef enum {
 struct device {
   /* Device hierarchy. */
   device_t *parent; /* parent node (bus?) or null (root or pseudo-dev) */
+  device_t *ic;     /* device's interrupt controller */
   TAILQ_ENTRY(device) link; /* node on list of siblings */
   device_list_t children;   /* head of children devices */
 

--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -95,13 +95,14 @@ void intr_root_handler(ctx_t *ctx) __no_profile;
  * Interrupt controller interface.
  */
 
-typedef resource_t *(*pic_alloc_intr_t)(device_t *ic, device_t *dev, int rid,
+typedef resource_t *(*pic_alloc_intr_t)(device_t *pic, device_t *dev, int rid,
                                         unsigned irq, rman_flags_t flags);
-typedef void (*pic_release_intr_t)(device_t *ic, device_t *dev, resource_t *r);
-typedef void (*pic_setup_intr_t)(device_t *ic, device_t *dev, resource_t *r,
+typedef void (*pic_release_intr_t)(device_t *pic, device_t *dev, resource_t *r);
+typedef void (*pic_setup_intr_t)(device_t *pic, device_t *dev, resource_t *r,
                                  ih_filter_t *filter, ih_service_t *service,
                                  void *arg, const char *name);
-typedef void (*pic_teardown_intr_t)(device_t *ic, device_t *dev, resource_t *r);
+typedef void (*pic_teardown_intr_t)(device_t *pic, device_t *dev,
+                                    resource_t *r);
 
 typedef struct pic_methods {
   pic_alloc_intr_t alloc_intr;

--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -95,20 +95,20 @@ void intr_root_handler(ctx_t *ctx) __no_profile;
  * Interrupt controller interface.
  */
 
-typedef resource_t *(*intr_alloc_t)(device_t *ic, device_t *dev, int rid,
-                                    unsigned irq, rman_flags_t flags);
-typedef void (*intr_release_t)(device_t *ic, device_t *dev, resource_t *r);
-typedef void (*intr_setup_t)(device_t *ic, device_t *dev, resource_t *r,
-                             ih_filter_t *filter, ih_service_t *service,
-                             void *arg, const char *name);
-typedef void (*intr_teardown_t)(device_t *ic, device_t *dev, resource_t *r);
+typedef resource_t *(*pic_alloc_intr_t)(device_t *ic, device_t *dev, int rid,
+                                        unsigned irq, rman_flags_t flags);
+typedef void (*pic_release_intr_t)(device_t *ic, device_t *dev, resource_t *r);
+typedef void (*pic_setup_intr_t)(device_t *ic, device_t *dev, resource_t *r,
+                                 ih_filter_t *filter, ih_service_t *service,
+                                 void *arg, const char *name);
+typedef void (*pic_teardown_intr_t)(device_t *ic, device_t *dev, resource_t *r);
 
-typedef struct ic_methods {
-  intr_alloc_t intr_alloc;
-  intr_release_t intr_release;
-  intr_setup_t intr_setup;
-  intr_teardown_t intr_teardown;
-} ic_methods_t;
+typedef struct pic_methods {
+  pic_alloc_intr_t alloc_intr;
+  pic_release_intr_t release_intr;
+  pic_setup_intr_t setup_intr;
+  pic_teardown_intr_t teardown_intr;
+} pic_methods_t;
 
 /*
  * Allocate an interrupt resource.
@@ -119,8 +119,8 @@ typedef struct ic_methods {
  *  - `irq`: interrupt request line number
  *  - `flags`: resource manager flags
  */
-resource_t *intr_alloc(device_t *dev, int rid, unsigned irq,
-                       rman_flags_t flags);
+resource_t *pic_alloc_intr(device_t *dev, int rid, unsigned irq,
+                           rman_flags_t flags);
 
 /*
  * Release allocated interrupt resource.
@@ -129,7 +129,7 @@ resource_t *intr_alloc(device_t *dev, int rid, unsigned irq,
  *  - `dev`: requesting device
  *  - `r`: interrupt resource to release
  */
-void intr_release(device_t *dev, resource_t *r);
+void pic_release_intr(device_t *dev, resource_t *r);
 
 /*
  * Register a new interrupt source for interrupt identified by `irq`.
@@ -143,8 +143,8 @@ void intr_release(device_t *dev, resource_t *r);
  *  - `arg`: argument passed to both filter and service routines
  *  - `name`: description of the interrupt source
  */
-void intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
-                ih_service_t *service, void *arg, const char *name);
+void pic_setup_intr(device_t *dev, resource_t *irq, ih_filter_t *filter,
+                    ih_service_t *service, void *arg, const char *name);
 
 /*
  * Remove specified interrupt source.
@@ -153,6 +153,6 @@ void intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
  *  - `dev`: requesting device
  *  - `r`: interrupt resource
  */
-void intr_teardown(device_t *dev, resource_t *r);
+void pic_teardown_intr(device_t *dev, resource_t *r);
 
 #endif /* !_SYS_INTERRUPT_H_ */

--- a/include/sys/interrupt.h
+++ b/include/sys/interrupt.h
@@ -5,6 +5,7 @@
 #include <sys/queue.h>
 #include <sys/spinlock.h>
 #include <sys/priority.h>
+#include <sys/rman.h>
 
 typedef struct ctx ctx_t;
 typedef struct device device_t;
@@ -89,5 +90,69 @@ typedef void (*intr_root_filter_t)(ctx_t *ctx, device_t *dev);
 
 void intr_root_claim(intr_root_filter_t filter, device_t *dev);
 void intr_root_handler(ctx_t *ctx) __no_profile;
+
+/*
+ * Interrupt controller interface.
+ */
+
+typedef resource_t *(*intr_alloc_t)(device_t *ic, device_t *dev, int rid,
+                                    unsigned irq, rman_flags_t flags);
+typedef void (*intr_release_t)(device_t *ic, device_t *dev, resource_t *r);
+typedef void (*intr_setup_t)(device_t *ic, device_t *dev, resource_t *r,
+                             ih_filter_t *filter, ih_service_t *service,
+                             void *arg, const char *name);
+typedef void (*intr_teardown_t)(device_t *ic, device_t *dev, resource_t *r);
+
+typedef struct ic_methods {
+  intr_alloc_t intr_alloc;
+  intr_release_t intr_release;
+  intr_setup_t intr_setup;
+  intr_teardown_t intr_teardown;
+} ic_methods_t;
+
+/*
+ * Allocate an interrupt resource.
+ *
+ * Arguments:
+ *  - `dev`: requesting device
+ *  - `rid`: unique resource ID that will be assigned to allocated resource
+ *  - `irq`: interrupt request line number
+ *  - `flags`: resource manager flags
+ */
+resource_t *intr_alloc(device_t *dev, int rid, unsigned irq,
+                       rman_flags_t flags);
+
+/*
+ * Release allocated interrupt resource.
+ *
+ * Arguments:
+ *  - `dev`: requesting device
+ *  - `r`: interrupt resource to release
+ */
+void intr_release(device_t *dev, resource_t *r);
+
+/*
+ * Register a new interrupt source for interrupt identified by `irq`.
+ *
+ * Arguments:
+ *  - `dev`: requesting device
+ *  - `irq`: interrupt resource
+ *  - `filter`: filter function called within interrupted context
+ *  - `service`: optional service function called within interrupt
+ *    thread context
+ *  - `arg`: argument passed to both filter and service routines
+ *  - `name`: description of the interrupt source
+ */
+void intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
+                ih_service_t *service, void *arg, const char *name);
+
+/*
+ * Remove specified interrupt source.
+ *
+ * Arguments:
+ *  - `dev`: requesting device
+ *  - `r`: interrupt resource
+ */
+void intr_teardown(device_t *dev, resource_t *r);
 
 #endif /* !_SYS_INTERRUPT_H_ */

--- a/sys/aarch64/timer.c
+++ b/sys/aarch64/timer.c
@@ -88,7 +88,8 @@ static int arm_timer_attach(device_t *dev) {
   tm_register(&state->timer);
   tm_select(&state->timer);
 
-  intr_setup(dev, state->irq_res, arm_timer_intr, NULL, dev, "ARM CPU timer");
+  pic_setup_intr(dev, state->irq_res, arm_timer_intr, NULL, dev,
+                 "ARM CPU timer");
 
   return 0;
 }

--- a/sys/aarch64/timer.c
+++ b/sys/aarch64/timer.c
@@ -88,8 +88,7 @@ static int arm_timer_attach(device_t *dev) {
   tm_register(&state->timer);
   tm_select(&state->timer);
 
-  bus_intr_setup(dev, state->irq_res, arm_timer_intr, NULL, dev,
-                 "ARM CPU timer");
+  intr_setup(dev, state->irq_res, arm_timer_intr, NULL, dev, "ARM CPU timer");
 
   return 0;
 }

--- a/sys/drv/82371AB.c
+++ b/sys/drv/82371AB.c
@@ -83,28 +83,28 @@ static int intel_isa_attach(device_t *isab) {
 
   /* atkbdc keyboard device */
   dev = device_add_child(isab, 0);
-  dev->ic = isab->ic;
+  dev->pic = isab->pic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_KBD, IO_KBDSIZE);
   device_add_irq(dev, 0, 1);
 
   /* ns16550 uart device */
   dev = device_add_child(isab, 1);
-  dev->ic = isab->ic;
+  dev->pic = isab->pic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_COM1, IO_COMSIZE);
   device_add_irq(dev, 0, 4);
 
   /* rtc device */
   dev = device_add_child(isab, 2);
-  dev->ic = isab->ic;
+  dev->pic = isab->pic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_RTC, IO_RTCSIZE);
   device_add_irq(dev, 0, 8);
 
   /* i8254 timer device */
   dev = device_add_child(isab, 3);
-  dev->ic = isab->ic;
+  dev->pic = isab->pic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_TIMER1, IO_TMRSIZE);
   device_add_irq(dev, 0, 0);

--- a/sys/drv/82371AB.c
+++ b/sys/drv/82371AB.c
@@ -23,14 +23,7 @@ static resource_t *intel_isa_alloc_resource(device_t *dev, res_type_t type,
                                             rman_addr_t end, size_t size,
                                             rman_flags_t flags) {
   assert(dev->bus == DEV_BUS_ISA);
-
-  if (type != RT_IOPORTS) {
-    assert(type == RT_IRQ);
-    device_t *idev = BUS_METHOD_PROVIDER(dev->parent, alloc_resource);
-    return bus_methods(idev->parent)
-      ->alloc_resource(idev, type, rid, start, end, size, flags);
-  }
-
+  assert(type == RT_IOPORTS);
   assert(start >= IO_ICUSIZE);
 
   intel_isa_state_t *isa = dev->parent->state;
@@ -58,23 +51,18 @@ static resource_t *intel_isa_alloc_resource(device_t *dev, res_type_t type,
 }
 
 static int intel_isa_activate_resource(device_t *dev, resource_t *r) {
-  assert(r->r_type == RT_IOPORTS || r->r_type == RT_IRQ);
-  /* Neither IRQs in general or IOports on ISA require activation */
+  assert(r->r_type == RT_IOPORTS);
+  /* IOports on ISA don't require activation */
   return 0;
 }
 
 static void intel_isa_deactivate_resource(device_t *dev, resource_t *r) {
-  assert(r->r_type == RT_IOPORTS || r->r_type == RT_IRQ);
-  /* Neither IRQs in general or IOports on ISA require deactivation */
+  assert(r->r_type == RT_IOPORTS);
+  /* IOports on ISA don't require deactivation */
 }
 
 static void intel_isa_release_resource(device_t *dev, resource_t *r) {
-  if (r->r_type != RT_IOPORTS) {
-    assert(r->r_type == RT_IRQ);
-    device_t *idev = BUS_METHOD_PROVIDER(dev->parent, release_resource);
-    bus_methods(idev->parent)->release_resource(idev, r);
-    return;
-  }
+  assert(r->r_type == RT_IOPORTS);
   bus_deactivate_resource(dev, r);
   resource_release(r);
 }
@@ -95,24 +83,28 @@ static int intel_isa_attach(device_t *isab) {
 
   /* atkbdc keyboard device */
   dev = device_add_child(isab, 0);
+  dev->ic = isab->ic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_KBD, IO_KBDSIZE);
   device_add_irq(dev, 0, 1);
 
   /* ns16550 uart device */
   dev = device_add_child(isab, 1);
+  dev->ic = isab->ic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_COM1, IO_COMSIZE);
   device_add_irq(dev, 0, 4);
 
   /* rtc device */
   dev = device_add_child(isab, 2);
+  dev->ic = isab->ic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_RTC, IO_RTCSIZE);
   device_add_irq(dev, 0, 8);
 
   /* i8254 timer device */
   dev = device_add_child(isab, 3);
+  dev->ic = isab->ic;
   dev->bus = DEV_BUS_ISA;
   device_add_ioports(dev, 0, IO_TIMER1, IO_TMRSIZE);
   device_add_irq(dev, 0, 0);
@@ -121,8 +113,6 @@ static int intel_isa_attach(device_t *isab) {
 }
 
 static bus_methods_t intel_isa_bus_bus_if = {
-  .intr_setup = NULL,    /* Dispatched */
-  .intr_teardown = NULL, /* Dispatched */
   .alloc_resource = intel_isa_alloc_resource,
   .activate_resource = intel_isa_activate_resource,
   .deactivate_resource = intel_isa_deactivate_resource,

--- a/sys/drv/atkbdc.c
+++ b/sys/drv/atkbdc.c
@@ -195,8 +195,8 @@ static int atkbdc_attach(device_t *dev) {
   assert(atkbdc->regs != NULL);
 
   atkbdc->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
-  bus_intr_setup(dev, atkbdc->irq_res, atkbdc_intr, NULL, atkbdc,
-                 "AT keyboard controller");
+  intr_setup(dev, atkbdc->irq_res, atkbdc_intr, NULL, atkbdc,
+             "AT keyboard controller");
 
   /* Enable interrupt */
   write_command(atkbdc->regs, KBDC_SET_COMMAND_BYTE);

--- a/sys/drv/atkbdc.c
+++ b/sys/drv/atkbdc.c
@@ -195,8 +195,8 @@ static int atkbdc_attach(device_t *dev) {
   assert(atkbdc->regs != NULL);
 
   atkbdc->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
-  intr_setup(dev, atkbdc->irq_res, atkbdc_intr, NULL, atkbdc,
-             "AT keyboard controller");
+  pic_setup_intr(dev, atkbdc->irq_res, atkbdc_intr, NULL, atkbdc,
+                 "AT keyboard controller");
 
   /* Enable interrupt */
   write_command(atkbdc->regs, KBDC_SET_COMMAND_BYTE);

--- a/sys/drv/bcm2835_rootdev.c
+++ b/sys/drv/bcm2835_rootdev.c
@@ -134,21 +134,21 @@ static void rootdev_disable_irq(intr_event_t *ie) {
   }
 }
 
-static resource_t *rootdev_alloc_intr(device_t *ic, device_t *dev, int rid,
+static resource_t *rootdev_alloc_intr(device_t *pic, device_t *dev, int rid,
                                       unsigned irq, rman_flags_t flags) {
-  rootdev_t *rd = ic->state;
+  rootdev_t *rd = pic->state;
   rman_t *rman = &rd->irq_rm;
   return rman_reserve_resource(rman, RT_IRQ, rid, irq, irq, 1, 0, flags);
 }
 
-static void rootdev_release_intr(device_t *ic, device_t *dev, resource_t *r) {
+static void rootdev_release_intr(device_t *pic, device_t *dev, resource_t *r) {
   resource_release(r);
 }
 
-static void rootdev_setup_intr(device_t *ic, device_t *dev, resource_t *r,
+static void rootdev_setup_intr(device_t *pic, device_t *dev, resource_t *r,
                                ih_filter_t *filter, ih_service_t *service,
                                void *arg, const char *name) {
-  rootdev_t *rd = ic->state;
+  rootdev_t *rd = pic->state;
   int irq = resource_start(r);
   assert(irq < NIRQ);
 
@@ -160,7 +160,7 @@ static void rootdev_setup_intr(device_t *ic, device_t *dev, resource_t *r,
     intr_event_add_handler(rd->intr_event[irq], filter, service, arg, name);
 }
 
-static void rootdev_teardown_intr(device_t *ic, device_t *dev,
+static void rootdev_teardown_intr(device_t *pic, device_t *dev,
                                   resource_t *irq) {
   intr_event_remove_handler(irq->r_handler);
 }

--- a/sys/drv/bcm2835_rootdev.c
+++ b/sys/drv/bcm2835_rootdev.c
@@ -134,10 +134,21 @@ static void rootdev_disable_irq(intr_event_t *ie) {
   }
 }
 
-static void rootdev_intr_setup(device_t *dev, resource_t *r,
+static resource_t *rootdev_intr_alloc(device_t *ic, device_t *dev, int rid,
+                                      unsigned irq, rman_flags_t flags) {
+  rootdev_t *rd = ic->state;
+  rman_t *rman = &rd->irq_rm;
+  return rman_reserve_resource(rman, RT_IRQ, rid, irq, irq, 1, 0, flags);
+}
+
+static void rootdev_intr_release(device_t *ic, device_t *dev, resource_t *r) {
+  resource_release(r);
+}
+
+static void rootdev_intr_setup(device_t *ic, device_t *dev, resource_t *r,
                                ih_filter_t *filter, ih_service_t *service,
                                void *arg, const char *name) {
-  rootdev_t *rd = dev->parent->state;
+  rootdev_t *rd = ic->state;
   int irq = resource_start(r);
   assert(irq < NIRQ);
 
@@ -149,7 +160,8 @@ static void rootdev_intr_setup(device_t *dev, resource_t *r,
     intr_event_add_handler(rd->intr_event[irq], filter, service, arg, name);
 }
 
-static void rootdev_intr_teardown(device_t *dev, resource_t *irq) {
+static void rootdev_intr_teardown(device_t *ic, device_t *dev,
+                                  resource_t *irq) {
   intr_event_remove_handler(irq->r_handler);
 }
 
@@ -221,10 +233,12 @@ static int rootdev_attach(device_t *bus) {
 
   /* Create ARM timer device and assign resources to it. */
   dev = device_add_child(bus, 0);
+  dev->ic = bus;
   device_add_irq(dev, 0, BCM2836_INT_CNTPNSIRQ_CPUN(0));
 
   /* Create PL011 UART device and assign resources to it. */
   dev = device_add_child(bus, 1);
+  dev->ic = bus;
   device_add_memory(dev, 0, BCM2835_PERIPHERALS_BUS_TO_PHYS(BCM2835_UART0_BASE),
                     BCM2835_UART0_SIZE);
   device_add_irq(dev, 0, BCM2835_INT_UART0);
@@ -239,27 +253,18 @@ static resource_t *rootdev_alloc_resource(device_t *dev, res_type_t type,
                                           rman_addr_t end, size_t size,
                                           rman_flags_t flags) {
   rootdev_t *rd = dev->parent->state;
-  size_t alignment = 0;
-  rman_t *rman = NULL;
+  rman_t *rman = &rd->rm;
+  size_t alignment = PAGESIZE;
 
-  if (type == RT_MEMORY) {
-    alignment = PAGESIZE;
-    rman = &rd->rm;
-  } else if (type == RT_IRQ) {
-    rman = &rd->irq_rm;
-  } else {
-    panic("Resource type not handled!");
-  }
+  assert(type == RT_MEMORY);
 
   resource_t *r =
     rman_reserve_resource(rman, type, rid, start, end, size, alignment, flags);
   if (!r)
     return NULL;
 
-  if (type == RT_MEMORY) {
-    r->r_bus_tag = rootdev_bus_space;
-    r->r_bus_handle = resource_start(r);
-  }
+  r->r_bus_tag = rootdev_bus_space;
+  r->r_bus_handle = resource_start(r);
 
   if (flags & RF_ACTIVE) {
     if (bus_activate_resource(dev, r)) {
@@ -272,28 +277,34 @@ static resource_t *rootdev_alloc_resource(device_t *dev, res_type_t type,
 }
 
 static void rootdev_release_resource(device_t *dev, resource_t *r) {
+  assert(r->r_type == RT_MEMORY);
   bus_deactivate_resource(dev, r);
   resource_release(r);
 }
 
 static int rootdev_activate_resource(device_t *dev, resource_t *r) {
-  if (r->r_type == RT_MEMORY)
-    return bus_space_map(r->r_bus_tag, resource_start(r), resource_size(r),
-                         &r->r_bus_handle);
-  return 0;
+  assert(r->r_type == RT_MEMORY);
+  return bus_space_map(r->r_bus_tag, resource_start(r), resource_size(r),
+                       &r->r_bus_handle);
 }
 
 static void rootdev_deactivate_resource(device_t *dev, resource_t *r) {
+  assert(r->r_type == RT_MEMORY);
   /* TODO: unmap mapped resources. */
 }
 
 static bus_methods_t rootdev_bus_if = {
-  .intr_setup = rootdev_intr_setup,
-  .intr_teardown = rootdev_intr_teardown,
   .alloc_resource = rootdev_alloc_resource,
   .release_resource = rootdev_release_resource,
   .activate_resource = rootdev_activate_resource,
   .deactivate_resource = rootdev_deactivate_resource,
+};
+
+static ic_methods_t rootdev_ic_if = {
+  .intr_alloc = rootdev_intr_alloc,
+  .intr_release = rootdev_intr_release,
+  .intr_setup = rootdev_intr_setup,
+  .intr_teardown = rootdev_intr_teardown,
 };
 
 driver_t rootdev_driver = {
@@ -305,6 +316,7 @@ driver_t rootdev_driver = {
   .interfaces =
     {
       [DIF_BUS] = &rootdev_bus_if,
+      [DIF_IC] = &rootdev_ic_if,
     },
 };
 

--- a/sys/drv/bcm2835_rootdev.c
+++ b/sys/drv/bcm2835_rootdev.c
@@ -134,18 +134,18 @@ static void rootdev_disable_irq(intr_event_t *ie) {
   }
 }
 
-static resource_t *rootdev_intr_alloc(device_t *ic, device_t *dev, int rid,
+static resource_t *rootdev_alloc_intr(device_t *ic, device_t *dev, int rid,
                                       unsigned irq, rman_flags_t flags) {
   rootdev_t *rd = ic->state;
   rman_t *rman = &rd->irq_rm;
   return rman_reserve_resource(rman, RT_IRQ, rid, irq, irq, 1, 0, flags);
 }
 
-static void rootdev_intr_release(device_t *ic, device_t *dev, resource_t *r) {
+static void rootdev_release_intr(device_t *ic, device_t *dev, resource_t *r) {
   resource_release(r);
 }
 
-static void rootdev_intr_setup(device_t *ic, device_t *dev, resource_t *r,
+static void rootdev_setup_intr(device_t *ic, device_t *dev, resource_t *r,
                                ih_filter_t *filter, ih_service_t *service,
                                void *arg, const char *name) {
   rootdev_t *rd = ic->state;
@@ -160,7 +160,7 @@ static void rootdev_intr_setup(device_t *ic, device_t *dev, resource_t *r,
     intr_event_add_handler(rd->intr_event[irq], filter, service, arg, name);
 }
 
-static void rootdev_intr_teardown(device_t *ic, device_t *dev,
+static void rootdev_teardown_intr(device_t *ic, device_t *dev,
                                   resource_t *irq) {
   intr_event_remove_handler(irq->r_handler);
 }
@@ -233,12 +233,12 @@ static int rootdev_attach(device_t *bus) {
 
   /* Create ARM timer device and assign resources to it. */
   dev = device_add_child(bus, 0);
-  dev->ic = bus;
+  dev->pic = bus;
   device_add_irq(dev, 0, BCM2836_INT_CNTPNSIRQ_CPUN(0));
 
   /* Create PL011 UART device and assign resources to it. */
   dev = device_add_child(bus, 1);
-  dev->ic = bus;
+  dev->pic = bus;
   device_add_memory(dev, 0, BCM2835_PERIPHERALS_BUS_TO_PHYS(BCM2835_UART0_BASE),
                     BCM2835_UART0_SIZE);
   device_add_irq(dev, 0, BCM2835_INT_UART0);
@@ -300,11 +300,11 @@ static bus_methods_t rootdev_bus_if = {
   .deactivate_resource = rootdev_deactivate_resource,
 };
 
-static ic_methods_t rootdev_ic_if = {
-  .intr_alloc = rootdev_intr_alloc,
-  .intr_release = rootdev_intr_release,
-  .intr_setup = rootdev_intr_setup,
-  .intr_teardown = rootdev_intr_teardown,
+static pic_methods_t rootdev_pic_if = {
+  .alloc_intr = rootdev_alloc_intr,
+  .release_intr = rootdev_release_intr,
+  .setup_intr = rootdev_setup_intr,
+  .teardown_intr = rootdev_teardown_intr,
 };
 
 driver_t rootdev_driver = {
@@ -316,7 +316,7 @@ driver_t rootdev_driver = {
   .interfaces =
     {
       [DIF_BUS] = &rootdev_bus_if,
-      [DIF_IC] = &rootdev_ic_if,
+      [DIF_PIC] = &rootdev_pic_if,
     },
 };
 

--- a/sys/drv/gt64120.c
+++ b/sys/drv/gt64120.c
@@ -218,21 +218,21 @@ static const char *gt_pci_intr_name[IO_ICUSIZE] = {
 };
 /* clang-format on */
 
-static resource_t *gt_pci_alloc_intr(device_t *ic, device_t *dev, int rid,
+static resource_t *gt_pci_alloc_intr(device_t *pic, device_t *dev, int rid,
                                      unsigned irq, rman_flags_t flags) {
-  gt_pci_state_t *gtpci = ic->state;
+  gt_pci_state_t *gtpci = pic->state;
   rman_t *rman = &gtpci->irq_rman;
   return rman_reserve_resource(rman, RT_IRQ, rid, irq, irq, 1, 0, flags);
 }
 
-static void gt_pci_release_intr(device_t *ic, device_t *dev, resource_t *r) {
+static void gt_pci_release_intr(device_t *pic, device_t *dev, resource_t *r) {
   resource_release(r);
 }
 
-static void gt_pci_setup_intr(device_t *ic, device_t *dev, resource_t *r,
+static void gt_pci_setup_intr(device_t *pic, device_t *dev, resource_t *r,
                               ih_filter_t *filter, ih_service_t *service,
                               void *arg, const char *name) {
-  gt_pci_state_t *gtpci = ic->state;
+  gt_pci_state_t *gtpci = pic->state;
   int irq = resource_start(r);
   assert(irq < IO_ICUSIZE);
 
@@ -244,7 +244,8 @@ static void gt_pci_setup_intr(device_t *ic, device_t *dev, resource_t *r,
     intr_event_add_handler(gtpci->intr_event[irq], filter, service, arg, name);
 }
 
-static void gt_pci_teardown_intr(device_t *ic, device_t *dev, resource_t *irq) {
+static void gt_pci_teardown_intr(device_t *pic, device_t *dev,
+                                 resource_t *irq) {
   intr_event_remove_handler(irq->r_handler);
 }
 

--- a/sys/drv/gt64120.c
+++ b/sys/drv/gt64120.c
@@ -218,11 +218,21 @@ static const char *gt_pci_intr_name[IO_ICUSIZE] = {
 };
 /* clang-format on */
 
-static void gt_pci_intr_setup(device_t *dev, resource_t *r, ih_filter_t *filter,
-                              ih_service_t *service, void *arg,
-                              const char *name) {
-  assert(dev->parent->driver == &gt_pci_bus);
-  gt_pci_state_t *gtpci = dev->parent->state;
+static resource_t *gt_pci_intr_alloc(device_t *ic, device_t *dev, int rid,
+                                     unsigned irq, rman_flags_t flags) {
+  gt_pci_state_t *gtpci = ic->state;
+  rman_t *rman = &gtpci->irq_rman;
+  return rman_reserve_resource(rman, RT_IRQ, rid, irq, irq, 1, 0, flags);
+}
+
+static void gt_pci_intr_release(device_t *ic, device_t *dev, resource_t *r) {
+  resource_release(r);
+}
+
+static void gt_pci_intr_setup(device_t *ic, device_t *dev, resource_t *r,
+                              ih_filter_t *filter, ih_service_t *service,
+                              void *arg, const char *name) {
+  gt_pci_state_t *gtpci = ic->state;
   int irq = resource_start(r);
   assert(irq < IO_ICUSIZE);
 
@@ -234,9 +244,7 @@ static void gt_pci_intr_setup(device_t *dev, resource_t *r, ih_filter_t *filter,
     intr_event_add_handler(gtpci->intr_event[irq], filter, service, arg, name);
 }
 
-static void gt_pci_intr_teardown(device_t *pcib, resource_t *irq) {
-  assert(pcib->parent->driver == &gt_pci_bus);
-
+static void gt_pci_intr_teardown(device_t *ic, device_t *dev, resource_t *irq) {
   intr_event_remove_handler(irq->r_handler);
 }
 
@@ -332,8 +340,8 @@ static int gt_pci_attach(device_t *pcib) {
   bus_write_1(io, PIIX_REG_ELCR + 1, HI(gtpci->elcr));
 
   gtpci->irq_res = device_take_irq(pcib, 0, RF_ACTIVE);
-  bus_intr_setup(pcib, gtpci->irq_res, gt_pci_intr, NULL, gtpci,
-                 "GT64120 main irq");
+  intr_setup(pcib, gtpci->irq_res, gt_pci_intr, NULL, gtpci,
+             "GT64120 main irq");
 
   pci_bus_enumerate(pcib);
 
@@ -341,6 +349,7 @@ static int gt_pci_attach(device_t *pcib) {
 
   /* ISA Bridge */
   dev = device_add_child(pcib, 0);
+  dev->ic = pcib;
   dev->bus = DEV_BUS_PCI;
   dev->devclass = &DEVCLASS(isa);
   device_add_ioports(dev, 0, IO_ISABEGIN, IO_ISAEND + 1);
@@ -373,13 +382,11 @@ static resource_t *gt_pci_alloc_resource(device_t *dev, res_type_t type,
   if (type == RT_IOPORTS) {
     rman = &gtpci->pci_io_rman;
     bh = gtpci->pci_io->r_bus_handle;
-  } else if (type == RT_IRQ) {
-    rman = &gtpci->irq_rman;
   } else if (type == RT_MEMORY) {
     alignment = PAGESIZE;
     rman = &gtpci->pci_mem_rman;
   } else {
-    panic("Unknown PCI device type: %d", type);
+    panic("Invalid resource type in bus allocation: %d", type);
   }
 
   if (gt_pci_bar(dev, type, rid, start))
@@ -390,10 +397,8 @@ static resource_t *gt_pci_alloc_resource(device_t *dev, res_type_t type,
   if (!r)
     return NULL;
 
-  if (type != RT_IRQ) {
-    r->r_bus_tag = generic_bus_space;
-    r->r_bus_handle = bh + resource_start(r);
-  }
+  r->r_bus_tag = generic_bus_space;
+  r->r_bus_handle = bh + resource_start(r);
 
   if (type == RT_IOPORTS || flags & RF_ACTIVE) {
     if (bus_activate_resource(dev, r)) {
@@ -413,8 +418,7 @@ static void gt_pci_release_resource(device_t *dev, resource_t *r) {
 static int gt_pci_activate_resource(device_t *dev, resource_t *r) {
   rman_addr_t start = resource_start(r);
 
-  if (r->r_type == RT_MEMORY ||
-      (r->r_type == RT_IOPORTS && start > IO_ISAEND)) {
+  if (r->r_type == RT_MEMORY || start > IO_ISAEND) {
     uint16_t command = pci_read_config_2(dev, PCIR_COMMAND);
     if (r->r_type == RT_MEMORY)
       command |= PCIM_CMD_MEMEN;
@@ -443,12 +447,17 @@ static int gt_pci_probe(device_t *d) {
 }
 
 static bus_methods_t gt_pci_bus_if = {
-  .intr_setup = gt_pci_intr_setup,
-  .intr_teardown = gt_pci_intr_teardown,
   .alloc_resource = gt_pci_alloc_resource,
   .release_resource = gt_pci_release_resource,
   .activate_resource = gt_pci_activate_resource,
   .deactivate_resource = gt_pci_deactivate_resource,
+};
+
+static ic_methods_t gt_ic_if = {
+  .intr_alloc = gt_pci_intr_alloc,
+  .intr_release = gt_pci_intr_release,
+  .intr_setup = gt_pci_intr_setup,
+  .intr_teardown = gt_pci_intr_teardown,
 };
 
 static pci_bus_methods_t gt_pci_pci_bus_if = {
@@ -467,6 +476,7 @@ static driver_t gt_pci_bus = {
   .interfaces =
     {
       [DIF_BUS] = &gt_pci_bus_if,
+      [DIF_IC] = &gt_ic_if,
       [DIF_PCI_BUS] = &gt_pci_pci_bus_if,
     },
 };

--- a/sys/drv/malta_rootdev.c
+++ b/sys/drv/malta_rootdev.c
@@ -37,21 +37,21 @@ static const char *rootdev_intr_name[MIPS_NIRQ] = {
 };
 /* clang-format on */
 
-static resource_t *rootdev_alloc_intr(device_t *ic, device_t *dev, int rid,
+static resource_t *rootdev_alloc_intr(device_t *pic, device_t *dev, int rid,
                                       unsigned irq, rman_flags_t flags) {
-  rootdev_t *rd = ic->state;
+  rootdev_t *rd = pic->state;
   rman_t *rman = &rd->irq;
   return rman_reserve_resource(rman, RT_IRQ, rid, irq, irq, 1, 0, flags);
 }
 
-static void rootdev_release_intr(device_t *ic, device_t *dev, resource_t *r) {
+static void rootdev_release_intr(device_t *pic, device_t *dev, resource_t *r) {
   resource_release(r);
 }
 
-static void rootdev_setup_intr(device_t *ic, device_t *dev, resource_t *r,
+static void rootdev_setup_intr(device_t *pic, device_t *dev, resource_t *r,
                                ih_filter_t *filter, ih_service_t *service,
                                void *arg, const char *name) {
-  rootdev_t *rd = ic->state;
+  rootdev_t *rd = pic->state;
   int irq = resource_start(r);
   assert(irq < MIPS_NIRQ);
 
@@ -63,7 +63,7 @@ static void rootdev_setup_intr(device_t *ic, device_t *dev, resource_t *r,
     intr_event_add_handler(rd->intr_event[irq], filter, service, arg, name);
 }
 
-static void rootdev_teardown_intr(device_t *ic, device_t *dev,
+static void rootdev_teardown_intr(device_t *pic, device_t *dev,
                                   resource_t *irq) {
   intr_event_remove_handler(irq->r_handler);
 

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -90,7 +90,7 @@ static int ns16550_attach(device_t *dev) {
   assert(ns16550->regs != NULL);
 
   ns16550->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
-  intr_setup(dev, ns16550->irq_res, uart_intr, NULL, dev, "NS16550 UART");
+  pic_setup_intr(dev, ns16550->irq_res, uart_intr, NULL, dev, "NS16550 UART");
 
   /* Setup UART and enable interrupts */
   setup(ns16550->regs);

--- a/sys/drv/ns16550.c
+++ b/sys/drv/ns16550.c
@@ -90,7 +90,7 @@ static int ns16550_attach(device_t *dev) {
   assert(ns16550->regs != NULL);
 
   ns16550->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
-  bus_intr_setup(dev, ns16550->irq_res, uart_intr, NULL, dev, "NS16550 UART");
+  intr_setup(dev, ns16550->irq_res, uart_intr, NULL, dev, "NS16550 UART");
 
   /* Setup UART and enable interrupts */
   setup(ns16550->regs);

--- a/sys/drv/pci.c
+++ b/sys/drv/pci.c
@@ -102,7 +102,7 @@ void pci_bus_enumerate(device_t *pcib) {
       device_t *dev = device_add_child(pcib, -1);
       pci_device_t *pcid = kmalloc(M_DEV, sizeof(pci_device_t), M_ZERO);
 
-      dev->ic = pcib;
+      dev->pic = pcib;
       dev->bus = DEV_BUS_PCI;
       dev->instance = pcid;
 

--- a/sys/drv/pci.c
+++ b/sys/drv/pci.c
@@ -102,6 +102,7 @@ void pci_bus_enumerate(device_t *pcib) {
       device_t *dev = device_add_child(pcib, -1);
       pci_device_t *pcid = kmalloc(M_DEV, sizeof(pci_device_t), M_ZERO);
 
+      dev->ic = pcib;
       dev->bus = DEV_BUS_PCI;
       dev->instance = pcid;
 

--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -112,14 +112,14 @@ static int pit_timer_start(timer_t *tm, unsigned flags, const bintime_t start,
 
   pit_set_frequency(pit);
 
-  bus_intr_setup(dev, pit->irq_res, pit_intr, NULL, pit, "i8254 timer");
+  intr_setup(dev, pit->irq_res, pit_intr, NULL, pit, "i8254 timer");
   return 0;
 }
 
 static int pit_timer_stop(timer_t *tm) {
   device_t *dev = device_of(tm);
   pit_state_t *pit = dev->state;
-  bus_intr_teardown(dev, pit->irq_res);
+  intr_teardown(dev, pit->irq_res);
   return 0;
 }
 

--- a/sys/drv/pit.c
+++ b/sys/drv/pit.c
@@ -112,14 +112,14 @@ static int pit_timer_start(timer_t *tm, unsigned flags, const bintime_t start,
 
   pit_set_frequency(pit);
 
-  intr_setup(dev, pit->irq_res, pit_intr, NULL, pit, "i8254 timer");
+  pic_setup_intr(dev, pit->irq_res, pit_intr, NULL, pit, "i8254 timer");
   return 0;
 }
 
 static int pit_timer_stop(timer_t *tm) {
   device_t *dev = device_of(tm);
   pit_state_t *pit = dev->state;
-  intr_teardown(dev, pit->irq_res);
+  pic_teardown_intr(dev, pit->irq_res);
   return 0;
 }
 

--- a/sys/drv/pl011.c
+++ b/sys/drv/pl011.c
@@ -128,7 +128,7 @@ static int pl011_attach(device_t *dev) {
   bus_write_4(r, PL011COM_IMSC, PL011_INT_RX);
 
   pl011->irq = device_take_irq(dev, 0, RF_ACTIVE);
-  bus_intr_setup(dev, pl011->irq, uart_intr, NULL, dev, "PL011 UART");
+  intr_setup(dev, pl011->irq, uart_intr, NULL, dev, "PL011 UART");
 
   /* Prepare /dev/uart interface. */
   tty_makedev(NULL, "uart", tty);

--- a/sys/drv/pl011.c
+++ b/sys/drv/pl011.c
@@ -128,7 +128,7 @@ static int pl011_attach(device_t *dev) {
   bus_write_4(r, PL011COM_IMSC, PL011_INT_RX);
 
   pl011->irq = device_take_irq(dev, 0, RF_ACTIVE);
-  intr_setup(dev, pl011->irq, uart_intr, NULL, dev, "PL011 UART");
+  pic_setup_intr(dev, pl011->irq, uart_intr, NULL, dev, "PL011 UART");
 
   /* Prepare /dev/uart interface. */
   tty_makedev(NULL, "uart", tty);

--- a/sys/drv/rtc.c
+++ b/sys/drv/rtc.c
@@ -102,7 +102,7 @@ static int rtc_attach(device_t *dev) {
   assert(rtc->regs != NULL);
 
   rtc->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
-  bus_intr_setup(dev, rtc->irq_res, rtc_intr, NULL, rtc, "RTC periodic timer");
+  intr_setup(dev, rtc->irq_res, rtc_intr, NULL, rtc, "RTC periodic timer");
 
   /* Configure how the time is presented through registers. */
   rtc_setb(rtc->regs, MC_REGB, MC_REGB_BINARY | MC_REGB_24HR);

--- a/sys/drv/rtc.c
+++ b/sys/drv/rtc.c
@@ -102,7 +102,7 @@ static int rtc_attach(device_t *dev) {
   assert(rtc->regs != NULL);
 
   rtc->irq_res = device_take_irq(dev, 0, RF_ACTIVE);
-  intr_setup(dev, rtc->irq_res, rtc_intr, NULL, rtc, "RTC periodic timer");
+  pic_setup_intr(dev, rtc->irq_res, rtc_intr, NULL, rtc, "RTC periodic timer");
 
   /* Configure how the time is presented through registers. */
   rtc_setb(rtc->regs, MC_REGB, MC_REGB_BINARY | MC_REGB_24HR);

--- a/sys/drv/rtl8139.c
+++ b/sys/drv/rtl8139.c
@@ -82,7 +82,7 @@ static int rtl8139_attach(device_t *dev) {
     err = ENXIO;
     goto fail;
   }
-  bus_intr_setup(dev, state->irq_res, rtl8139_intr, NULL, state, "RTL8139");
+  intr_setup(dev, state->irq_res, rtl8139_intr, NULL, state, "RTL8139");
 
   /* TODO: introduce ring buffer */
 

--- a/sys/drv/rtl8139.c
+++ b/sys/drv/rtl8139.c
@@ -82,7 +82,7 @@ static int rtl8139_attach(device_t *dev) {
     err = ENXIO;
     goto fail;
   }
-  intr_setup(dev, state->irq_res, rtl8139_intr, NULL, state, "RTL8139");
+  pic_setup_intr(dev, state->irq_res, rtl8139_intr, NULL, state, "RTL8139");
 
   /* TODO: introduce ring buffer */
 

--- a/sys/drv/uhci.c
+++ b/sys/drv/uhci.c
@@ -821,7 +821,7 @@ static int uhci_attach(device_t *dev) {
   /* Setup host controller's interrupt. */
   uhci->irq = device_take_irq(dev, 0, RF_ACTIVE);
   assert(uhci->irq);
-  bus_intr_setup(dev, uhci->irq, uhci_isr, NULL, uhci, "UHCI");
+  intr_setup(dev, uhci->irq, uhci_isr, NULL, uhci, "UHCI");
 
   /* Turn on the IOC and error interrupts. */
   set16(UHCI_INTR, UHCI_INTR_TOCRCIE | UHCI_INTR_IOCE);
@@ -835,7 +835,7 @@ static int uhci_attach(device_t *dev) {
   /* Detect and configure attached devices. */
   int error = usb_enumerate(dev);
   if (error)
-    bus_intr_teardown(dev, uhci->irq);
+    intr_teardown(dev, uhci->irq);
   return error;
 }
 

--- a/sys/drv/uhci.c
+++ b/sys/drv/uhci.c
@@ -821,7 +821,7 @@ static int uhci_attach(device_t *dev) {
   /* Setup host controller's interrupt. */
   uhci->irq = device_take_irq(dev, 0, RF_ACTIVE);
   assert(uhci->irq);
-  intr_setup(dev, uhci->irq, uhci_isr, NULL, uhci, "UHCI");
+  pic_setup_intr(dev, uhci->irq, uhci_isr, NULL, uhci, "UHCI");
 
   /* Turn on the IOC and error interrupts. */
   set16(UHCI_INTR, UHCI_INTR_TOCRCIE | UHCI_INTR_IOCE);
@@ -835,7 +835,7 @@ static int uhci_attach(device_t *dev) {
   /* Detect and configure attached devices. */
   int error = usb_enumerate(dev);
   if (error)
-    intr_teardown(dev, uhci->irq);
+    pic_teardown_intr(dev, uhci->irq);
   return error;
 }
 

--- a/sys/kern/bus.c
+++ b/sys/kern/bus.c
@@ -96,22 +96,6 @@ bus_space_t *generic_bus_space = &(bus_space_t){
   .bs_write_region_4 = generic_bs_write_region_4,
 };
 
-void bus_intr_setup(device_t *dev, resource_t *irq, ih_filter_t *filter,
-                    ih_service_t *service, void *arg, const char *name) {
-  device_t *idev = BUS_METHOD_PROVIDER(dev, intr_setup);
-  bus_methods(idev->parent)->intr_setup(idev, irq, filter, service, arg, name);
-  if (irq->r_handler)
-    resource_activate(irq);
-}
-
-void bus_intr_teardown(device_t *dev, resource_t *irq) {
-  assert(resource_active(irq));
-  device_t *idev = BUS_METHOD_PROVIDER(dev, intr_teardown);
-  bus_methods(idev->parent)->intr_teardown(idev, irq);
-  irq->r_handler = NULL;
-  resource_deactivate(irq);
-}
-
 int bus_activate_resource(device_t *dev, resource_t *r) {
   if (resource_active(r) || r->r_type == RT_IRQ)
     return 0;

--- a/sys/kern/device.c
+++ b/sys/kern/device.c
@@ -68,7 +68,11 @@ void device_add_resource(device_t *dev, res_type_t type, int rid,
                          rman_addr_t start, rman_addr_t end, size_t size,
                          rman_flags_t flags) {
   assert(!resource_list_find(dev, rid, type));
-  resource_t *r = bus_alloc_resource(dev, type, rid, start, end, size, flags);
+  resource_t *r;
+  if (type == RT_IRQ)
+    r = intr_alloc(dev, rid, start, flags);
+  else
+    r = bus_alloc_resource(dev, type, rid, start, end, size, flags);
   assert(r);
   SLIST_INSERT_HEAD(&dev->resources, r, r_link);
 }
@@ -79,7 +83,7 @@ resource_t *device_take_resource(device_t *dev, res_type_t type, int rid,
   if (!r)
     return NULL;
 
-  if (flags & RF_ACTIVE)
+  if ((type != RT_IRQ) && flags & RF_ACTIVE)
     bus_activate_resource(dev, r);
 
   return r;

--- a/sys/kern/device.c
+++ b/sys/kern/device.c
@@ -70,7 +70,7 @@ void device_add_resource(device_t *dev, res_type_t type, int rid,
   assert(!resource_list_find(dev, rid, type));
   resource_t *r;
   if (type == RT_IRQ)
-    r = intr_alloc(dev, rid, start, flags);
+    r = pic_alloc_intr(dev, rid, start, flags);
   else
     r = bus_alloc_resource(dev, type, rid, start, end, size, flags);
   assert(r);

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -214,36 +214,36 @@ void intr_event_run_handlers(intr_event_t *ie) {
     klog("Spurious %s interrupt!", ie->ie_name);
 }
 
-static inline ic_methods_t *ic_methods(device_t *dev) {
-  return (ic_methods_t *)dev->driver->interfaces[DIF_IC];
+static inline pic_methods_t *pic_methods(device_t *dev) {
+  return (pic_methods_t *)dev->driver->interfaces[DIF_PIC];
 }
 
-resource_t *intr_alloc(device_t *dev, int rid, unsigned irq,
-                       rman_flags_t flags) {
-  device_t *ic = dev->ic;
-  return ic_methods(ic)->intr_alloc(ic, dev, rid, irq, flags);
+resource_t *pic_alloc_intr(device_t *dev, int rid, unsigned irq,
+                           rman_flags_t flags) {
+  device_t *pic = dev->pic;
+  return pic_methods(pic)->alloc_intr(pic, dev, rid, irq, flags);
 }
 
-void intr_release(device_t *dev, resource_t *r) {
+void pic_release_intr(device_t *dev, resource_t *r) {
   assert(r->r_type == RT_IRQ);
-  device_t *ic = dev->ic;
-  ic_methods(ic)->intr_release(ic, dev, r);
+  device_t *pic = dev->pic;
+  pic_methods(pic)->release_intr(pic, dev, r);
 }
 
-void intr_setup(device_t *dev, resource_t *r, ih_filter_t *filter,
-                ih_service_t *service, void *arg, const char *name) {
+void pic_setup_intr(device_t *dev, resource_t *r, ih_filter_t *filter,
+                    ih_service_t *service, void *arg, const char *name) {
   assert(r->r_type == RT_IRQ);
-  device_t *ic = dev->ic;
-  ic_methods(ic)->intr_setup(ic, dev, r, filter, service, arg, name);
+  device_t *pic = dev->pic;
+  pic_methods(pic)->setup_intr(pic, dev, r, filter, service, arg, name);
   if (r->r_handler)
     resource_activate(r);
 }
 
-void intr_teardown(device_t *dev, resource_t *r) {
+void pic_teardown_intr(device_t *dev, resource_t *r) {
   assert(r->r_type == RT_IRQ);
   assert(resource_active(r));
-  device_t *ic = dev->ic;
-  ic_methods(ic)->intr_teardown(ic, dev, r);
+  device_t *pic = dev->pic;
+  pic_methods(pic)->teardown_intr(pic, dev, r);
   r->r_handler = NULL;
   resource_deactivate(r);
 }

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -7,6 +7,7 @@
 #include <sys/pcpu.h>
 #include <sys/sleepq.h>
 #include <sys/sched.h>
+#include <sys/device.h>
 
 static KMALLOC_DEFINE(M_INTR, "interrupt events & handlers");
 
@@ -211,6 +212,40 @@ void intr_event_run_handlers(intr_event_t *ie) {
 
   if (ie_status == IF_STRAY)
     klog("Spurious %s interrupt!", ie->ie_name);
+}
+
+static inline ic_methods_t *ic_methods(device_t *dev) {
+  return (ic_methods_t *)dev->driver->interfaces[DIF_IC];
+}
+
+resource_t *intr_alloc(device_t *dev, int rid, unsigned irq,
+                       rman_flags_t flags) {
+  device_t *ic = dev->ic;
+  return ic_methods(ic)->intr_alloc(ic, dev, rid, irq, flags);
+}
+
+void intr_release(device_t *dev, resource_t *r) {
+  assert(r->r_type == RT_IRQ);
+  device_t *ic = dev->ic;
+  ic_methods(ic)->intr_release(ic, dev, r);
+}
+
+void intr_setup(device_t *dev, resource_t *r, ih_filter_t *filter,
+                ih_service_t *service, void *arg, const char *name) {
+  assert(r->r_type == RT_IRQ);
+  device_t *ic = dev->ic;
+  ic_methods(ic)->intr_setup(ic, dev, r, filter, service, arg, name);
+  if (r->r_handler)
+    resource_activate(r);
+}
+
+void intr_teardown(device_t *dev, resource_t *r) {
+  assert(r->r_type == RT_IRQ);
+  assert(resource_active(r));
+  device_t *ic = dev->ic;
+  ic_methods(ic)->intr_teardown(ic, dev, r);
+  r->r_handler = NULL;
+  resource_deactivate(r);
 }
 
 static void intr_thread(void *arg) {

--- a/sys/mips/timer.c
+++ b/sys/mips/timer.c
@@ -85,15 +85,14 @@ static int mips_timer_start(timer_t *tm, unsigned flags, const bintime_t start,
   state->compare.val = read_count(state);
 
   set_next_tick(state);
-  bus_intr_setup(dev, state->irq_res, mips_timer_intr, NULL, dev,
-                 "MIPS CPU timer");
+  intr_setup(dev, state->irq_res, mips_timer_intr, NULL, dev, "MIPS CPU timer");
   return 0;
 }
 
 static int mips_timer_stop(timer_t *tm) {
   device_t *dev = tm->tm_priv;
   mips_timer_state_t *state = dev->state;
-  bus_intr_teardown(dev, state->irq_res);
+  intr_teardown(dev, state->irq_res);
   return 0;
 }
 

--- a/sys/mips/timer.c
+++ b/sys/mips/timer.c
@@ -85,14 +85,15 @@ static int mips_timer_start(timer_t *tm, unsigned flags, const bintime_t start,
   state->compare.val = read_count(state);
 
   set_next_tick(state);
-  intr_setup(dev, state->irq_res, mips_timer_intr, NULL, dev, "MIPS CPU timer");
+  pic_setup_intr(dev, state->irq_res, mips_timer_intr, NULL, dev,
+                 "MIPS CPU timer");
   return 0;
 }
 
 static int mips_timer_stop(timer_t *tm) {
   device_t *dev = tm->tm_priv;
   mips_timer_state_t *state = dev->state;
-  intr_teardown(dev, state->irq_res);
+  pic_teardown_intr(dev, state->irq_res);
   return 0;
 }
 


### PR DESCRIPTION
With the arrival of RISC-V we finally have interrupt controllers that cannot be perceived as buses. Therefore, the current bus interface must be split into two separate interfaces:
- bus interface,
- interrupt controller interface.