### PR TITLE
[RISCV] Make the size of the boot memory allocator area dynamic.

### DIFF
--- a/include/riscv/vm_param.h
+++ b/include/riscv/vm_param.h
@@ -13,7 +13,6 @@
 
 #define VM_PAGE_PDS 32
 #define KSTACK_PAGES 2
-#define BOOTMEM_PAGES 40
 #else
 #define KERNEL_SPACE_BEGIN 0x80000000
 #define KERNEL_SPACE_END 0xffffffff
@@ -26,7 +25,6 @@
 
 #define VM_PAGE_PDS 4
 #define KSTACK_PAGES 1
-#define BOOTMEM_PAGES 8
 #endif
 
 #define PAGESIZE 4096
@@ -34,7 +32,5 @@
 #define VM_PHYSSEG_NMAX 16
 
 #define KSTACK_SIZE (KSTACK_PAGES * PAGESIZE)
-
-#define BOOTMEM_SIZE (BOOTMEM_PAGES * PAGESIZE)
 
 #endif /* !_RISCV_VM_PARAM_H_ */

--- a/sys/riscv/board.c
+++ b/sys/riscv/board.c
@@ -15,7 +15,7 @@
 #include <riscv/sbi.h>
 #include <riscv/vm_param.h>
 
-#define KERNEL_PHYS_END (align(RISCV_PHYSADDR(__ebss), PAGESIZE) + BOOTMEM_SIZE)
+paddr_t kern_phys_end;
 
 static size_t count_args(void) {
   /*
@@ -110,8 +110,9 @@ typedef struct {
 #define END(pa) roundup((pa), PAGESIZE)
 
 static void ar_get_kernel_img(addr_range_t *ar) {
+  assert(kern_phys_end);
   ar->start = (paddr_t)__eboot;
-  ar->end = KERNEL_PHYS_END;
+  ar->end = kern_phys_end;
 }
 
 static void ar_get_initrd(addr_range_t *ar) {


### PR DESCRIPTION
The assumption of a constant size boot memory allocator area should be dropped as with KASAN is becomes tedious to maintain four different configurations (32/64 + KASAN on / KASAN off) that must be adjusted whenever the area size has to change.