### PR TITLE
[initrd] Access initrd using dmap

### DIFF
--- a/sys/kern/initrd.c
+++ b/sys/kern/initrd.c
@@ -2,7 +2,6 @@
 #include <sys/klog.h>
 #include <sys/errno.h>
 #include <sys/malloc.h>
-#include <sys/kmem.h>
 #include <sys/libkern.h>
 #include <cpio.h>
 #include <sys/initrd.h>
@@ -13,6 +12,7 @@
 #include <sys/linker_set.h>
 #include <sys/dirent.h>
 #include <sys/kenv.h>
+#include <sys/pmap.h>
 
 typedef uint32_t cpio_dev_t;
 typedef uint32_t cpio_ino_t;
@@ -130,8 +130,7 @@ static const char *basename(const char *path) {
 }
 
 static void read_cpio_archive(void) {
-  void *tape =
-    (void *)kmem_map_contig(ramdisk_get_start(), ramdisk_get_size(), 0);
+  void *tape = phys_to_dmap(ramdisk_get_start());
 
   while (true) {
     cpio_node_t *node = cpio_node_alloc();


### PR DESCRIPTION
We don't have to map the large initrd to kernel virtual memory as the entire archive can be accessed using dmap.