### PR TITLE
[include] Fix builtin defines.

### DIFF
--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -16,9 +16,9 @@
 #include <sys/types.h>
 
 #define log2(x) (CHAR_BIT * sizeof(unsigned long) - __builtin_clzl(x) - 1)
-#define ffs(x) (size_t)(__builtin_ffs(x))
-#define clz(x) (size_t)(__builtin_clz(x))
-#define ctz(x) (size_t)(__builtin_ctz(x))
+#define ffs(x) ((u_long)__builtin_ffsl(x))
+#define clz(x) ((u_long)__builtin_clzl(x))
+#define ctz(x) ((u_long)__builtin_ctzl(x))
 
 #define abs(x)                                                                 \
   ({                                                                           \


### PR DESCRIPTION
The `ffs`, `clz`, and `ctz` automatically cast the input argument to a 32-bit integer, thereby a 64-bit argument is handled incorrectly.
E.g. in the following snippet from `init_vm_page`, `pa` is truncated to a 32-bit value regardless of the pointer size of the target architecture.
```
size_t size = 1 << min(PM_NQUEUES - 1, ctz(pa / PAGESIZE));
```