### PR TITLE
[drv] Fix simplebus.

### DIFF
--- a/include/sys/fdt.h
+++ b/include/sys/fdt.h
@@ -15,7 +15,7 @@
 #define FDT_MAX_RSV_MEM_REGS 16
 #define FDT_MAX_REG_TUPLES 16
 #define FDT_MAX_ICELLS 3
-#define FDT_MAX_INTRS 8
+#define FDT_MAX_INTRS 16
 
 typedef uint32_t phandle_t;
 typedef uint32_t pcell_t;

--- a/sys/drv/simplebus.c
+++ b/sys/drv/simplebus.c
@@ -53,8 +53,8 @@ static int sb_get_interrupts(device_t *dev, fdt_intr_t *intrs, size_t *cntp) {
     return err;
 
   pcell_t *tuples;
-  int ntuples =
-    FDT_getencprop_alloc_multi(node, "interrupts", icells, (void **)&tuples);
+  int ntuples = FDT_getencprop_alloc_multi(
+    node, "interrupts", icells * sizeof(pcell_t), (void **)&tuples);
   if (ntuples == -1)
     return ENXIO;
   if (!ntuples)


### PR DESCRIPTION
- It turns out that it's not that rare for a device to generate more 8 interrupts (e.g. plic and clint in HiFive Unleashed)
- Fix tuples allocation for interrupt cells
- Fix validation logic
- Fix tuple copying