### PR TITLE
[drv] Move device's state allocation and release to attach

### DIFF
--- a/sys/kern/device.c
+++ b/sys/kern/device.c
@@ -34,21 +34,18 @@ void device_remove_child(device_t *parent, device_t *dev) {
 int device_probe(device_t *dev) {
   assert(dev->driver != NULL);
   d_probe_t probe = dev->driver->probe;
-  int found = probe ? probe(dev) : 0;
-  if (found)
-    dev->state = kmalloc(M_DEV, dev->driver->size, M_ZERO);
-  return found;
+  return probe ? probe(dev) : 0;
 }
 
 int device_attach(device_t *dev) {
   assert(dev->driver != NULL);
   d_attach_t attach = dev->driver->attach;
-  int err = ENODEV;
-  if (attach != NULL) {
-    err = attach(dev);
-    if (!err)
-      return 0;
-  }
+  if (attach == NULL)
+    return ENODEV;
+  dev->state = kmalloc(M_DEV, dev->driver->size, M_ZERO);
+  int err = attach(dev);
+  if (!err)
+    return 0;
   kfree(M_DEV, dev->state);
   return err;
 }

--- a/sys/kern/device.c
+++ b/sys/kern/device.c
@@ -43,7 +43,14 @@ int device_probe(device_t *dev) {
 int device_attach(device_t *dev) {
   assert(dev->driver != NULL);
   d_attach_t attach = dev->driver->attach;
-  return attach ? attach(dev) : ENODEV;
+  int err = ENODEV;
+  if (attach != NULL) {
+    err = attach(dev);
+    if (!err)
+      return 0;
+  }
+  kfree(M_DEV, dev->state);
+  return err;
 }
 
 int device_detach(device_t *dev) {


### PR DESCRIPTION
First, we need to start releasing the state allocated for a device if the attach is unsuccessful. Additionally, I moved allocation from probe to attach.