### PR TITLE
[RISCV] Fix copy routines.

### DIFF
--- a/sys/riscv/copy.S
+++ b/sys/riscv/copy.S
@@ -34,7 +34,7 @@
 .macro onfault_clr tmp, td
 	exit_user_access \tmp
 	PTR_L	\td, PCPU_CURTHREAD(tp)
-	PTR_S	zero, TD_ONFAULT(tp)
+	PTR_S	zero, TD_ONFAULT(\td)
 .endm
 
 /*
@@ -98,7 +98,7 @@
  */
 ENTRY(copyin)
 	/* len > 0 */
-	beqz	a2, 1f
+	beqz	a2, 0f
 
 	/* (uintptr_t)udaddr < (uintptr_t)(udaddr + len) */
 	PTR_ADD	t0, a0, a2
@@ -112,7 +112,7 @@ ENTRY(copyin)
 	copycommon
 	onfault_clr t0, t1
 
-1:	mv	a0, zero
+0:	mv	a0, zero
 	ret
 END(copyin)
 
@@ -123,7 +123,7 @@ END(copyin)
  */
 ENTRY(copyout)
 	/* len > 0 */
-	beqz	a2, 1f
+	beqz	a2, 0f
 
 	/* (uintptr_t)udaddr < (uintptr_t)(udaddr + len) */
 	PTR_ADD	t0, a1, a2
@@ -137,7 +137,7 @@ ENTRY(copyout)
 	copycommon
 	onfault_clr t0, t1
 
-1:	mv	a0, zero
+0:	mv	a0, zero
 	ret
 END(copyout)
 


### PR DESCRIPTION
- the `onfault` pointer is not cleared appropriately
- the 0 length case is broken as we jump in the middle of the `copycommon` block