### PR TITLE
[dev] Fix return value of simplebus interrupt processing function.

### DIFF
--- a/sys/drv/simplebus.c
+++ b/sys/drv/simplebus.c
@@ -231,7 +231,7 @@ static int sb_intr_to_rl(device_t *dev) {
 
 end:
   kfree(M_DEV, intrs);
-  return 0;
+  return err;
 }
 
 int simplebus_add_child(device_t *bus, const char *path, int unit,


### PR DESCRIPTION
`sb_intr_to_rl` should return an error code.