### PR TITLE
[vm] Remove kernel vm_map since all kernel mappings are wired

### DIFF
--- a/include/sys/pmap.h
+++ b/include/sys/pmap.h
@@ -28,6 +28,9 @@ typedef struct pmap pmap_t;
 __long_call void pmap_bootstrap(paddr_t pd_pa, void *pd);
 void init_pmap(void);
 
+vaddr_t pmap_start(pmap_t *pmap);
+vaddr_t pmap_end(pmap_t *pmap);
+
 pmap_t *pmap_new(void);
 void pmap_delete(pmap_t *pmap);
 

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -46,10 +46,10 @@ typedef struct uio {
   }
 
 #define UIO_SINGLE_KERNEL(op, offset, buf, buflen)                             \
-  UIO_SINGLE(op, vm_map_kernel(), offset, buf, buflen)
+  UIO_SINGLE(op, NULL, offset, buf, buflen)
 
 #define UIO_SINGLE_USER(op, offset, buf, buflen)                               \
-  UIO_SINGLE(op, vm_map_user(), offset, buf, buflen)
+  UIO_SINGLE(op, vm_map_cur(), offset, buf, buflen)
 
 #define UIO_VECTOR(op, vm_map, iov, iovcnt, len)                               \
   (uio_t) {                                                                    \
@@ -59,10 +59,10 @@ typedef struct uio {
   }
 
 #define UIO_VECTOR_KERNEL(op, iov, iovcnt, len)                                \
-  UIO_VECTOR(op, vm_map_kernel(), iov, iovcnt, len)
+  UIO_VECTOR(op, NULL, iov, iovcnt, len)
 
 #define UIO_VECTOR_USER(op, iov, iovcnt, len)                                  \
-  UIO_VECTOR(op, vm_map_user(), iov, iovcnt, len)
+  UIO_VECTOR(op, vm_map_cur(), iov, iovcnt, len)
 
 int uiomove(void *buf, size_t n, uio_t *uio);
 void uio_save(const uio_t *uio, uiostate_t *save);

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -49,7 +49,7 @@ typedef struct uio {
   UIO_SINGLE(op, NULL, offset, buf, buflen)
 
 #define UIO_SINGLE_USER(op, offset, buf, buflen)                               \
-  UIO_SINGLE(op, vm_map_cur(), offset, buf, buflen)
+  UIO_SINGLE(op, vm_map_user(), offset, buf, buflen)
 
 #define UIO_VECTOR(op, vm_map, iov, iovcnt, len)                               \
   (uio_t) {                                                                    \
@@ -62,7 +62,7 @@ typedef struct uio {
   UIO_VECTOR(op, NULL, iov, iovcnt, len)
 
 #define UIO_VECTOR_USER(op, iov, iovcnt, len)                                  \
-  UIO_VECTOR(op, vm_map_cur(), iov, iovcnt, len)
+  UIO_VECTOR(op, vm_map_user(), iov, iovcnt, len)
 
 int uiomove(void *buf, size_t n, uio_t *uio);
 void uio_save(const uio_t *uio, uiostate_t *save);

--- a/include/sys/vm_map.h
+++ b/include/sys/vm_map.h
@@ -34,9 +34,7 @@ DEFINE_CLEANUP_FUNCTION(vm_map_t *, vm_map_unlock);
 void vm_map_activate(vm_map_t *map);
 void vm_map_switch(thread_t *td);
 
-vm_map_t *vm_map_user(void);
-vm_map_t *vm_map_kernel(void);
-vm_map_t *vm_map_lookup(vaddr_t addr);
+vm_map_t *vm_map_cur(void);
 
 vm_map_t *vm_map_new(void);
 void vm_map_delete(vm_map_t *vm_map);
@@ -53,14 +51,6 @@ void vm_map_protect(vm_map_t *map, vaddr_t start, vaddr_t end, vm_prot_t prot);
 
 /*! \brief Insert given \a entry into the \a map. */
 int vm_map_insert(vm_map_t *map, vm_map_entry_t *entry, vm_flags_t flags);
-
-/*! \brief Can address \a addr be mapped by this \a map? */
-bool vm_map_address_p(vm_map_t *map, vaddr_t addr);
-bool vm_map_contains_p(vm_map_t *map, vaddr_t start, vaddr_t end);
-
-/*! \brief Reports start & end addresses that are handled by the map. */
-vaddr_t vm_map_start(vm_map_t *map);
-vaddr_t vm_map_end(vm_map_t *map);
 
 /*! \brief Reports start & end addresses that are handled by the entry. */
 vaddr_t vm_map_entry_start(vm_map_entry_t *ent);

--- a/include/sys/vm_map.h
+++ b/include/sys/vm_map.h
@@ -34,7 +34,7 @@ DEFINE_CLEANUP_FUNCTION(vm_map_t *, vm_map_unlock);
 void vm_map_activate(vm_map_t *map);
 void vm_map_switch(thread_t *td);
 
-vm_map_t *vm_map_cur(void);
+vm_map_t *vm_map_user(void);
 
 vm_map_t *vm_map_new(void);
 void vm_map_delete(vm_map_t *vm_map);

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -76,7 +76,6 @@ static void abort_handler(ctx_t *ctx, register_t esr, vaddr_t vaddr,
     goto fault;
 
   vm_map_t *vmap = vm_map_user();
-  assert(vmap);
 
   if (vm_page_fault(vmap, vaddr, access) == 0)
     return;

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -75,7 +75,8 @@ static void abort_handler(ctx_t *ctx, register_t esr, vaddr_t vaddr,
   if (error == EACCES || error == EINVAL)
     goto fault;
 
-  vm_map_t *vmap = vm_map_cur();
+  vm_map_t *vmap = vm_map_user();
+  assert(vmap);
 
   if (vm_page_fault(vmap, vaddr, access) == 0)
     return;

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -75,11 +75,8 @@ static void abort_handler(ctx_t *ctx, register_t esr, vaddr_t vaddr,
   if (error == EACCES || error == EINVAL)
     goto fault;
 
-  vm_map_t *vmap = vm_map_lookup(vaddr);
-  if (!vmap) {
-    klog("No virtual address space defined for %lx!", vaddr);
-    goto fault;
-  }
+  vm_map_t *vmap = vm_map_cur();
+
   if (vm_page_fault(vmap, vaddr, access) == 0)
     return;
 

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -51,11 +51,11 @@ static bool kern_addr_p(vaddr_t addr) {
   return addr >= KERNEL_SPACE_BEGIN && addr < KERNEL_SPACE_END;
 }
 
-static vaddr_t pmap_start(pmap_t *pmap) {
+vaddr_t pmap_start(pmap_t *pmap) {
   return pmap->asid ? USER_SPACE_BEGIN : KERNEL_SPACE_BEGIN;
 }
 
-static vaddr_t pmap_end(pmap_t *pmap) {
+vaddr_t pmap_end(pmap_t *pmap) {
   return pmap->asid ? USER_SPACE_END : KERNEL_SPACE_END;
 }
 

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -80,7 +80,6 @@ __noreturn void kernel_init(void) {
   init_pool();
   init_vmem();
   init_kmem();
-  init_vm_map();
 
   init_cons();
 

--- a/sys/kern/uio.c
+++ b/sys/kern/uio.c
@@ -7,12 +7,12 @@
 
 static int copyin_vmspace(vm_map_t *vm, const void *restrict udaddr,
                           void *restrict kaddr, size_t len) {
-  if (vm == vm_map_kernel()) {
+  if (!vm) {
     memcpy(kaddr, udaddr, len);
     return 0;
   }
 
-  if (vm == vm_map_user())
+  if (vm == vm_map_cur())
     return copyin(udaddr, kaddr, len);
 
   panic("copyin on non-active vm maps is not supported");
@@ -20,12 +20,12 @@ static int copyin_vmspace(vm_map_t *vm, const void *restrict udaddr,
 
 static int copyout_vmspace(vm_map_t *vm, const void *restrict kaddr,
                            void *restrict udaddr, size_t len) {
-  if (vm == vm_map_kernel()) {
+  if (!vm) {
     memcpy(udaddr, kaddr, len);
     return 0;
   }
 
-  if (vm == vm_map_user())
+  if (vm == vm_map_cur())
     return copyout(kaddr, udaddr, len);
 
   panic("copyout on non-active vm maps is not supported");

--- a/sys/kern/uio.c
+++ b/sys/kern/uio.c
@@ -12,7 +12,7 @@ static int copyin_vmspace(vm_map_t *vm, const void *restrict udaddr,
     return 0;
   }
 
-  if (vm == vm_map_cur())
+  if (vm == vm_map_user())
     return copyin(udaddr, kaddr, len);
 
   panic("copyin on non-active vm maps is not supported");
@@ -25,7 +25,7 @@ static int copyout_vmspace(vm_map_t *vm, const void *restrict kaddr,
     return 0;
   }
 
-  if (vm == vm_map_cur())
+  if (vm == vm_map_user())
     return copyout(kaddr, udaddr, len);
 
   panic("copyout on non-active vm maps is not supported");

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -55,7 +55,9 @@ void vm_map_unlock(vm_map_t *map) {
 }
 
 vm_map_t *vm_map_user(void) {
-  return PCPU_GET(uspace);
+  vm_map_t *map = PCPU_GET(uspace);
+  assert(map);
+  return map;
 }
 
 vaddr_t vm_map_entry_start(vm_map_entry_t *ent) {
@@ -70,7 +72,7 @@ inline vm_map_entry_t *vm_map_entry_next(vm_map_entry_t *ent) {
   return TAILQ_NEXT(ent, link);
 }
 
-static bool vm_map_contains_p(vaddr_t start, vaddr_t end) {
+static bool userspace_p(vaddr_t start, vaddr_t end) {
   return USER_SPACE_BEGIN <= start && end <= USER_SPACE_END;
 }
 
@@ -292,7 +294,7 @@ int vm_map_alloc_entry(vm_map_t *map, vaddr_t addr, size_t length,
   if (length == 0)
     return EINVAL;
 
-  if (addr != 0 && !vm_map_contains_p(addr, addr + length))
+  if (addr != 0 && !userspace_p(addr, addr + length))
     return EINVAL;
 
   /* Create object with a pager that supplies cleared pages on page fault. */

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -33,10 +33,7 @@ struct vm_map {
 static POOL_DEFINE(P_VM_MAP, "vm_map", sizeof(vm_map_t));
 static POOL_DEFINE(P_VM_MAPENT, "vm_map_entry", sizeof(vm_map_entry_t));
 
-static vm_map_t *kspace = &(vm_map_t){};
-
 void vm_map_activate(vm_map_t *map) {
-  assert(map != kspace);
   SCOPED_NO_PREEMPTION();
 
   PCPU_SET(uspace, map);
@@ -57,20 +54,8 @@ void vm_map_unlock(vm_map_t *map) {
   mtx_unlock(&map->mtx);
 }
 
-vm_map_t *vm_map_user(void) {
+vm_map_t *vm_map_cur(void) {
   return PCPU_GET(uspace);
-}
-
-vm_map_t *vm_map_kernel(void) {
-  return kspace;
-}
-
-vaddr_t vm_map_start(vm_map_t *map) {
-  return map->pmap == pmap_kernel() ? KERNEL_SPACE_BEGIN : USER_SPACE_BEGIN;
-}
-
-vaddr_t vm_map_end(vm_map_t *map) {
-  return map->pmap == pmap_kernel() ? KERNEL_SPACE_END : USER_SPACE_END;
 }
 
 vaddr_t vm_map_entry_start(vm_map_entry_t *ent) {
@@ -85,30 +70,13 @@ inline vm_map_entry_t *vm_map_entry_next(vm_map_entry_t *ent) {
   return TAILQ_NEXT(ent, link);
 }
 
-bool vm_map_address_p(vm_map_t *map, vaddr_t addr) {
-  return map && vm_map_start(map) <= addr && addr < vm_map_end(map);
-}
-
-bool vm_map_contains_p(vm_map_t *map, vaddr_t start, vaddr_t end) {
-  return map && vm_map_start(map) <= start && end <= vm_map_end(map);
-}
-
-vm_map_t *vm_map_lookup(vaddr_t addr) {
-  if (vm_map_address_p(vm_map_user(), addr))
-    return vm_map_user();
-  if (vm_map_address_p(vm_map_kernel(), addr))
-    return vm_map_kernel();
-  return NULL;
+static bool vm_map_contains_p(vaddr_t start, vaddr_t end) {
+  return USER_SPACE_BEGIN <= start && end <= USER_SPACE_END;
 }
 
 static void vm_map_setup(vm_map_t *map) {
   TAILQ_INIT(&map->entries);
   mtx_init(&map->mtx, 0);
-}
-
-void init_vm_map(void) {
-  vm_map_setup(kspace);
-  kspace->pmap = pmap_kernel();
 }
 
 vm_map_t *vm_map_new(void) {
@@ -237,8 +205,8 @@ static int vm_map_findspace_nolock(vm_map_t *map, vaddr_t /*inout*/ *start_p,
   assert(page_aligned_p(start) && page_aligned_p(length));
 
   /* Bounds check */
-  start = max(start, vm_map_start(map));
-  if (start + length > vm_map_end(map))
+  start = max(start, (vaddr_t)USER_SPACE_BEGIN);
+  if (start + length > (vaddr_t)USER_SPACE_END)
     return ENOMEM;
 
   if (after_p)
@@ -258,7 +226,7 @@ static int vm_map_findspace_nolock(vm_map_t *map, vaddr_t /*inout*/ *start_p,
   TAILQ_FOREACH (it, &map->entries, link) {
     vm_map_entry_t *next = vm_map_entry_next(it);
     vaddr_t gap_start = it->end;
-    vaddr_t gap_end = next ? next->start : vm_map_end(map);
+    vaddr_t gap_end = next ? next->start : USER_SPACE_END;
 
     /* Move start address forward if it points inside allocated space. */
     if (start < gap_start)
@@ -324,7 +292,7 @@ int vm_map_alloc_entry(vm_map_t *map, vaddr_t addr, size_t length,
   if (length == 0)
     return EINVAL;
 
-  if (addr != 0 && !vm_map_contains_p(map, addr, addr + length))
+  if (addr != 0 && !vm_map_contains_p(addr, addr + length))
     return EINVAL;
 
   /* Create object with a pager that supplies cleared pages on page fault. */
@@ -350,7 +318,7 @@ int vm_map_entry_resize(vm_map_t *map, vm_map_entry_t *ent, vaddr_t new_end) {
   if (new_end >= ent->end) {
     /* Expanding entry */
     vm_map_entry_t *next = vm_map_entry_next(ent);
-    vaddr_t gap_end = next ? next->start : vm_map_end(map);
+    vaddr_t gap_end = next ? next->start : USER_SPACE_END;
     if (new_end > gap_end)
       return ENOMEM;
   } else {
@@ -373,8 +341,7 @@ int vm_map_entry_resize(vm_map_t *map, vm_map_entry_t *ent, vaddr_t new_end) {
 void vm_map_dump(vm_map_t *map) {
   SCOPED_MTX_LOCK(&map->mtx);
 
-  klog("Virtual memory map (%08lx - %08lx):", vm_map_start(map),
-       vm_map_end(map));
+  klog("Virtual memory map (%08lx - %08lx):", USER_SPACE_BEGIN, USER_SPACE_END);
 
   vm_map_entry_t *it;
   TAILQ_FOREACH (it, &map->entries, link) {

--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -54,7 +54,7 @@ void vm_map_unlock(vm_map_t *map) {
   mtx_unlock(&map->mtx);
 }
 
-vm_map_t *vm_map_cur(void) {
+vm_map_t *vm_map_user(void) {
   return PCPU_GET(uspace);
 }
 

--- a/sys/mips/trap.c
+++ b/sys/mips/trap.c
@@ -146,11 +146,7 @@ static void tlb_exception_handler(ctx_t *ctx) {
   if (error == EACCES || error == EINVAL)
     goto fault;
 
-  vm_map_t *vmap = vm_map_lookup(vaddr);
-  if (!vmap) {
-    klog("No virtual address space defined for %08lx!", vaddr);
-    goto fault;
-  }
+  vm_map_t *vmap = vm_map_cur();
 
   if (vm_page_fault(vmap, vaddr, access) == 0)
     return;

--- a/sys/mips/trap.c
+++ b/sys/mips/trap.c
@@ -147,7 +147,6 @@ static void tlb_exception_handler(ctx_t *ctx) {
     goto fault;
 
   vm_map_t *vmap = vm_map_user();
-  assert(vmap);
 
   if (vm_page_fault(vmap, vaddr, access) == 0)
     return;

--- a/sys/mips/trap.c
+++ b/sys/mips/trap.c
@@ -146,7 +146,8 @@ static void tlb_exception_handler(ctx_t *ctx) {
   if (error == EACCES || error == EINVAL)
     goto fault;
 
-  vm_map_t *vmap = vm_map_cur();
+  vm_map_t *vmap = vm_map_user();
+  assert(vmap);
 
   if (vm_page_fault(vmap, vaddr, access) == 0)
     return;

--- a/sys/riscv/trap.c
+++ b/sys/riscv/trap.c
@@ -105,7 +105,6 @@ static void page_fault_handler(ctx_t *ctx) {
     goto fault;
 
   vm_map_t *vmap = vm_map_user();
-  assert(vmap);
 
   if (!vm_page_fault(vmap, vaddr, access))
     return;

--- a/sys/riscv/trap.c
+++ b/sys/riscv/trap.c
@@ -104,11 +104,7 @@ static void page_fault_handler(ctx_t *ctx) {
   if (error == EACCES || error == EINVAL)
     goto fault;
 
-  vm_map_t *vmap = vm_map_lookup(vaddr);
-  if (!vmap) {
-    klog("No virtual address space defined for %lx!", vaddr);
-    goto fault;
-  }
+  vm_map_t *vmap = vm_map_cur();
 
   if (!vm_page_fault(vmap, vaddr, access))
     return;

--- a/sys/riscv/trap.c
+++ b/sys/riscv/trap.c
@@ -104,7 +104,8 @@ static void page_fault_handler(ctx_t *ctx) {
   if (error == EACCES || error == EINVAL)
     goto fault;
 
-  vm_map_t *vmap = vm_map_cur();
+  vm_map_t *vmap = vm_map_user();
+  assert(vmap);
 
   if (!vm_page_fault(vmap, vaddr, access))
     return;

--- a/sys/tests/uiomove.c
+++ b/sys/tests/uiomove.c
@@ -20,7 +20,7 @@ static int test_uiomove(void) {
 
   /* Perform WRITE to buffer1, using text as data. */
   uio.uio_op = UIO_WRITE;
-  uio.uio_vmspace = vm_map_kernel();
+  uio.uio_vmspace = NULL;
   iov[0].iov_base = (char *)text;
   iov[0].iov_len = 8;
   iov[1].iov_base = (char *)text + 20;
@@ -40,7 +40,7 @@ static int test_uiomove(void) {
 
   /* Now, perform a READ from text, using buffer2 as data. */
   uio.uio_op = UIO_READ;
-  uio.uio_vmspace = vm_map_kernel();
+  uio.uio_vmspace = NULL;
   iov[0].iov_base = buffer2;
   iov[0].iov_len = 8;
   iov[1].iov_base = buffer2 + 12;

--- a/sys/tests/vm_map.c
+++ b/sys/tests/vm_map.c
@@ -24,7 +24,7 @@ static int paging_on_demand_and_memory_protection_demo(void) {
   SCOPED_NO_PREEMPTION();
   proc_t *p = proc_self();
 
-  vm_map_t *orig = vm_map_user();
+  vm_map_t *orig = vm_map_cur();
   /* XXX: We can't guarantee that we won't switch to another process,
    * so we need to store the temporary userspace map in our process.
    * This is fine as long as there are no concurrent threads in our
@@ -32,13 +32,13 @@ static int paging_on_demand_and_memory_protection_demo(void) {
   p->p_uspace = vm_map_new();
   vm_map_activate(p->p_uspace);
 
-  vm_map_t *kmap = vm_map_kernel();
-  vm_map_t *umap = vm_map_user();
+  pmap_t *kpmap = pmap_kernel();
+  pmap_t *upmap = pmap_user();
 
-  klog("Kernel physical map : %08lx-%08lx", vm_map_start(kmap),
-       vm_map_end(kmap));
-  klog("User physical map   : %08lx-%08lx", vm_map_start(umap),
-       vm_map_end(umap));
+  klog("Kernel physical map : %08lx-%08lx", pmap_start(kpmap), pmap_end(kpmap));
+  klog("User physical map   : %08lx-%08lx", pmap_start(upmap), pmap_end(upmap));
+
+  vm_map_t *umap = vm_map_cur();
 
   vaddr_t pre_start = 0x1000000;
   vaddr_t start = 0x1001000;
@@ -74,7 +74,6 @@ static int paging_on_demand_and_memory_protection_demo(void) {
   }
 
   vm_map_dump(umap);
-  vm_map_dump(kmap);
 
 #ifdef __riscv
   enter_user_access();
@@ -91,7 +90,6 @@ static int paging_on_demand_and_memory_protection_demo(void) {
 #endif
 
   vm_map_dump(umap);
-  vm_map_dump(kmap);
 
   vm_map_delete(umap);
 
@@ -107,7 +105,7 @@ static int findspace_demo(void) {
    * restored while switching back. */
   SCOPED_NO_PREEMPTION();
 
-  vm_map_t *orig = vm_map_user();
+  vm_map_t *orig = vm_map_cur();
 
   vm_map_t *umap = vm_map_new();
   vm_map_activate(umap);

--- a/sys/tests/vm_map.c
+++ b/sys/tests/vm_map.c
@@ -24,7 +24,7 @@ static int paging_on_demand_and_memory_protection_demo(void) {
   SCOPED_NO_PREEMPTION();
   proc_t *p = proc_self();
 
-  vm_map_t *orig = vm_map_cur();
+  vm_map_t *orig = vm_map_user();
   /* XXX: We can't guarantee that we won't switch to another process,
    * so we need to store the temporary userspace map in our process.
    * This is fine as long as there are no concurrent threads in our
@@ -38,7 +38,7 @@ static int paging_on_demand_and_memory_protection_demo(void) {
   klog("Kernel physical map : %08lx-%08lx", pmap_start(kpmap), pmap_end(kpmap));
   klog("User physical map   : %08lx-%08lx", pmap_start(upmap), pmap_end(upmap));
 
-  vm_map_t *umap = vm_map_cur();
+  vm_map_t *umap = vm_map_user();
 
   vaddr_t pre_start = 0x1000000;
   vaddr_t start = 0x1001000;
@@ -105,7 +105,7 @@ static int findspace_demo(void) {
    * restored while switching back. */
   SCOPED_NO_PREEMPTION();
 
-  vm_map_t *orig = vm_map_cur();
+  vm_map_t *orig = vm_map_user();
 
   vm_map_t *umap = vm_map_new();
   vm_map_activate(umap);


### PR DESCRIPTION
With the arrival of #1243, the kernel can only use wired memory mappings. This makes maintaining  `kspace` needles and the generic `vm_map` logic can be simplified to consider only user virtual memory maps.