### PR TITLE
[RISCV] QEmu: add 64-bit system emulator.

### DIFF
--- a/toolchain/qemu-mimiker/Makefile
+++ b/toolchain/qemu-mimiker/Makefile
@@ -44,7 +44,7 @@ configure-stamp: patch-stamp
 		--disable-bzip2 \
 		--disable-tpm \
 		--disable-linux-aio \
-	    	--target-list=mipsel-softmmu,aarch64-softmmu \
+	    	--target-list=mipsel-softmmu,aarch64-softmmu,riscv64-softmmu \
 		--with-suffix=qemu-mimiker
 	touch $@
 

--- a/toolchain/qemu-mimiker/debian/changelog
+++ b/toolchain/qemu-mimiker/debian/changelog
@@ -1,3 +1,9 @@
+qemu-mimiker (6.0.0+mimiker2) unstable; urgency=medium
+
+  * Add system simulator for 64-bit RISC-V.
+
+ -- Krystian Bacławski <cahirwpz@cs.uni.wroc.pl>  Wed, 20 Apr 2022 13:31:33 +0200
+
 qemu-mimiker (6.0.0+mimiker1) unstable; urgency=medium
 
   * Bump up version.

--- a/toolchain/qemu-mimiker/debian/control
+++ b/toolchain/qemu-mimiker/debian/control
@@ -10,5 +10,5 @@ Package: qemu-mimiker
 Architecture: amd64
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: QEMU system simulator for Mimiker OS development
- This package contains modified QEMU system simulator for mipsel and aarch64
- architectures.
+ This package contains modified QEMU system simulator for mipsel, aarch64,
+ and riscv64 architectures.


### PR DESCRIPTION
Mimiker will support both 32- and 64-bit RISC-V CPUs. For the 64-bit variant, the QEum system emulator will be used.