### PR TITLE
[dtb] Access FDT blob using dmap.

### DIFF
--- a/include/sys/fdt.h
+++ b/include/sys/fdt.h
@@ -41,11 +41,14 @@ typedef struct fdt_mem_reg {
 void FDT_early_init(paddr_t pa, vaddr_t va);
 
 /*
- * Final FDT initialization.
- *
- * Called during MI kernel bootstrap.
+ * Obtain the physical address of the FDT blob.
  */
-void FDT_init(void);
+paddr_t FDT_get_physaddr(void);
+
+/*
+ * Change the internal root FDT pointer.
+ */
+void FDT_changeroot(void *root);
 
 /*
  * Obtain physical memory boundaries of the FDT blob.

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -96,7 +96,6 @@ __noreturn void kernel_init(void) {
   preempt_enable();
 
   /* [FIRST_PASS] Initialize first timer and console devices. */
-  FDT_init();
   init_devices();
 
   init_vfs();


### PR DESCRIPTION
We don't have to map the FDT blob to kva as it can be accessed through the direct map. The `FDT_change_root` and `FDT_get_physaddr` functions are used (currently only by RISC-V, see #1182) to provide the FDT module with a dmap address after building the direct map. (Note that the same will be done for Aarch64 when the code is changed to first read the memory boundaries and build dmap afterward.)

Besides, the PR removes a warning caused by aliasing violation.