### PR TITLE
[RISCV] Fix generic assembly macros.

### DIFF
--- a/include/riscv/asm.h
+++ b/include/riscv/asm.h
@@ -112,15 +112,15 @@
 #define INT_SCALESHIFT 2
 #if __riscv_xlen == 64
 #define INT_ADD addw
-#define INT_ADDI addwi
+#define INT_ADDI addiw
 #define INT_SUB subw
-#define INT_SUBI subwi
-#define INT_SLL sllwi
-#define INT_SLLV sllw
-#define INT_SRL srlwi
-#define INT_SRLV srlw
-#define INT_SRA srawi
-#define INT_SRAV sraw
+#define INT_SUBI subiw
+#define INT_SLLI slliw
+#define INT_SLL sllw
+#define INT_SRLI srliw
+#define INT_SRL srlw
+#define INT_SRAI sraiw
+#define INT_SRA sraw
 #else
 #define INT_ADD add
 #define INT_ADDI addi


### PR DESCRIPTION
Apparently, [NetBSD](https://mimiker.ii.uni.wroc.pl/source/xref/NetBSD/sys/arch/riscv/include/asm.h?r=1fe5c4da#188) has wrong definitions of the 64-bit ops that operate on 32-bit values.