### PR TITLE
[RISCV] Enhance the GNU toolchain to include RISC-V 64.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ RUN curl -O https://mimiker.ii.uni.wroc.pl/download/aarch64-mimiker-elf_latest_a
     dpkg -i aarch64-mimiker-elf_latest_amd64.deb && rm -f aarch64-mimiker-elf_latest_amd64.deb
 RUN curl -O https://mimiker.ii.uni.wroc.pl/download/riscv32-mimiker-elf_latest_amd64.deb && \
     dpkg -i riscv32-mimiker-elf_latest_amd64.deb && rm -f riscv32-mimiker-elf_latest_amd64.deb
+RUN curl -O https://mimiker.ii.uni.wroc.pl/download/riscv64-mimiker-elf_latest_amd64.deb && \
+    dpkg -i riscv64-mimiker-elf_latest_amd64.deb && rm -f riscv64-mimiker-elf_latest_amd64.deb
 RUN curl -O https://mimiker.ii.uni.wroc.pl/download/qemu-mimiker_latest_amd64.deb && \
     dpkg -i qemu-mimiker_latest_amd64.deb && rm -f qemu-mimiker_latest_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: sys-build initrd.cpio
 
 PHONY-TARGETS += setup test
 
-IMGVER = 1.8.5
+IMGVER = 1.9.0
 IMGNAME = cahirwpz/mimiker-ci
 
 docker-build:

--- a/toolchain/gnu/config.mk
+++ b/toolchain/gnu/config.mk
@@ -23,4 +23,4 @@ BINUTILS-URL = "https://ftp.gnu.org/gnu/binutils/$(BINUTILS).tar.xz"
 GCC-URL = "https://ftp.gnu.org/gnu/gcc/$(GCC)/$(GCC).tar.xz"
 GDB-URL = "https://ftp.gnu.org/gnu/gdb/$(GDB).tar.xz"
 
-TARGETS = mipsel aarch64 riscv32
+TARGETS = mipsel aarch64 riscv32 riscv64

--- a/toolchain/gnu/riscv64-mimiker-elf/Makefile
+++ b/toolchain/gnu/riscv64-mimiker-elf/Makefile
@@ -1,0 +1,12 @@
+# vim: tabstop=8 shiftwidth=8 noexpandtab list:
+
+TOPDIR = $(realpath ..)
+
+ARCH = riscv64
+TARGET = riscv64-mimiker-elf
+
+GCC_EXTRA_CONF = --with-arch=rv64gc \
+		 --with-abi=lp64d \
+		 --with-cmodel=medany
+
+include $(TOPDIR)/target.mk


### PR DESCRIPTION
Although we ultimately want to switch entirely to LLVM toolchain, FTTB we rely on the GNU toolchain.