### PR TITLE
[libkern] Implement kasprintf.

### DIFF
--- a/include/sys/libkern.h
+++ b/include/sys/libkern.h
@@ -40,6 +40,7 @@ int toascii(int);
 int snprintf(char *buf, size_t size, const char *fmt, ...)
   __attribute__((format(printf, 3, 4)));
 int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap);
+char *kasprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 int sscanf(const char *str, const char *fmt, ...)
   __attribute__((format(scanf, 2, 3)));
 int vsscanf(const char *str, char const *fmt, va_list ap);

--- a/sys/libkern/stdio/printf.c
+++ b/sys/libkern/stdio/printf.c
@@ -36,6 +36,7 @@
 
 #include <sys/libkern.h>
 #include <sys/console.h>
+#include <sys/malloc.h>
 #include <limits.h>
 
 /*
@@ -110,6 +111,27 @@ vsnprintf(char *buf, size_t size, const char *cfmt, va_list ap)
 		*(arg.buf)++ = 0;
 
 	return (retval);
+}
+
+char *
+kasprintf(const char *fmt, ...)
+{
+	va_list ap, aq;
+	unsigned len;
+	char *p;
+
+	va_start(ap, fmt);
+
+	va_copy(aq, ap);
+	len = vsnprintf(NULL, 0, fmt, aq);
+	va_end(aq);
+
+	p = kmalloc(M_STR, len + 1, M_WAITOK);
+	vsnprintf(p, len + 1, fmt, ap);
+
+	va_end(ap);
+
+	return p;
 }
 
 static void


### PR DESCRIPTION
`kasprintf` is a prinf-like function commonly used by device drivers e.q. in Linux. We came to the conclusion that it would be beneficial to have this function implemented in Mimiker. We already have a usage example in #1237 (in `plic_intr_name`).