### PR TITLE
[RISCV] 64-bit boot process implementation.

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -25,6 +25,13 @@ endif
 ifeq ($(BOARD), litex-riscv)
 ARCH := riscv
 RISCV := 1
+XLEN := 32
+endif
+
+ifeq ($(BOARD), sifive_u)
+ARCH := riscv
+RISCV := 1
+XLEN := 64
 endif
 
 VERBOSE ?= 0

--- a/include/riscv/pmap.h
+++ b/include/riscv/pmap.h
@@ -21,7 +21,13 @@
 #define RISCV_PHYSADDR(x)                                                      \
   ((paddr_t)((vaddr_t)(x) & ~KERNEL_SPACE_BEGIN) + KERNEL_PHYS)
 
+#if __riscv_xlen == 64
+#define PAGE_TABLE_DEPTH 3
+#define GROWKERNEL_STRIDE L1_SIZE
+#else
 #define PAGE_TABLE_DEPTH 2
+#define GROWKERNEL_STRIDE L0_SIZE
+#endif
 
 #define PTE_EMPTY_KERNEL 0
 #define PTE_EMPTY_USER 0
@@ -31,8 +37,6 @@
 
 #define PTE_SET_ON_MODIFIED (PTE_D | PTE_W)
 #define PTE_CLR_ON_MODIFIED 0
-
-#define GROWKERNEL_STRIDE L0_SIZE
 
 typedef struct pmap pmap_t;
 
@@ -55,7 +59,13 @@ static inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
   pde_t *pde = phys_to_dmap(pd_pa);
   if (lvl == 0)
     return pde + L0_INDEX(va);
+#if __riscv_xlen == 32
   return pde + L1_INDEX(va);
+#else
+  if (lvl == 1)
+    return pde + L1_INDEX(va);
+  return pde + L2_INDEX(va);
+#endif
 }
 
 /*

--- a/sys/riscv/board.c
+++ b/sys/riscv/board.c
@@ -111,7 +111,8 @@ typedef struct {
 
 static void ar_get_kernel_img(addr_range_t *ar) {
   assert(kern_phys_end);
-  ar->start = (paddr_t)__eboot;
+  extern paddr_t _eboot;
+  ar->start = _eboot;
   ar->end = kern_phys_end;
 }
 

--- a/sys/riscv/boot.c
+++ b/sys/riscv/boot.c
@@ -17,12 +17,7 @@
  *   - temoprarily mapping kernel page directory into VM (because there is
  *     no direct map to access it in the usual fashion),
  *
- *   - (HACK) preparing page tables for `vm_page_t` structs (we need to do so
- *     because the procedure that maps kernel virtual space allocated for the
- *     structs can't allocate physical pages on its own since
- *     the buddy system isn't initialized at that point),
- *
- *   - Preparing KASAN shadow memory for the mapped area,
+ *   - preparing KASAN shadow memory for the mapped area,
  *
  *   - enabling MMU and moving to the second stage.
  *
@@ -74,12 +69,12 @@
 #include <riscv/cpufunc.h>
 #include <riscv/pmap.h>
 
-#define KERNEL_VIRT_IMG_END align((vaddr_t)__ebss, PAGESIZE)
-#define KERNEL_PHYS_IMG_END align(RISCV_PHYSADDR(__ebss), PAGESIZE)
+#define KERNEL_VIRT_IMG_END align(_ebss, PAGESIZE)
+#define KERNEL_PHYS_IMG_END align(RISCV_PHYSADDR(_ebss), PAGESIZE)
 
 #define BOOT_KASAN_SANITIZED_SIZE                                              \
-  roundup2(roundup2(KERNEL_VIRT_IMG_END, GROWKERNEL_STRIDE) +                  \
-             (VM_PAGE_PDS * GROWKERNEL_STRIDE) - KASAN_SANITIZED_START,        \
+  roundup2(roundup2(KERNEL_VIRT_IMG_END, GROWKERNEL_STRIDE) -                  \
+             KASAN_SANITIZED_START,                                            \
            PAGESIZE * KASAN_SHADOW_SCALE_SIZE)
 
 #define BOOT_KASAN_SHADOW_SIZE                                                 \
@@ -97,12 +92,26 @@ __boot_data static void *bootmem_brk;
 
 __boot_data static pde_t *kernel_pde;
 
+/* Boot symbols. */
+__boot_data static vaddr_t _kernel_start;
+__boot_data static vaddr_t _text;
+__boot_data static vaddr_t _riscv_boot;
+__boot_data static vaddr_t _data;
+__boot_data static uint8_t *_boot_stack;
+__boot_data static vaddr_t _ebss;
+__boot_data static vaddr_t _kernel_end;
+
 /*
  * Virtual memory boot data.
  */
 
 /* NOTE: the boot stack is used before we switch out to `thread0`. */
-static alignas(STACK_ALIGN) uint8_t boot_stack[PAGESIZE];
+#define __bss_boot_stack __section(".bss.boot_stack")
+__bss_boot_stack static __used alignas(STACK_ALIGN) uint8_t
+  boot_stack[PAGESIZE];
+
+/* Kernel symbols. */
+paddr_t _eboot;
 
 /*
  * Bare memory boot functions.
@@ -111,6 +120,28 @@ static alignas(STACK_ALIGN) uint8_t boot_stack[PAGESIZE];
 __boot_text static __noreturn void halt(void) {
   for (;;)
     __wfi();
+}
+
+__boot_text static void set_boot_syms(void) {
+#if __riscv_xlen == 64
+  extern char __boot_syms[];
+  uintptr_t *syms = (uintptr_t *)__boot_syms;
+  _kernel_start = (vaddr_t)syms[1];
+  _text = (vaddr_t)syms[2];
+  _riscv_boot = (vaddr_t)syms[3];
+  _data = (vaddr_t)syms[4];
+  _boot_stack = (uint8_t *)syms[5];
+  _ebss = (vaddr_t)syms[6];
+  _kernel_end = (vaddr_t)syms[7];
+#else
+  _kernel_start = (vaddr_t)__kernel_start;
+  _text = (vaddr_t)__text;
+  _riscv_boot = (vaddr_t)riscv_boot;
+  _data = (vaddr_t)__data;
+  _boot_stack = (uint8_t *)boot_stack;
+  _ebss = (vaddr_t)__ebss;
+  _kernel_end = (vaddr_t)__kernel_end;
+#endif
 }
 
 /*
@@ -126,17 +157,34 @@ __boot_text static void *bootmem_alloc(size_t bytes) {
   return addr;
 }
 
+__boot_text static pde_t *early_pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
+  pde_t *pde = (pde_t *)pd_pa;
+  if (lvl == 0)
+    return pde + L0_INDEX(va);
+#if __riscv_xlen == 32
+  return pde + L1_INDEX(va);
+#else
+  if (lvl == 1)
+    return pde + L1_INDEX(va);
+  return pde + L2_INDEX(va);
+#endif
+}
+
 __boot_text static pte_t *ensure_pte(vaddr_t va) {
-  pde_t *pdep = kernel_pde;
+  pde_t *pdep = early_pde_ptr((paddr_t)kernel_pde, 0, va);
 
-  /* Level 0 */
-  pdep += L0_INDEX(va);
-  if (!VALID_PTE_P(*pdep))
-    *pdep = PA_TO_PTE((paddr_t)bootmem_alloc(PAGESIZE)) | PTE_V;
-  pdep = (pde_t *)PTE_TO_PA(*pdep);
+  for (unsigned lvl = 1; lvl < PAGE_TABLE_DEPTH; lvl++) {
+    paddr_t pa;
+    if (!VALID_PDE_P(*pdep)) {
+      pa = (paddr_t)bootmem_alloc(PAGESIZE);
+      *pdep = PA_TO_PTE(pa) | PTE_V;
+    } else {
+      pa = (paddr_t)PTE_TO_PA(*pdep);
+    }
+    pdep = early_pde_ptr(pa, lvl, va);
+  }
 
-  /* Level 1 */
-  return (pte_t *)pdep + L1_INDEX(va);
+  return (pte_t *)pdep;
 }
 
 __boot_text static void early_kenter(vaddr_t va, size_t size, paddr_t pa,
@@ -150,11 +198,10 @@ __boot_text static void early_kenter(vaddr_t va, size_t size, paddr_t pa,
   }
 }
 
-static __noreturn void riscv_boot(paddr_t dtb, paddr_t pde, paddr_t kern_end);
-
 __boot_text __noreturn void riscv_init(paddr_t dtb) {
-  if (!((paddr_t)__eboot < (vaddr_t)__kernel_start ||
-        (vaddr_t)__kernel_end < (paddr_t)__boot))
+  set_boot_syms();
+
+  if (!((paddr_t)__eboot < _kernel_start || _kernel_end < (paddr_t)__boot))
     halt();
 
   /* Initialize boot memory allocator. */
@@ -163,30 +210,21 @@ __boot_text __noreturn void riscv_init(paddr_t dtb) {
   /* Allocate kernel page directory.*/
   kernel_pde = bootmem_alloc(PAGESIZE);
 
-  /*
-   * !HACK!
-   * See 4th point of bare memory boot description
-   * at the top of this file for details.
-   */
-  vaddr_t va = roundup2(KERNEL_VIRT_IMG_END, GROWKERNEL_STRIDE);
-  for (int i = 0; i < VM_PAGE_PDS; i++)
-    (void)ensure_pte(va + i * GROWKERNEL_STRIDE);
-
   /* Kernel read-only segment - sections: .text and .rodata. */
-  early_kenter((vaddr_t)__text, __data - __text, RISCV_PHYSADDR(__text),
+  early_kenter(_text, _data - _text, RISCV_PHYSADDR(_text),
                PTE_X | PTE_KERN_RO);
 
   /* Kernel read-write segment - sections: .data and .bss. */
-  early_kenter((vaddr_t)__data, KERNEL_VIRT_IMG_END - (vaddr_t)__data,
-               RISCV_PHYSADDR(__data), PTE_KERN);
+  early_kenter(_data, KERNEL_VIRT_IMG_END - _data, RISCV_PHYSADDR(_data),
+               PTE_KERN);
 
   /*
    * NOTE: we don't have to map the boot allocation area as the allocated
    * data will only be accessed using physical addresses (see pmap).
    */
 
-  /* DTB - assume that DTB will be covered by a single last level page
-   * directory. */
+  /* DTB - assume that DTB will be covered
+   * by single last level page directory. */
   early_kenter(BOOT_DTB_VADDR, GROWKERNEL_STRIDE, rounddown(dtb, PAGESIZE),
                PTE_KERN);
 
@@ -201,13 +239,18 @@ __boot_text __noreturn void riscv_init(paddr_t dtb) {
 #endif /* !KASAN */
 
   /* Temporarily set the trap vector. */
-  csr_write(stvec, riscv_boot);
+  csr_write(stvec, _riscv_boot);
 
   /*
    * Move to VM boot stage.
    */
+#if __riscv_xlen == 64
+  const paddr_t satp = SATP_MODE_SV39 | ((paddr_t)kernel_pde >> PAGE_SHIFT);
+#else
   const paddr_t satp = SATP_MODE_SV32 | ((paddr_t)kernel_pde >> PAGE_SHIFT);
-  void *boot_sp = &boot_stack[PAGESIZE];
+#endif
+
+  void *boot_sp = &_boot_stack[PAGESIZE];
 
   __sfence_vma();
 
@@ -216,7 +259,7 @@ __boot_text __noreturn void riscv_init(paddr_t dtb) {
                    "mv a2, %2\n\t"
                    "mv sp, %3\n\t"
                    "csrw satp, %4\n\t"
-                   "nop" /* triggers instruction fetch page fault */
+                   "ebreak" /* triggers instruction fetch page fault */
                    :
                    : "r"(dtb), "r"(kernel_pde), "r"(bootmem_brk), "r"(boot_sp),
                      "r"(satp)
@@ -228,6 +271,16 @@ __boot_text __noreturn void riscv_init(paddr_t dtb) {
 /*
  * Virtual memory boot functions.
  */
+
+static void set_kernel_syms(void) {
+#if __riscv_xlen == 64
+  extern char __kernel_syms[];
+  uintptr_t *syms = (uintptr_t *)__kernel_syms;
+  _eboot = (paddr_t)syms[0];
+#else
+  _eboot = (paddr_t)__eboot;
+#endif
+}
 
 static void clear_bss(void) {
   long *ptr = (long *)__bss;
@@ -242,7 +295,9 @@ extern void cpu_exception_handler(void);
 extern void *board_stack(paddr_t dtb_pa, void *dtb_va);
 extern void __noreturn board_init(void);
 
-static __noreturn void riscv_boot(paddr_t dtb, paddr_t pde, paddr_t kern_end) {
+#define __text_riscv_boot __section(".text.riscv_boot")
+__text_riscv_boot static __noreturn __used void
+riscv_boot(paddr_t dtb, paddr_t pde, paddr_t kern_end) {
   /*
    * Set initial register values.
    */
@@ -262,13 +317,18 @@ static __noreturn void riscv_boot(paddr_t dtb, paddr_t pde, paddr_t kern_end) {
   csr_clear(sie, SIP_SEIP | SIP_STIP | SIP_SSIP);
   csr_clear(sie, SIE_SEIE | SIE_STIE | SIE_SSIE);
 
+  set_kernel_syms();
+
   clear_bss();
 
   extern paddr_t kern_phys_end;
   kern_phys_end = kern_end;
 
 #if KASAN
-  _kasan_sanitized_end = KASAN_SANITIZED_START + BOOT_KASAN_SANITIZED_SIZE;
+  _kasan_sanitized_end =
+    KASAN_SANITIZED_START +
+    (roundup(align((vaddr_t)__ebss, PAGESIZE), GROWKERNEL_STRIDE) -
+     KASAN_SANITIZED_START);
 #endif
 
   void *dtb_va = (void *)BOOT_DTB_VADDR + (dtb & (PAGESIZE - 1));

--- a/sys/riscv/pmap.c
+++ b/sys/riscv/pmap.c
@@ -106,8 +106,13 @@ void pmap_md_activate(pmap_t *umap) {
 }
 
 void pmap_md_setup(pmap_t *pmap) {
+#if __riscv_xlen == 64
+  pmap->md.satp = SATP_MODE_SV39 | ((paddr_t)pmap->asid << SATP_ASID_S) |
+                  (pmap->pde >> PAGE_SHIFT);
+#else
   pmap->md.satp = SATP_MODE_SV32 | ((paddr_t)pmap->asid << SATP_ASID_S) |
                   (pmap->pde >> PAGE_SHIFT);
+#endif
   pmap->md.generation = (pmap == pmap_kernel());
 }
 

--- a/sys/riscv/riscv.ld.in
+++ b/sys/riscv/riscv.ld.in
@@ -2,7 +2,6 @@
 
 /* Linker scripts are documented here:
  * https://sourceware.org/binutils/docs/ld/Scripts.html */
-OUTPUT_FORMAT("elf32-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
 

--- a/sys/riscv/riscv.ld.in
+++ b/sys/riscv/riscv.ld.in
@@ -20,6 +20,18 @@ SECTIONS
     __boot = ABSOLUTE(.);
     KEEP(riscv/riscv.ka:start.o)
     *(.boot .boot.*)
+#if __riscv_xlen == 64
+    . = ALIGN(8);
+    __boot_syms = ABSOLUTE(.);
+    QUAD(__global_pointer$);
+    QUAD(__kernel_start);
+    QUAD(__text);
+    QUAD(__riscv_boot);
+    QUAD(__data);
+    QUAD(__boot_stack);
+    QUAD(__ebss);
+    QUAD(__kernel_end);
+#endif
     . = ALIGN(4096);
     __eboot = ABSOLUTE(.);
   } : boot
@@ -30,6 +42,8 @@ SECTIONS
   {
     __kernel_start = ABSOLUTE(.);
     __text = ABSOLUTE(.);
+    __riscv_boot = ABSOLUTE(.);
+    *(.text.riscv_boot)
     *(.text .text.*)
     __etext = ABSOLUTE(.);
     /* Constructors are used by KASAN to initialize global redzones */
@@ -49,6 +63,11 @@ SECTIONS
   {
     __data = ABSOLUTE(.);
     *(.data .data.*)
+#if __riscv_xlen == 64
+    . = ALIGN(8);
+    __kernel_syms = ABSOLUTE(.);
+    QUAD(__eboot);
+#endif
   } : data
 
   /* We use linker relaxations based on `__global_pointer$` for `.sdata`.
@@ -62,6 +81,7 @@ SECTIONS
 
   .sdata :
   {
+    . = ALIGN(8);
     /* Load/store instruction offset is 12 bits (sign extended). */
     __global_pointer$ = . + 0x800;
     *(.srodata .srodata.*)
@@ -72,6 +92,8 @@ SECTIONS
   .bss :
   {
     __bss = ABSOLUTE(.);
+    __boot_stack = ABSOLUTE(.);
+    *(.bss.boot_stack)
     *(.sbss .sbss.*)
     *(.scommon)
     *(.bss .bss.*)

--- a/sys/riscv/start.S
+++ b/sys/riscv/start.S
@@ -17,15 +17,22 @@
  *  - all other registers remain in an undefined state
  */
 _ENTRY(_start)
+#if __riscv_xlen == 64
+	.option push
+	.option norelax
+	PTR_LA t0, __boot_syms
+	PTR_L gp, (t0)
+	.option pop
+#else
 	LOAD_GP()
+#endif
 
 	/* 
 	 * NOTE: In an actual SMP system, we could have multiple harts
 	 * entering the kernel simultaneously. In such case,
 	 * we would have to choose the hart to perform the global startup.
-	 * FTTB, we assume a single hart of ID 0.
+	 * FTTB, we assume a single hart entering the kernel.
 	 */
-	bnez a0, halt
 
 	/* Move to the initial stack. */
 	PTR_LA sp, initstack_end


### PR DESCRIPTION
Implementation of the machine-dependent boot proces (`_start` -> `kernel_init`) for the RISC-V 64-bit target architecture.

This PR contains changes introduced in #1280, #1281, and #1282.