### PR TITLE
Use simplebus to attach PL011 driver

### DIFF
--- a/sys/drv/pl011.c
+++ b/sys/drv/pl011.c
@@ -74,10 +74,10 @@ static int pl011_probe(device_t *dev) {
     klog("Warning: %s missing `compatible` property", __func__);
     return 0;
   }
-  
+
   char *buf = kmalloc(M_DEV, len + 1, M_ZERO);
 
-  FDT_getprop(dev->node, "compatible", (pcell_t*)buf, len + 1);
+  FDT_getprop(dev->node, "compatible", (pcell_t *)buf, len + 1);
   int success = !strcmp(buf, PL011_FDT_COMPATIBLE);
 
   kfree(M_DEV, buf);

--- a/sys/dts/rpi3.dts
+++ b/sys/dts/rpi3.dts
@@ -12,5 +12,10 @@
 	soc {
 		#address-cells = <0x01>;
 		#size-cells = <0x01>;
+
+		uart0@7e201000 {
+			compatible = "uart,pl011";
+			reg = <0x3f201000 0x90>;
+		};
 	};
 };


### PR DESCRIPTION
Use simplebus to attach PL011 UART driver.
* Use `simplebus_add_child` to create device and add memory resource.
* Due to complexity of IRQs, those are still added manually
* Due to `BCM2835_PERIPHERALS_BUS_TO_PHYS` weirdness the address in FDT is slightly different than the one in specs.
* `pl011_probe` uses `"compatible"` field to check if a driver should be attached.