### PR TITLE
[physmem] Access vm_page_t structs using dmap.

### DIFF
--- a/include/riscv/vm_param.h
+++ b/include/riscv/vm_param.h
@@ -15,7 +15,6 @@
 #define KASAN_SHADOW_START 0xffffffd800000000L
 #define KASAN_MAX_SHADOW_SIZE (0x8L << 30) /* 8 GB */
 
-#define VM_PAGE_PDS 32
 #define KSTACK_PAGES 2
 
 #else /* __riscv_xlen == 32 */
@@ -33,7 +32,6 @@
 #define KASAN_SHADOW_START 0xa0000000
 #define KASAN_MAX_SHADOW_SIZE (1 << 26) /* 64 MB */
 
-#define VM_PAGE_PDS 4
 #define KSTACK_PAGES 1
 #endif
 

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -146,13 +146,6 @@ __boot_text static paddr_t build_page_table(void) {
   l1[L1_INDEX(va)] = (pde_t)l2 | L1_TABLE;
   l2[L2_INDEX(va)] = (pde_t)l3 | L2_TABLE;
 
-  /* TODO(pj) imitate pmap_growkernel from NetBSD */
-  l2[L2_INDEX(0)] = (pde_t)bootmem_alloc(PAGESIZE) | L2_TABLE;
-  for (int i = 0; i < 32; i++) {
-    l2[L2_INDEX(0xffff000000400000 + i * PAGESIZE * PT_ENTRIES)] =
-      (pde_t)bootmem_alloc(PAGESIZE) | L2_TABLE;
-  }
-
   const pte_t pte_default =
     L3_PAGE | ATTR_AF | ATTR_SH_IS | ATTR_IDX(ATTR_NORMAL_MEM_WB);
 
@@ -187,12 +180,8 @@ __boot_text static paddr_t build_page_table(void) {
   l0[L0_INDEX(DMAP_BASE)] = (pde_t)l1d | L0_TABLE;
 
 #if KASAN /* Prepare KASAN shadow mappings */
-  /* XXX we add 2 * SUPERPAGESIZE to account for future allocations made with
-   * vm_boot_alloc() which can't extend the shadow map, as the VM system isn't
-   * fully initialized yet. */
-  size_t kasan_sanitized_size =
-    2 * SUPERPAGESIZE + roundup2(va - KASAN_SANITIZED_START,
-                                 SUPERPAGESIZE * KASAN_SHADOW_SCALE_SIZE);
+  size_t kasan_sanitized_size = roundup2(
+    va - KASAN_SANITIZED_START, SUPERPAGESIZE * KASAN_SHADOW_SCALE_SIZE);
   size_t kasan_shadow_size = kasan_sanitized_size / KASAN_SHADOW_SCALE_SIZE;
   vaddr_t kasan_shadow_end = KASAN_SHADOW_START + kasan_shadow_size;
   va = KASAN_SHADOW_START;

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -71,7 +71,6 @@ static void *vm_boot_alloc(size_t n) {
 
   seg->start += n;
   seg->npages -= n / PAGESIZE;
-  assert(seg->npages);
 
   return va;
 }

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -59,7 +59,6 @@ static void *vm_boot_alloc(size_t n) {
   assert(!vm_boot_done);
 
   n = roundup2(n, PAGESIZE);
-  assert(n);
 
   vm_physseg_t *seg = TAILQ_FIRST(&seglist);
 
@@ -70,11 +69,9 @@ static void *vm_boot_alloc(size_t n) {
 
   void *va = phys_to_dmap(seg->start);
 
-  for (size_t i = 0; i < n / PAGESIZE; i++) {
-    seg->start += PAGESIZE;
-    seg->npages--;
-    assert(seg->npages);
-  }
+  seg->start += n;
+  seg->npages -= n / PAGESIZE;
+  assert(seg->npages);
 
   return va;
 }

--- a/sys/kern/vm_physmem.c
+++ b/sys/kern/vm_physmem.c
@@ -6,7 +6,6 @@
 #include <sys/mutex.h>
 #include <sys/pmap.h>
 #include <sys/vm_physmem.h>
-#include <sys/kasan.h>
 
 #define FREELIST(page) (&freelist[log2((page)->size)])
 #define PAGECOUNT(page) (pagecount[log2((page)->size)])
@@ -31,6 +30,9 @@ static vm_pagelist_t freelist[PM_NQUEUES];
 static size_t pagecount[PM_NQUEUES];
 static MTX_DEFINE(physmem_lock, LK_RECURSIVE);
 
+atomic_vaddr_t vm_kernel_end = (vaddr_t)__kernel_end;
+MTX_DEFINE(vm_kernel_end_lock, 0);
+
 void _vm_physseg_plug(paddr_t start, paddr_t end, bool used) {
   assert(page_aligned_p(start) && page_aligned_p(end) && start < end);
 
@@ -52,23 +54,12 @@ void _vm_physseg_plug(paddr_t start, paddr_t end, bool used) {
 }
 
 static bool vm_boot_done = false;
-atomic_vaddr_t vm_kernel_end = (vaddr_t)__kernel_end;
-MTX_DEFINE(vm_kernel_end_lock, 0);
 
 static void *vm_boot_alloc(size_t n) {
   assert(!vm_boot_done);
 
-  void *begin = align((void *)vm_kernel_end, sizeof(long));
-  void *end = align(begin + n, PAGESIZE);
-#if KASAN
-  /* We're not ready to call kasan_grow() yet, so this function could
-   * potentially make vm_kernel_end go past _kernel_sanitized_end, which could
-   * lead to KASAN referencing unmapped addresses in the shadow map, causing
-   * a panic. Make sure that doesn't happen.
-   * If this assertion fails, more shadow memory must be allocated when
-   * initializing KASAN.*/
-  assert((vaddr_t)end <= _kasan_sanitized_end);
-#endif
+  n = roundup2(n, PAGESIZE);
+  assert(n);
 
   vm_physseg_t *seg = TAILQ_FIRST(&seglist);
 
@@ -77,20 +68,15 @@ static void *vm_boot_alloc(size_t n) {
 
   assert(seg != NULL);
 
-  for (void *va = align(begin, PAGESIZE); va < end; va += PAGESIZE) {
-    paddr_t pa = seg->start;
-    seg->start += PAGESIZE;
-    if (--seg->npages == 0) {
-      TAILQ_REMOVE(&seglist, seg, seglink);
-      seg = TAILQ_FIRST(&seglist);
-    }
+  void *va = phys_to_dmap(seg->start);
 
-    pmap_kenter((vaddr_t)va, pa, VM_PROT_READ | VM_PROT_WRITE, 0);
+  for (size_t i = 0; i < n / PAGESIZE; i++) {
+    seg->start += PAGESIZE;
+    seg->npages--;
+    assert(seg->npages);
   }
 
-  vm_kernel_end += n;
-
-  return begin;
+  return va;
 }
 
 static void vm_boot_finish(void) {


### PR DESCRIPTION
Currently, the target architecture must provide kernel page directories for the `vm_page_t` structs during the boot phase as physmem initialization cannot rely on the buddy system to allocate physical pages. This problem can be solved by relying on dmap to access the `vm_page_t` structs.