### PR TITLE
[RISCV] Update toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,3 @@ RUN curl -O https://mimiker.ii.uni.wroc.pl/download/riscv32-mimiker-elf_latest_a
     dpkg -i riscv32-mimiker-elf_latest_amd64.deb && rm -f riscv32-mimiker-elf_latest_amd64.deb
 RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_latest_amd64.deb && \
     dpkg -i qemu-mimiker_latest_amd64.deb && rm -f qemu-mimiker_latest_amd64.deb
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,21 @@ FROM debian:bullseye-backports
 WORKDIR /root
 
 RUN apt-get -q update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends -t bullseye-backports \
       git make cpio curl universal-ctags cscope socat patch gperf quilt \
       bmake byacc python3-pip clang clang-format device-tree-compiler tmux \
-      libfdt1 libpython3.9 libsdl2-2.0-0 libglib2.0-0 libpixman-1-0
+      libmpfr6 libfdt1 libpython3.9 libsdl2-2.0-0 libglib2.0-0 libpixman-1-0
 # patch & quilt required by lua and programs in contrib/
 # gperf required by libterminfo
 # socat & tmux required by launch
 COPY requirements.txt .
 RUN pip3 install setuptools wheel && pip3 install -r requirements.txt
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.5.4_amd64.deb && \
-    dpkg -i mipsel-mimiker-elf_1.5.4_amd64.deb && rm -f mipsel-mimiker-elf_1.5.4_amd64.deb
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_1.5.4_amd64.deb && \
-    dpkg -i aarch64-mimiker-elf_1.5.4_amd64.deb && rm -f aarch64-mimiker-elf_1.5.4_amd64.deb
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.5.4_amd64.deb && \
-    dpkg -i riscv32-mimiker-elf_1.5.4_amd64.deb && rm -f mipsel-mimiker-elf_1.5.4_amd64.deb
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_6.0.0+mimiker1_amd64.deb && \
-    dpkg -i qemu-mimiker_6.0.0+mimiker1_amd64.deb && rm -f qemu-mimiker_6.0.0+mimiker1_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_latest_amd64.deb && \
+    dpkg -i mipsel-mimiker-elf_latest_amd64.deb && rm -f mipsel-mimiker-elf_latest_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_latest_amd64.deb && \
+    dpkg -i aarch64-mimiker-elf_latest_amd64.deb && rm -f aarch64-mimiker-elf_latest_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/riscv32-mimiker-elf_latest_amd64.deb && \
+    dpkg -i riscv32-mimiker-elf_latest_amd64.deb && rm -f riscv32-mimiker-elf_latest_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_latest_amd64.deb && \
+    dpkg -i qemu-mimiker_latest_amd64.deb && rm -f qemu-mimiker_latest_amd64.deb
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get install -y --no-install-recommends \
 # socat & tmux required by launch
 COPY requirements.txt .
 RUN pip3 install setuptools wheel && pip3 install -r requirements.txt
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.5.3_amd64.deb && \
-    dpkg -i mipsel-mimiker-elf_1.5.3_amd64.deb && rm -f mipsel-mimiker-elf_1.5.3_amd64.deb
-RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_1.5.3_amd64.deb && \
-    dpkg -i aarch64-mimiker-elf_1.5.3_amd64.deb && rm -f aarch64-mimiker-elf_1.5.3_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.5.4_amd64.deb && \
+    dpkg -i mipsel-mimiker-elf_1.5.4_amd64.deb && rm -f mipsel-mimiker-elf_1.5.4_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_1.5.4_amd64.deb && \
+    dpkg -i aarch64-mimiker-elf_1.5.4_amd64.deb && rm -f aarch64-mimiker-elf_1.5.4_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/mipsel-mimiker-elf_1.5.4_amd64.deb && \
+    dpkg -i riscv32-mimiker-elf_1.5.4_amd64.deb && rm -f mipsel-mimiker-elf_1.5.4_amd64.deb
 RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_6.0.0+mimiker1_amd64.deb && \
     dpkg -i qemu-mimiker_6.0.0+mimiker1_amd64.deb && rm -f qemu-mimiker_6.0.0+mimiker1_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: sys-build initrd.cpio
 
 PHONY-TARGETS += setup test
 
-IMGVER = 1.8.4
+IMGVER = 1.8.5
 IMGNAME = cahirwpz/mimiker-ci
 
 docker-build:

--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -13,7 +13,7 @@ ELFTYPE := elf32-littleriscv
 ELFARCH := riscv
 
 ifeq ($(BOARD), litex-riscv)
-	EXT := ima_zicsr_zifence
+	EXT := ima_zicsr_zifencei
 	ABI := ilp32
 	KERNEL_PHYS := 0x40000000
 	KERNEL-IMAGES := mimiker.img

--- a/toolchain/gnu/riscv32-mimiker-elf/Makefile
+++ b/toolchain/gnu/riscv32-mimiker-elf/Makefile
@@ -5,7 +5,7 @@ TOPDIR = $(realpath ..)
 ARCH = riscv32
 TARGET = riscv32-mimiker-elf
 
-GCC_EXTRA_CONF = --with-arch=rv32ima_zicsr_zifence \
+GCC_EXTRA_CONF = --with-arch=rv32ima_zicsr_zifencei \
 		 --with-abi=ilp32
 
 include $(TOPDIR)/target.mk


### PR DESCRIPTION
The current setup uses "zifence" instead of "zifencei".