### PR TITLE
[RISCV][dev] Fix LiteX VexRiscv rootdev device node assignemnt

### DIFF
--- a/sys/drv/litex_riscv_rootdev.c
+++ b/sys/drv/litex_riscv_rootdev.c
@@ -186,7 +186,10 @@ static int rootdev_probe(device_t *bus) {
 
 static int rootdev_attach(device_t *bus) {
   rootdev_t *rd = bus->state;
-  bus->node = 0;
+
+  bus->node = FDT_finddevice("/cpus/cpu/interrupt-controller");
+  if (bus->node == FDT_NODEV)
+    return ENXIO;
 
   rman_init(&rd->mem_rm, "RISC-V I/O space");
   rman_manage_region(&rd->mem_rm, 0xf0000000, 0x10000000);


### PR DESCRIPTION
The current convention assumed by simplebus is that the device node of the rootdev device points at the local interrupt controller.