### PR TITLE
Sidebar link fix 

### DIFF
--- a/wiki/docs/_Sidebar.md
+++ b/wiki/docs/_Sidebar.md
@@ -1,7 +1,7 @@
 # Mimiker Wiki
 
 - [Home](https://github.com/cahirwpz/mimiker/wiki)
-- [Structure](https://github.com/cahirwpz/mimiker/wiki/structure.md)
+- [Structure](https://github.com/cahirwpz/mimiker/wiki/structure)
 - [Commenting](https://github.com/cahirwpz/mimiker/wiki/commenting)
 - [Onboarding](https://github.com/cahirwpz/mimiker/wiki/onboarding)
 - [Test infrastructure](https://github.com/cahirwpz/mimiker/wiki/tests)


### PR DESCRIPTION
This PR fixes the “Structure” link in the sidebar of the wiki, since it followed into the plaintext version of the document.