### PR TITLE
[RISCV] Generic rootdev driver.

### DIFF
--- a/sys/drv/Makefile
+++ b/sys/drv/Makefile
@@ -39,8 +39,8 @@ SOURCES-AARCH64 = \
 SOURCES-RISCV = \
 	clint.c \
 	liteuart.c \
-	litex_riscv_rootdev.c \
 	plic.c \
+	riscv_rootdev.c \
 	sifive_uart.c
 
 CPPFLAGS += -D_MACHDEP

--- a/sys/drv/riscv_rootdev.c
+++ b/sys/drv/riscv_rootdev.c
@@ -192,7 +192,11 @@ static int rootdev_attach(device_t *bus) {
     return ENXIO;
 
   rman_init(&rd->mem_rm, "RISC-V I/O space");
+#if __riscv_xlen == 64
+  rman_manage_region(&rd->mem_rm, 0x00000000, 0x30000000);
+#else
   rman_manage_region(&rd->mem_rm, 0xf0000000, 0x10000000);
+#endif
 
   /*
    * NOTE: supervisor can only control supervisor and user interrupts, however,


### PR DESCRIPTION
We would like to maintain a single rootdev driver for botch 32- and 64-bit RISC-V platforms.