### PR TITLE
[RISCV] Remove faulty CSR immediate macros.

### DIFF
--- a/include/riscv/riscvreg.h
+++ b/include/riscv/riscvreg.h
@@ -124,40 +124,17 @@
 #define INSN_SIZE 4
 #define INSN_C_SIZE 2
 
-#define CSR_ZIMM(val) (__builtin_constant_p(val) && ((u_long)(val) < 32))
-
 #define csr_swap(csr, val)                                                     \
   ({                                                                           \
-    if (CSR_ZIMM(val))                                                         \
-      __asm __volatile("csrrwi %0, " #csr ", %1" : "=r"(val) : "i"(val));      \
-    else                                                                       \
-      __asm __volatile("csrrw %0, " #csr ", %1" : "=r"(val) : "r"(val));       \
+    __asm __volatile("csrrw %0, " #csr ", %1" : "=r"(val) : "r"(val));         \
     val;                                                                       \
   })
 
-#define csr_write(csr, val)                                                    \
-  ({                                                                           \
-    if (CSR_ZIMM(val))                                                         \
-      __asm __volatile("csrwi " #csr ", %0" ::"i"(val));                       \
-    else                                                                       \
-      __asm __volatile("csrw " #csr ", %0" ::"r"(val));                        \
-  })
+#define csr_write(csr, val) __asm __volatile("csrw " #csr ", %0" ::"r"(val))
 
-#define csr_set(csr, val)                                                      \
-  ({                                                                           \
-    if (CSR_ZIMM(val))                                                         \
-      __asm __volatile("csrsi " #csr ", %0" ::"i"(val));                       \
-    else                                                                       \
-      __asm __volatile("csrs " #csr ", %0" ::"r"(val));                        \
-  })
+#define csr_set(csr, val) __asm __volatile("csrs " #csr ", %0" ::"r"(val))
 
-#define csr_clear(csr, val)                                                    \
-  ({                                                                           \
-    if (CSR_ZIMM(val))                                                         \
-      __asm __volatile("csrci " #csr ", %0" ::"i"(val));                       \
-    else                                                                       \
-      __asm __volatile("csrc " #csr ", %0" ::"r"(val));                        \
-  })
+#define csr_clear(csr, val) __asm __volatile("csrc " #csr ", %0" ::"r"(val))
 
 #define csr_read(csr)                                                          \
   ({                                                                           \


### PR DESCRIPTION
It turns out that the `CSR_ZIMM` is faulty, e.g. it can classify an expression of the type `array_addr - imm` as a constant within the range [0, 31].