### PR TITLE
Enable KASAN on build with Clang

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -24,7 +24,7 @@ jobs:
       - run: ./verify-pycodestyle.sh
 
   build_mips_gcc:
-    name: Build MIPS (GCC + KASAN)
+    name: Build MIPS (GCC)
     runs-on: self-hosted
     needs: [verify_c_style, verify_py_style]
     steps:
@@ -46,10 +46,10 @@ jobs:
     needs: [verify_c_style, verify_py_style]
     steps:
       - uses: actions/checkout@v2
-      - run: make BOARD=malta LLVM=1
+      - run: make BOARD=malta LLVM=1 KASAN=1 LOCKDEP=1
 
   build_aarch64_gcc:
-    name: Build AArch64 (GCC + KASAN)
+    name: Build AArch64 (GCC)
     runs-on: self-hosted
     needs: [verify_c_style, verify_py_style]
     steps:
@@ -73,10 +73,10 @@ jobs:
     needs: [verify_c_style, verify_py_style]
     steps:
       - uses: actions/checkout@v2
-      - run: make BOARD=rpi3 LLVM=1
+      - run: make BOARD=rpi3 LLVM=1 KASAN=1 LOCKDEP=1
 
   build_rv32_gcc:
-    name: Build RISC-V 32-bit (GCC + KASAN)
+    name: Build RISC-V 32-bit (GCC)
     runs-on: self-hosted
     needs: [verify_c_style, verify_py_style]
     steps:
@@ -98,7 +98,7 @@ jobs:
     needs: [verify_c_style, verify_py_style]
     steps:
       - uses: actions/checkout@v2
-      - run: make BOARD=litex-riscv LLVM=1
+      - run: make BOARD=litex-riscv LLVM=1 KASAN=1 LOCKDEP=1
 
   build_rv64_clang:
     name: Build RISC-V 64-bit (Clang)
@@ -106,10 +106,10 @@ jobs:
     needs: [verify_c_style, verify_py_style]
     steps:
       - uses: actions/checkout@v2
-      - run: make BOARD=sifive_u LLVM=1
+      - run: make BOARD=sifive_u LLVM=1 KASAN=1 LOCKDEP=1
 
   kernel_tests_mips_gcc:
-    name: Tests MIPS (GCC + KASAN)
+    name: Tests MIPS (GCC)
     runs-on: self-hosted
     needs: build_mips_gcc
     steps:
@@ -120,7 +120,7 @@ jobs:
       - run: ./run_tests.py --board malta --timeout=80 --times=50
 
   kernel_tests_aarch64_gcc:
-    name: Tests AArch64 (GCC + KASAN)
+    name: Tests AArch64 (GCC)
     runs-on: self-hosted
     needs: build_aarch64_gcc
     steps:

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -10,7 +10,7 @@ ELFARCH := aarch64
 
 ifeq ($(LLVM), 1)
   TARGET := aarch64-linux-mimiker-elf
-  ABIFLAGS := -target $(TARGET)
+  ABIFLAGS :=
 else
   TARGET := aarch64-mimiker-elf
   ABIFLAGS := -mno-outline-atomics

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -5,11 +5,16 @@
 # Required common variables: KERNEL, BOARD.
 #
 
-TARGET := aarch64-linux-mimiker-elf
-GCC_ABIFLAGS := -mno-outline-atomics
-CLANG_ABIFLAGS := -target $(TARGET)
 ELFTYPE := elf64-littleaarch64
 ELFARCH := aarch64
+
+ifeq ($(LLVM), 1)
+  TARGET := aarch64-linux-mimiker-elf
+  ABIFLAGS := -target $(TARGET)
+else
+  TARGET := aarch64-mimiker-elf
+  ABIFLAGS := -mno-outline-atomics
+endif
 
 # NOTE(pj): We set A, SA, SA0 bits for SCTLR_EL1 register (sys/aarch64/boot.c)
 # as a result not aligned access to memory causes an exception. It's okay but

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -5,7 +5,7 @@
 # Required common variables: KERNEL, BOARD.
 #
 
-TARGET := aarch64-mimiker-elf
+TARGET := aarch64-linux-mimiker-elf
 GCC_ABIFLAGS := -mno-outline-atomics
 CLANG_ABIFLAGS := -target $(TARGET)
 ELFTYPE := elf64-littleaarch64

--- a/build/arch.mips.mk
+++ b/build/arch.mips.mk
@@ -4,19 +4,19 @@
 #
 # Required common variables: KERNEL, BOARD.
 
+ELFARCH := mips
+
 # -G 0 disables small-data and small-bss,
 # as otherwise they would exceed 64KB limit
 ifeq ($(LLVM), 1)
   TARGET := mipsel-linux-mimiker-elf
-  ABIFLAGS := -target $(TARGET) -march=mips32r2 -mno-abicalls \
-		          -modd-spreg -G 0 -D__ELF__=1
+  ABIFLAGS := -march=mips32r2 -mno-abicalls -modd-spreg -G 0 -D__ELF__=1
   ELFTYPE := elf32-tradlittlemips
 else
   TARGET := mipsel-mimiker-elf
   ABIFLAGS := -mips32r2 -EL -G 0
   ELFTYPE := elf32-littlemips
 endif
-ELFARCH := mips
 
 ASAN_SHADOW_OFFSET := 0xD8000000
 

--- a/build/arch.mips.mk
+++ b/build/arch.mips.mk
@@ -21,6 +21,5 @@ endif
 ASAN_SHADOW_OFFSET := 0xD8000000
 
 ifeq ($(KERNEL), 1)
-  # Added to all files
   ABIFLAGS += -msoft-float
 endif

--- a/build/arch.mips.mk
+++ b/build/arch.mips.mk
@@ -4,15 +4,16 @@
 #
 # Required common variables: KERNEL, BOARD.
 
-TARGET := mipsel-linux-mimiker-elf
 # -G 0 disables small-data and small-bss,
 # as otherwise they would exceed 64KB limit
-GCC_ABIFLAGS := -mips32r2 -EL -G 0
-CLANG_ABIFLAGS := -target $(TARGET) -march=mips32r2 -mno-abicalls \
-		  -modd-spreg -G 0 -D__ELF__=1
 ifeq ($(LLVM), 1)
+  TARGET := mipsel-linux-mimiker-elf
+  ABIFLAGS := -target $(TARGET) -march=mips32r2 -mno-abicalls \
+		          -modd-spreg -G 0 -D__ELF__=1
   ELFTYPE := elf32-tradlittlemips
 else
+  TARGET := mipsel-mimiker-elf
+  ABIFLAGS := -mips32r2 -EL -G 0
   ELFTYPE := elf32-littlemips
 endif
 ELFARCH := mips
@@ -21,6 +22,5 @@ ASAN_SHADOW_OFFSET := 0xD8000000
 
 ifeq ($(KERNEL), 1)
   # Added to all files
-  GCC_ABIFLAGS += -msoft-float
-  CLANG_ABIFLAGS += -msoft-float
+  ABIFLAGS += -msoft-float
 endif

--- a/build/arch.mips.mk
+++ b/build/arch.mips.mk
@@ -4,7 +4,7 @@
 #
 # Required common variables: KERNEL, BOARD.
 
-TARGET := mipsel-mimiker-elf
+TARGET := mipsel-linux-mimiker-elf
 # -G 0 disables small-data and small-bss,
 # as otherwise they would exceed 64KB limit
 GCC_ABIFLAGS := -mips32r2 -EL -G 0

--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -43,10 +43,10 @@ endif
 
 ifeq ($(LLVM), 1)
   TARGET := riscv$(XLEN)-linux-mimiker-elf
-  ABIFLAGS += -target $(TARGET) -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
+  ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
 else
- TARGET := riscv$(XLEN)-mimiker-elf
- ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
+  TARGET := riscv$(XLEN)-mimiker-elf
+  ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
 endif
 
 ifeq ($(KERNEL), 1)

--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -8,7 +8,7 @@
 # Required common variables: KERNEL, BOARD.
 #
 
-TARGET := riscv$(XLEN)-mimiker-elf
+TARGET := riscv$(XLEN)-linux-mimiker-elf
 ELFTYPE := elf$(XLEN)-littleriscv
 ELFARCH := riscv
 

--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -8,7 +8,6 @@
 # Required common variables: KERNEL, BOARD.
 #
 
-TARGET := riscv$(XLEN)-linux-mimiker-elf
 ELFTYPE := elf$(XLEN)-littleriscv
 ELFARCH := riscv
 
@@ -42,8 +41,13 @@ ifeq ($(BOARD), sifive_u)
   endif
 endif
 
-GCC_ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI) 
-CLANG_ABIFLAGS += -target $(TARGET) -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
+ifeq ($(LLVM), 1)
+  TARGET := riscv$(XLEN)-linux-mimiker-elf
+  ABIFLAGS += -target $(TARGET) -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
+else
+ TARGET := riscv$(XLEN)-mimiker-elf
+ ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
+endif
 
 ifeq ($(KERNEL), 1)
   CFLAGS += -mcmodel=medany

--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -43,11 +43,11 @@ endif
 
 ifeq ($(LLVM), 1)
   TARGET := riscv$(XLEN)-linux-mimiker-elf
-  ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
 else
   TARGET := riscv$(XLEN)-mimiker-elf
-  ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
 endif
+
+ABIFLAGS += -march=rv$(XLEN)$(EXT) -mabi=$(ABI)
 
 ifeq ($(KERNEL), 1)
   CFLAGS += -mcmodel=medany

--- a/build/flags.kern.mk
+++ b/build/flags.kern.mk
@@ -22,12 +22,14 @@ ifeq ($(KASAN), 1)
   ifeq ($(LLVM), 1)
     CFLAGS_KASAN = -fsanitize=kernel-address \
                    -mllvm -asan-mapping-offset=$(ASAN_SHADOW_OFFSET) \
+                   -mllvm -asan-instrumentation-with-call-threshold=0 \
                    -mllvm -asan-globals=true \
                    -mllvm -asan-stack=true \
                    -mllvm -asan-instrument-dynamic-allocas=true
   else
     CFLAGS_KASAN = -fsanitize=kernel-address \
                    -fasan-shadow-offset=$(ASAN_SHADOW_OFFSET) \
+                   --param asan-instrumentation-with-call-threshold=0 \
                    --param asan-globals=1 \
                    --param asan-stack=1 \
                    --param asan-instrument-allocas=1

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -4,7 +4,7 @@
 # tools used throughout the build system.
 #
 # The following make variables are set by the including makefile:
-# - TARGET, {CLANG,GCC}_ABIFLAGS: Set by arch.*.mk files.
+# - TARGET, ABIFLAGS: Set by arch.*.mk files.
 
 ifndef ARCH
   $(error ARCH variable not defined. Have you included config.mk?)
@@ -25,7 +25,7 @@ ifneq ($(shell which llvm-ar > /dev/null; echo $$?), 0)
   $(error llvm toolchain not found)
 endif
 
-CC	= clang $(CLANG_ABIFLAGS) -g
+CC	= clang $(ABIFLAGS) -g
 CPP	= $(CC) -x c -E
 AS	= $(CC)
 LD	= ld.lld
@@ -48,7 +48,7 @@ ifneq ($(shell which $(TARGET)-gcc > /dev/null; echo $$?), 0)
   $(error $(TARGET)-gcc compiler not found - please refer to README.md!)
 endif
 
-CC	= $(TARGET)-gcc $(GCC_ABIFLAGS) -g
+CC	= $(TARGET)-gcc $(ABIFLAGS) -g
 CPP	= $(TARGET)-cpp
 AS	= $(CC)
 LD	= $(TARGET)-ld

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -25,7 +25,7 @@ ifneq ($(shell which llvm-ar > /dev/null; echo $$?), 0)
   $(error llvm toolchain not found)
 endif
 
-CC	= clang $(ABIFLAGS) -g
+CC	= clang -target $(TARGET) $(ABIFLAGS) -g
 CPP	= $(CC) -x c -E
 AS	= $(CC)
 LD	= ld.lld

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -116,10 +116,10 @@
 #define __sysloglike(fmtarg, firstvararg)                                      \
   __attribute__((__format__(__syslog__, fmtarg, firstvararg)))
 
-#define __strong_alias(alias, sym)                                             \
-  extern __typeof(alias) alias __attribute__((__alias__(#sym)))
-#define __weak_alias(alias, sym)                                               \
-  __strong_alias(alias, sym) __attribute__((__weak__))
+#define __strong_alias(sym, alias)                                             \
+  extern __typeof(sym) alias __attribute__((__alias__(#sym)))
+#define __weak_alias(sym, alias)                                               \
+  __strong_alias(sym, alias) __attribute__((__weak__))
 
 /*
  * The following macro is used to remove const cast-away warnings

--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -137,9 +137,12 @@ extern char __etext[];
 /* Symbols defined by linker and used during kernel boot phase. */
 extern char __boot[];
 extern char __eboot[];
+extern char __text[];
 extern char __data[];
 extern char __bss[];
 extern char __ebss[];
+extern char __kernel_start[];
+extern char __kernel_end[];
 
 /* Last physical address used by kernel for boot memory allocation. */
 extern __boot_data void *_bootmem_end;

--- a/lib/libc/stdlib/merge.c
+++ b/lib/libc/stdlib/merge.c
@@ -87,8 +87,7 @@ static void insertionsort(u_char *, size_t, size_t,
  */
 /* Assumption: PSIZE is a power of 2. */
 #define EVAL(p)                                                                \
-  ((u_char **)(void *)(((u_char *)(void *)(p) + PSIZE - 1 - (u_char *)0) &     \
-                       ~(PSIZE - 1)))
+  ((u_char **)(void *)(((uintptr_t)(p) + PSIZE - 1) & ~(PSIZE - 1)))
 
 /*
  * Arguments are as for qsort.
@@ -117,7 +116,7 @@ int mergesort(void *base, size_t nmemb, size_t size,
    * Stupid subtraction for the Cray.
    */
   iflag = 0;
-  if (!(size % ISIZE) && !(((char *)base - (char *)0) % ISIZE))
+  if (!(size % ISIZE) && !(((uintptr_t)base) % ISIZE))
     iflag = 1;
 
   if ((list2 = malloc(nmemb * size + PSIZE)) == NULL)

--- a/lib/libc/stdlib/qsort.c
+++ b/lib/libc/stdlib/qsort.c
@@ -57,7 +57,7 @@ static inline void swapfunc(char *, char *, size_t, int);
   }
 
 #define SWAPINIT(a, es)                                                        \
-  swaptype = ((char *)a - (char *)0) % sizeof(long) || es % sizeof(long)       \
+  swaptype = ((uintptr_t)a) % sizeof(long) || es % sizeof(long)       \
                ? 2                                                             \
                : es == sizeof(long) ? 0 : 1;
 

--- a/lib/libm/src/s_scalbn.c
+++ b/lib/libm/src/s_scalbn.c
@@ -30,7 +30,7 @@ double scalbn(double x, int n) {
   return scalbln(x, n);
 }
 
-__weak_alias(ldexp, scalbn);
+__weak_alias(scalbn, ldexp);
 
 double scalbln(double x, long n) {
   int32_t k, hx, lx;

--- a/sys/kern/kasan.c
+++ b/sys/kern/kasan.c
@@ -288,7 +288,7 @@ DEFINE_ASAN_LOAD_STORE(16);
 
 void __asan_loadN_noabort(uintptr_t addr, size_t size) {
   shadow_check(addr, size, true);
-};
+}
 
 __weak_alias(__asan_loadN_noabort, __asan_report_load_n_noabort);
 

--- a/sys/kern/kasan.c
+++ b/sys/kern/kasan.c
@@ -272,15 +272,13 @@ void init_kasan(void) {
   void __asan_load##size##_noabort(uintptr_t addr) {                           \
     shadow_check(addr, size, true);                                            \
   }                                                                            \
-  void __asan_report_load##size##_noabort(uintptr_t addr);                     \
-  __weak_alias(__asan_report_load##size##_noabort,                             \
-               __asan_load##size##_noabort);                                   \
+  __weak_alias(__asan_load##size##_noabort,                                    \
+               __asan_report_load##size##_noabort);                            \
   void __asan_store##size##_noabort(uintptr_t addr) {                          \
     shadow_check(addr, size, false);                                           \
   }                                                                            \
-  void __asan_report_store##size##_noabort(uintptr_t addr);                    \
-  __weak_alias(__asan_report_store##size##_noabort,                            \
-               __asan_store##size##_noabort);
+  __weak_alias(__asan_store##size##_noabort,                                   \
+               __asan_report_store##size##_noabort);
 
 DEFINE_ASAN_LOAD_STORE(1);
 DEFINE_ASAN_LOAD_STORE(2);
@@ -292,15 +290,13 @@ void __asan_loadN_noabort(uintptr_t addr, size_t size) {
   shadow_check(addr, size, true);
 };
 
-void __asan_report_load_n_noabort(uintptr_t addr, size_t size);
-__weak_alias(__asan_report_load_n_noabort, __asan_loadN_noabort);
+__weak_alias(__asan_loadN_noabort, __asan_report_load_n_noabort);
 
 void __asan_storeN_noabort(uintptr_t addr, size_t size) {
   shadow_check(addr, size, false);
 }
 
-void __asan_report_store_n_noabort(uintptr_t addr, size_t size);
-__weak_alias(__asan_report_store_n_noabort, __asan_storeN_noabort);
+__weak_alias(__asan_storeN_noabort, __asan_report_store_n_noabort);
 
 /* Called at the end of every function marked as "noreturn".
  * Performs cleanup of the current stack's shadow memory to prevent false

--- a/sys/kern/kasan.c
+++ b/sys/kern/kasan.c
@@ -228,11 +228,12 @@ void kasan_mark_invalid(const void *addr, size_t size, uint8_t code) {
 }
 
 /* Call constructors that will register globals */
+typedef void (*ctor_t)(void);
+
 static void call_ctors(void) {
-  extern uintptr_t __CTOR_LIST__, __CTOR_END__;
-  for (uintptr_t *ptr = &__CTOR_LIST__; ptr != &__CTOR_END__; ptr++) {
-    void (*func)(void) = (void (*)(void))(*ptr);
-    (*func)();
+  extern ctor_t __CTOR_LIST__[], __CTOR_END__[];
+  for (ctor_t *ctor = __CTOR_LIST__; ctor != __CTOR_END__; ctor++) {
+    (*ctor)();
   }
 }
 

--- a/sys/kern/kasan.c
+++ b/sys/kern/kasan.c
@@ -272,9 +272,15 @@ void init_kasan(void) {
   void __asan_load##size##_noabort(uintptr_t addr) {                           \
     shadow_check(addr, size, true);                                            \
   }                                                                            \
+  void __asan_report_load##size##_noabort(uintptr_t addr);                     \
+  __weak_alias(__asan_report_load##size##_noabort,                             \
+               __asan_load##size##_noabort);                                   \
   void __asan_store##size##_noabort(uintptr_t addr) {                          \
     shadow_check(addr, size, false);                                           \
-  }
+  }                                                                            \
+  void __asan_report_store##size##_noabort(uintptr_t addr);                    \
+  __weak_alias(__asan_report_store##size##_noabort,                            \
+               __asan_store##size##_noabort);
 
 DEFINE_ASAN_LOAD_STORE(1);
 DEFINE_ASAN_LOAD_STORE(2);
@@ -284,11 +290,17 @@ DEFINE_ASAN_LOAD_STORE(16);
 
 void __asan_loadN_noabort(uintptr_t addr, size_t size) {
   shadow_check(addr, size, true);
-}
+};
+
+void __asan_report_load_n_noabort(uintptr_t addr, size_t size);
+__weak_alias(__asan_report_load_n_noabort, __asan_loadN_noabort);
 
 void __asan_storeN_noabort(uintptr_t addr, size_t size) {
   shadow_check(addr, size, false);
 }
+
+void __asan_report_store_n_noabort(uintptr_t addr, size_t size);
+__weak_alias(__asan_report_store_n_noabort, __asan_storeN_noabort);
 
 /* Called at the end of every function marked as "noreturn".
  * Performs cleanup of the current stack's shadow memory to prevent false

--- a/sys/libkern/stdlib/qsort.c
+++ b/sys/libkern/stdlib/qsort.c
@@ -59,7 +59,7 @@ void qsort(void *a, size_t n, size_t es, cmp_t *cmp);
 	} while (--i > 0);				\
 }
 
-#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \
+#define SWAPINIT(a, es) swaptype = ((uintptr_t)a) % sizeof(long) || \
 	es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
 
 static inline void

--- a/sys/riscv/boot.c
+++ b/sys/riscv/boot.c
@@ -114,6 +114,8 @@ __boot_data static pde_t *kernel_pde;
 
 __boot_data static volatile vaddr_t _kernel_start = (vaddr_t)__kernel_start;
 __boot_data static volatile vaddr_t _kernel_end = (vaddr_t)__kernel_end;
+__boot_data static volatile paddr_t _boot = (paddr_t)__boot;
+__boot_data static volatile paddr_t _eboot = (paddr_t)__eboot;
 __boot_data static volatile vaddr_t _ebss = (vaddr_t)__ebss;
 __boot_data static volatile vaddr_t _text = (vaddr_t)__text;
 __boot_data static volatile vaddr_t _data = (vaddr_t)__data;
@@ -175,7 +177,7 @@ __boot_text static void early_kenter(vaddr_t va, size_t size, paddr_t pa,
 }
 
 __boot_text __noreturn void riscv_init(paddr_t dtb) {
-  if (!((paddr_t)__eboot < _kernel_start) || (_kernel_end < (paddr_t)__boot))
+  if (!(_eboot < _kernel_start || _kernel_end < _boot))
     halt();
 
   /* Initialize boot memory allocator. */

--- a/sys/riscv/boot.c
+++ b/sys/riscv/boot.c
@@ -14,7 +14,7 @@
  *     before knowing the physical memory boundaries which are contained in the
  *     DTB itself),
  *
- *   - temoprarily mapping kernel page directory into VM (because there is
+ *   - temporarily mapping kernel page directory into VM (because there is
  *     no direct map to access it in the usual fashion),
  *
  *   - Preparing KASAN shadow memory for the mapped area,
@@ -69,30 +69,39 @@
 #include <riscv/cpufunc.h>
 #include <riscv/pmap.h>
 
-extern char __riscv_boot_pa[];
-extern char __boot_stack_pa[];
-extern char __kernel_start_pa[];
-extern char __text_pa[];
-extern char __data_pa[];
-extern char __ebss_pa[];
-extern char __kernel_end_pa[];
+extern char __text[];
+extern char __data[];
+extern char __ebss[];
+extern char __kernel_start[];
+extern char __kernel_end[];
 
-#define RISCV_VIRTADDR(x)                                                      \
-  ((vaddr_t)((paddr_t)(x)-KERNEL_PHYS) | KERNEL_SPACE_BEGIN)
+static __noreturn __used void riscv_boot(paddr_t dtb, paddr_t pde,
+                                         paddr_t kern_end);
 
-#define KERNEL_VIRT_IMG_END align(RISCV_VIRTADDR(__ebss_pa), PAGESIZE)
-#define KERNEL_PHYS_IMG_END align((paddr_t)__ebss_pa, PAGESIZE)
+#define PHYSADDR(x) ((paddr_t)((vaddr_t)(x)-KERNEL_VIRT) | KERNEL_PHYS)
 
-#define BOOT_KASAN_SANITIZED_SIZE                                              \
-  roundup2(roundup2(KERNEL_VIRT_IMG_END, GROWKERNEL_STRIDE) -                  \
-             KASAN_SANITIZED_START,                                            \
+#define BOOT_KASAN_SANITIZED_SIZE(end)                                         \
+  roundup2(roundup2((intptr_t)end, GROWKERNEL_STRIDE) - KASAN_SANITIZED_START, \
            PAGESIZE * KASAN_SHADOW_SCALE_SIZE)
-
-#define BOOT_KASAN_SHADOW_SIZE                                                 \
-  (BOOT_KASAN_SANITIZED_SIZE / KASAN_SHADOW_SCALE_SIZE)
 
 #define BOOT_DTB_VADDR DMAP_BASE
 #define BOOT_PD_VADDR (DMAP_BASE + GROWKERNEL_STRIDE)
+
+/*
+ * Virtual memory boot data.
+ */
+
+/* NOTE: the boot stack is used before we switch out to `thread0`. */
+static __used alignas(STACK_ALIGN) uint8_t boot_stack[PAGESIZE];
+
+/*
+ * Bare memory boot functions.
+ */
+
+__boot_text static __noreturn void halt(void) {
+  for (;;)
+    __wfi();
+}
 
 /*
  * Bare memory boot data.
@@ -103,24 +112,13 @@ __boot_data static void *bootmem_brk;
 
 __boot_data static pde_t *kernel_pde;
 
-/*
- * Virtual memory boot data.
- */
-
-#define __bss_boot_stack __section(".bss.boot_stack")
-
-/* NOTE: the boot stack is used before we switch out to `thread0`. */
-__bss_boot_stack static __used alignas(STACK_ALIGN) uint8_t
-  boot_stack[PAGESIZE];
-
-/*
- * Bare memory boot functions.
- */
-
-__boot_text static __noreturn void halt(void) {
-  for (;;)
-    __wfi();
-}
+__boot_data static volatile vaddr_t _kernel_start = (vaddr_t)__kernel_start;
+__boot_data static volatile vaddr_t _kernel_end = (vaddr_t)__kernel_end;
+__boot_data static volatile vaddr_t _ebss = (vaddr_t)__ebss;
+__boot_data static volatile vaddr_t _text = (vaddr_t)__text;
+__boot_data static volatile vaddr_t _data = (vaddr_t)__data;
+__boot_data static volatile vaddr_t _riscv_boot = (vaddr_t)riscv_boot;
+__boot_data static volatile vaddr_t _boot_stack = (vaddr_t)boot_stack;
 
 /*
  * Allocate and clear pages in physical memory just after kernel image end.
@@ -177,24 +175,22 @@ __boot_text static void early_kenter(vaddr_t va, size_t size, paddr_t pa,
 }
 
 __boot_text __noreturn void riscv_init(paddr_t dtb) {
-  if (!((paddr_t)__eboot < RISCV_VIRTADDR(__kernel_start_pa) ||
-        RISCV_VIRTADDR(__kernel_end_pa) < (paddr_t)__boot))
+  if (!((paddr_t)__eboot < _kernel_start) || (_kernel_end < (paddr_t)__boot))
     halt();
 
   /* Initialize boot memory allocator. */
-  bootmem_brk = (void *)KERNEL_PHYS_IMG_END;
+  bootmem_brk = (void *)align(PHYSADDR(_ebss), PAGESIZE);
 
   /* Allocate kernel page directory.*/
   kernel_pde = bootmem_alloc(PAGESIZE);
 
-  const vaddr_t text = RISCV_VIRTADDR(__text_pa);
-  const vaddr_t data = RISCV_VIRTADDR(__data_pa);
+  vaddr_t kernel_end = align(_ebss, PAGESIZE);
 
   /* Kernel read-only segment - sections: .text and .rodata. */
-  early_kenter(text, data - text, (paddr_t)__text_pa, PTE_X | PTE_KERN_RO);
+  early_kenter(_text, _data - _text, PHYSADDR(_text), PTE_X | PTE_KERN_RO);
 
   /* Kernel read-write segment - sections: .data and .bss. */
-  early_kenter(data, KERNEL_VIRT_IMG_END - data, (paddr_t)__data_pa, PTE_KERN);
+  early_kenter(_data, kernel_end - _data, PHYSADDR(_data), PTE_KERN);
 
   /*
    * NOTE: we don't have to map the boot allocation area as the allocated
@@ -210,14 +206,15 @@ __boot_text __noreturn void riscv_init(paddr_t dtb) {
   early_kenter(BOOT_PD_VADDR, PAGESIZE, (paddr_t)kernel_pde, PTE_KERN);
 
 #if KASAN
-  paddr_t shadow_mem = (paddr_t)bootmem_alloc(BOOT_KASAN_SHADOW_SIZE);
+  size_t shadow_size =
+    BOOT_KASAN_SANITIZED_SIZE(kernel_end) / KASAN_SHADOW_SCALE_SIZE;
+  paddr_t shadow_mem = (paddr_t)bootmem_alloc(shadow_size);
 
-  early_kenter(KASAN_SHADOW_START, BOOT_KASAN_SHADOW_SIZE, shadow_mem,
-               PTE_KERN);
+  early_kenter(KASAN_SHADOW_START, shadow_size, shadow_mem, PTE_KERN);
 #endif /* !KASAN */
 
   /* Temporarily set the trap vector. */
-  csr_write(stvec, RISCV_VIRTADDR(__riscv_boot_pa));
+  csr_write(stvec, _riscv_boot);
 
   /*
    * Move to VM boot stage.
@@ -228,7 +225,7 @@ __boot_text __noreturn void riscv_init(paddr_t dtb) {
   const paddr_t satp = SATP_MODE_SV32 | ((paddr_t)kernel_pde >> PAGE_SHIFT);
 #endif
 
-  void *boot_sp = (void *)RISCV_VIRTADDR(__boot_stack_pa) + PAGESIZE;
+  void *boot_sp = (void *)_boot_stack + PAGESIZE;
 
   __sfence_vma();
 
@@ -264,10 +261,8 @@ extern void cpu_exception_handler(void);
 extern void *board_stack(paddr_t dtb_pa, void *dtb_va);
 extern void __noreturn board_init(void);
 
-#define __text_riscv_boot __section(".text.riscv_boot")
-
-__text_riscv_boot static __noreturn __used void
-riscv_boot(paddr_t dtb, paddr_t pde, paddr_t kern_end) {
+static __noreturn __used void riscv_boot(paddr_t dtb, paddr_t pde,
+                                         paddr_t kern_end) {
   /*
    * Set initial register values.
    */
@@ -293,7 +288,8 @@ riscv_boot(paddr_t dtb, paddr_t pde, paddr_t kern_end) {
   kern_phys_end = kern_end;
 
 #if KASAN
-  _kasan_sanitized_end = KASAN_SANITIZED_START + BOOT_KASAN_SANITIZED_SIZE;
+  _kasan_sanitized_end =
+    KASAN_SANITIZED_START + BOOT_KASAN_SANITIZED_SIZE(__ebss);
 #endif
 
   void *dtb_va = (void *)BOOT_DTB_VADDR + (dtb & (PAGESIZE - 1));

--- a/sys/riscv/riscv.ld.in
+++ b/sys/riscv/riscv.ld.in
@@ -19,6 +19,7 @@ SECTIONS
     KEEP(*(.boot))
     *(.boot.text)
     *(.boot.data)
+    *(.boot.bss)
     . = ALIGN(4096);
     __eboot = ABSOLUTE(.);
   } : boot
@@ -28,11 +29,7 @@ SECTIONS
   .text KERNEL_VIRT + _boot_size : AT(__eboot) ALIGN(4096)
   {
     __kernel_start = ABSOLUTE(.);
-    __kernel_start_pa = LOADADDR(.text);
     __text = ABSOLUTE(.);
-    __text_pa = LOADADDR(.text);
-    __riscv_boot_pa = LOADADDR(.text);
-    *(.text.riscv_boot)
     *(.text .text.*)
     __etext = ABSOLUTE(.);
     /* Constructors are used by KASAN to initialize global redzones */
@@ -51,7 +48,6 @@ SECTIONS
   .data : ALIGN(4096)
   {
     __data = ABSOLUTE(.);
-    __data_pa = LOADADDR(.data);
     *(.data .data.*)
   } : data
 
@@ -68,7 +64,6 @@ SECTIONS
   {
     /* Load/store instruction offset is 12 bits (sign extended). */
     __global_pointer$ = . + 0x800;
-    __global_pointer$_pa = LOADADDR(.sdata) + 0x800;
     *(.srodata .srodata.*)
     *(.sdata .sdata.*)
     __edata = ABSOLUTE(.);
@@ -77,16 +72,12 @@ SECTIONS
   .bss :
   {
     __bss = ABSOLUTE(.);
-    __boot_stack_pa = LOADADDR(.bss);
-    *(.bss.boot_stack)
     *(.sbss .sbss.*)
     *(.scommon)
     *(.bss .bss.*)
     *(COMMON)
     __ebss = ABSOLUTE(.);
-    __ebss_pa = LOADADDR(.bss) + SIZEOF(.bss);
     __kernel_end = ABSOLUTE(.);
-    __kernel_end_pa = LOADADDR(.bss) + SIZEOF(.bss);
   }
 
   /* Sections to be discarded. */

--- a/sys/riscv/start.S
+++ b/sys/riscv/start.S
@@ -19,14 +19,7 @@
  *  - all other registers remain in an undefined state
  */
 _ENTRY(_start)
-	.option push
-	.option norelax
-	PTR_LA	gp, __global_pointer$_pa
-	REG_LI	t0, KERNEL_SPACE_BEGIN
-	REG_LI	t1, KERNEL_PHYS
-	REG_SUB	gp, gp, t1
-	or  gp, gp, t0
-	.option pop
+	PTR_L	gp, _global_pointer
 
 	/*
 	 * NOTE: In an actual SMP system, we could have multiple harts
@@ -36,16 +29,24 @@ _ENTRY(_start)
 	 */
 
 	/* Move to the initial stack. */
-	PTR_LA sp, initstack_end
+	PTR_LA	sp, initstack_end
 
-	mv a0, a1
-	tail riscv_init
+	mv	a0, a1
+	tail	riscv_init
 halt:
 	wfi
-	j halt
+	j	halt
 _END(_start)
 
-	.section .boot.data
+	.section .boot.data,"aw",@progbits
+_global_pointer:
+#if __riscv_xlen == 32
+	.long	__global_pointer$
+#else
+	.quad	__global_pointer$
+#endif
+
+	.section .boot.bss,"aw",@nobits
 
 	.align STACK_ALIGN
 initstack:

--- a/sys/riscv/start.S
+++ b/sys/riscv/start.S
@@ -6,6 +6,7 @@
 
 #define INITSTACK_SIZE 512
 
+	.option nopic
 	.section .boot,"ax",@progbits
 
 /*

--- a/sys/riscv/trap.c
+++ b/sys/riscv/trap.c
@@ -252,8 +252,8 @@ __no_profile void trap_handler(ctx_t *ctx) {
      * frame we consider situation to be critical and panic.
      * Hopefully sizeof(ctx_t) bytes of unallocated stack space will be enough
      * to display error message. */
-    register_t sp = __sp();
-    if ((sp & (PAGESIZE - 1)) < sizeof(ctx_t))
+    uintptr_t sp = __sp();
+    if (sp < (uintptr_t)td->td_kstack.stk_base + sizeof(ctx_t))
       panic("Kernel stack overflow caught at %p!", _REG(ctx, PC));
     kframe_saved = td->td_kframe;
     td->td_kframe = ctx;


### PR DESCRIPTION
We'd like to switch to Clang exclusively and ditch support for GCC. Hence all Clang builds need to pass when compiled with KASAN and LOCKDEP. There're some minor differences between Clang and GCC wrt. routines they expect to be implemented by ASAN runtime.