### PR TITLE
[RISCV] Change ISA to IMA.

### DIFF
--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -13,7 +13,7 @@ ELFTYPE := elf32-littleriscv
 ELFARCH := riscv
 
 ifeq ($(BOARD), litex-riscv)
-	EXT := ima
+	EXT := ima_zicsr_zifence
 	ABI := ilp32
 	KERNEL_PHYS := 0x40000000
 	KERNEL-IMAGES := mimiker.img

--- a/toolchain/gnu/riscv32-mimiker-elf/Makefile
+++ b/toolchain/gnu/riscv32-mimiker-elf/Makefile
@@ -5,7 +5,7 @@ TOPDIR = $(realpath ..)
 ARCH = riscv32
 TARGET = riscv32-mimiker-elf
 
-GCC_EXTRA_CONF = --with-arch=rv32ima \
+GCC_EXTRA_CONF = --with-arch=rv32ima_zicsr_zifence \
 		 --with-abi=ilp32
 
 include $(TOPDIR)/target.mk

--- a/toolchain/gnu/riscv32-mimiker-elf/Makefile
+++ b/toolchain/gnu/riscv32-mimiker-elf/Makefile
@@ -5,7 +5,7 @@ TOPDIR = $(realpath ..)
 ARCH = riscv32
 TARGET = riscv32-mimiker-elf
 
-GCC_EXTRA_CONF = --with-arch=rv32gc \
-		 --with-abi=ilp32d
+GCC_EXTRA_CONF = --with-arch=rv32ima \
+		 --with-abi=ilp32
 
 include $(TOPDIR)/target.mk


### PR DESCRIPTION
FTTB, the only supported hardware platform for the RISC-V 32 target architecture is LiteX VexRiscv. Our configuration of the VexRiscv core doesn't support any floating-point extension which makes it impossible to compile the system using the current toolchain as we rely on libgcc which expects hard floats.

Besides, more recent releases of the gnu tools distinguish zicsr and zifence extensions from the i extension.