### PR TITLE
Add simplebus procedure for adding child by phandle

### DIFF
--- a/include/dev/simplebus.h
+++ b/include/dev/simplebus.h
@@ -4,7 +4,7 @@
 #include <sys/device.h>
 
 /*
- * Add a simplebus-attached device.
+ * Add a simplebus-attached device by node's path.
  *
  * Arguments:
  *  - `bus`: parent bus of the device
@@ -19,5 +19,22 @@
  */
 int simplebus_add_child(device_t *bus, const char *path, int unit,
                         device_t *pic, device_t **devp);
+
+/*
+ * Add a simplebus-attached device by phandle to its node.
+ *
+ * Arguments:
+ *  - `bus`: parent bus of the device
+ *  - `node`: phandle to device's node
+ *  - `unit`: unit number
+ *  - `pic`: programmable interrupt controller of the device
+ *  - `devp`: if not `NULL`, dst for the pointer of the allocated device
+ *
+ * Returns:
+ *  - 0: success
+ *  - != 0: errno code identifying the occured error
+ */
+int simplebus_add_child_node(device_t *bus, phandle_t node, int unit,
+                             device_t *pic, device_t **devp);
 
 #endif /* !_DEV_SIMPLEBUS_H_ */

--- a/sys/drv/bcm2835_emmc.c
+++ b/sys/drv/bcm2835_emmc.c
@@ -21,6 +21,8 @@
 #include <sys/errno.h>
 #include <sys/bitops.h>
 #include <dev/bcm2835_emmcreg.h>
+#include <sys/fdt.h>
+#include <dev/simplebus.h>
 
 typedef struct bcmemmc_state {
   resource_t *gpio;      /* GPIO resource (needed until we have a decent
@@ -571,10 +573,12 @@ static int bcmemmc_attach(device_t *dev) {
 
   /* This is not a legitimate bus in a sense that it implements `DIF_BUS`, but
    * it should work nevertheless */
-  device_t *child = device_add_child(dev, 0);
+  phandle_t child_node = FDT_child(dev->node);
+  if (child_node == FDT_NODEV)
+    return 0;
+  device_t *child;
+  simplebus_add_child_node(dev, child_node, 0, dev->pic, &child);
   child->bus = DEV_BUS_EMMC;
-  child->devclass = &DEVCLASS(emmc);
-  child->unit = 0;
 
   return bus_generic_probe(dev);
 }

--- a/sys/drv/simplebus.c
+++ b/sys/drv/simplebus.c
@@ -234,12 +234,8 @@ end:
   return err;
 }
 
-int simplebus_add_child(device_t *bus, const char *path, int unit,
-                        device_t *pic, device_t **devp) {
-  phandle_t node;
-  if ((node = FDT_finddevice(path)) == FDT_NODEV)
-    return ENXIO;
-
+int simplebus_add_child_node(device_t *bus, phandle_t node, int unit,
+                             device_t *pic, device_t **devp) {
   device_t *dev = device_add_child(bus, unit);
   dev->node = node;
   dev->pic = pic;
@@ -262,4 +258,13 @@ end:
   if (err)
     device_remove_child(bus, dev);
   return err;
+}
+
+int simplebus_add_child(device_t *bus, const char *path, int unit,
+                        device_t *pic, device_t **devp) {
+  phandle_t node;
+  if ((node = FDT_finddevice(path)) == FDT_NODEV)
+    return ENXIO;
+
+  return simplebus_add_child_node(bus, node, unit, pic, devp);
 }


### PR DESCRIPTION
I can't find a way to get the absolute path back from a phandle. This makes it impossible to use simplebus for attaching children of bus other than rootdev. On the other hand, I can iterate over phandles of children nodes of a bus device node. This PR allows me to use those phandles to attach such children using simplebus (see the emmc controller driver)