### PR TITLE
Move DTB to kernel bss section on boot

### DIFF
--- a/include/riscv/boot.h
+++ b/include/riscv/boot.h
@@ -1,0 +1,9 @@
+#ifndef _RISCV_BOOT_H_
+#define _RISCV_BOOT_H_
+
+#include <sys/types.h>
+
+#define PHYSADDR(x) ((paddr_t)((vaddr_t)(x) + (KERNEL_PHYS - KERNEL_VIRT)))
+#define VIRTADDR(x) ((vaddr_t)((paddr_t)(x) + (KERNEL_VIRT - KERNEL_PHYS)))
+
+#endif /* !_RISCV_BOOT_H_ */

--- a/include/riscv/cpufunc.h
+++ b/include/riscv/cpufunc.h
@@ -21,7 +21,7 @@
     __rv;                                                                      \
   })
 
-#define __set_tp() __asm__ volatile("mv tp, %0" ::"r"(_pcpu_data) : "tp")
+#define __set_tp() __asm__ volatile("mv tp, %0" ::"r"(_pcpu_data))
 
 #define __set_satp(val) csr_write(satp, val)
 

--- a/include/sys/boot.h
+++ b/include/sys/boot.h
@@ -24,6 +24,10 @@ __boot_text void boot_clear(paddr_t start, paddr_t end);
 __boot_text __noreturn void halt(void);
 
 /* Last physical address used by kernel for boot memory allocation. */
+#ifndef __mips
+extern paddr_t boot_sbrk_end;
+#else
 extern __boot_data void *_bootmem_end;
+#endif
 
 #endif /* !_SYS_BOOT_H_ */

--- a/include/sys/boot.h
+++ b/include/sys/boot.h
@@ -1,0 +1,27 @@
+#ifndef _SYS_BOOT_H_
+#define _SYS_BOOT_H_
+
+#ifndef _MACHDEP
+#error "Do not use this header file outside kernel machine dependent code!"
+#endif
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+#include <sys/mimiker.h>
+
+/* Attribute macros for boot/wired functions/data */
+#define __boot_text __long_call __section(".boot.text")
+#define __boot_data __section(".boot.data")
+
+__boot_text void boot_sbrk_init(paddr_t ebss_pa);
+__boot_text void *boot_sbrk(size_t n);
+__boot_text paddr_t boot_sbrk_align(size_t n);
+
+__boot_text paddr_t boot_save_dtb(paddr_t dtb);
+
+__boot_text __noreturn void halt(void);
+
+/* Last physical address used by kernel for boot memory allocation. */
+extern __boot_data void *_bootmem_end;
+
+#endif /* !_SYS_BOOT_H_ */

--- a/include/sys/boot.h
+++ b/include/sys/boot.h
@@ -19,6 +19,8 @@ __boot_text paddr_t boot_sbrk_align(size_t n);
 
 __boot_text paddr_t boot_save_dtb(paddr_t dtb);
 
+__boot_text void boot_clear(paddr_t start, paddr_t end);
+
 __boot_text __noreturn void halt(void);
 
 /* Last physical address used by kernel for boot memory allocation. */

--- a/include/sys/fdt.h
+++ b/include/sys/fdt.h
@@ -40,35 +40,15 @@ typedef struct fdt_intr {
 } fdt_intr_t;
 
 /*
- * Early FDT initialization.
+ * FDT initialization.
  *
  * Must be called during MD bootstrap before the kernel environment is built.
  * This is the first FDT function that gets called.
  *
  * Arguments:
- *  - `pa`: FDT physical address
  *  - `va`: FDT kernel virtual address
  */
-void FDT_early_init(paddr_t pa, void *va);
-
-/*
- * Obtain the physical address of the FDT blob.
- */
-paddr_t FDT_get_physaddr(void);
-
-/*
- * Change the internal root FDT pointer.
- */
-void FDT_changeroot(void *root);
-
-/*
- * Obtain physical memory boundaries of the FDT blob.
- *
- * Arguments:
- *  - `startp`: dst for the first address
- *  - `endp`: dst for the first address after the blob
- */
-void FDT_get_blob_range(paddr_t *startp, paddr_t *endp);
+void FDT_init(void *va);
 
 /*
  * Find the package handle of a pointed device in the device tree.

--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -71,10 +71,6 @@
 bool preempt_disabled(void);
 bool intr_disabled(void) __no_profile;
 
-/* Attribute macros for boot/wired functions/data */
-#define __boot_text __long_call __section(".boot.text")
-#define __boot_data __section(".boot.data")
-
 #define CLEANUP_FUNCTION(func) __CONCAT(__cleanup_, func)
 #define DEFINE_CLEANUP_FUNCTION(type, func)                                    \
   static inline void __cleanup_##func(type *ptr) {                             \
@@ -141,9 +137,6 @@ extern char __rodata[];
 extern char __data[];
 extern char __bss[];
 extern char __ebss[];
-
-/* Last physical address used by kernel for boot memory allocation. */
-extern __boot_data void *_bootmem_end;
 #endif /* !_MACHDEP */
 
 #endif /* !_SYS_MIMIKER_H_ */

--- a/sys/aarch64/board.c
+++ b/sys/aarch64/board.c
@@ -99,28 +99,29 @@ static void rpi3_physmem(void) {
   paddr_t kern_end = (paddr_t)_bootmem_end;
   paddr_t rd_start = ramdisk_get_start();
   paddr_t rd_end = rd_start + ramdisk_get_size();
-  paddr_t dtb_start, dtb_end;
-  FDT_get_blob_range(&dtb_start, &dtb_end);
 
   /* TODO(pj) if vm_physseg_plug* interface was more flexible,
    * we could do without following hack, please refer to issue #1129 */
-  addr_range_t memory[3] = {
-    {.start = rounddown(kern_start, PAGESIZE),
-     .end = roundup(kern_end, PAGESIZE)},
-    {.start = rounddown(rd_start, PAGESIZE), .end = roundup(rd_end, PAGESIZE)},
-    {.start = rounddown(dtb_start, PAGESIZE),
-     .end = roundup(dtb_end, PAGESIZE)},
+  addr_range_t memory[2] = {
+    {
+      .start = rounddown(kern_start, PAGESIZE),
+      .end = roundup(kern_end, PAGESIZE),
+    },
+    {
+      .start = rounddown(rd_start, PAGESIZE),
+      .end = roundup(rd_end, PAGESIZE),
+    },
   };
 
-  qsort(memory, 3, sizeof(addr_range_t), addr_range_cmp);
+  qsort(memory, 2, sizeof(addr_range_t), addr_range_cmp);
 
   vm_physseg_plug(ram_start, memory[0].start);
-  for (int i = 0; i < 3; ++i) {
+  for (int i = 0; i < 2; ++i) {
     if (memory[i].start == memory[i].end)
       continue;
     assert(memory[i].start < memory[i].end);
     vm_physseg_plug_used(memory[i].start, memory[i].end);
-    if (i == 2) {
+    if (i == 1) {
       if (memory[i].end < ram_end)
         vm_physseg_plug(memory[i].end, ram_end);
     } else if (memory[i].end < memory[i + 1].start) {

--- a/sys/aarch64/board.c
+++ b/sys/aarch64/board.c
@@ -1,4 +1,5 @@
 #include <sys/kenv.h>
+#include <sys/boot.h>
 #include <sys/cmdline.h>
 #include <sys/libkern.h>
 #include <sys/klog.h>

--- a/sys/aarch64/board.c
+++ b/sys/aarch64/board.c
@@ -97,7 +97,7 @@ static void rpi3_physmem(void) {
   paddr_t ram_start = PAGESIZE;
   paddr_t ram_end = kenv_get_ulong("memsize");
   paddr_t kern_start = (paddr_t)__boot;
-  paddr_t kern_end = (paddr_t)_bootmem_end;
+  paddr_t kern_end = boot_sbrk_end;
   paddr_t rd_start = ramdisk_get_start();
   paddr_t rd_end = rd_start + ramdisk_get_size();
 

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -262,6 +262,7 @@ __boot_text static void enable_mmu(pde_t *pde) {
 __boot_text __noreturn void aarch64_init(paddr_t dtb) {
   drop_to_el1();
   configure_cpu();
+  boot_clear(PHYSADDR(__bss), PHYSADDR(__ebss));
   boot_sbrk_init(PHYSADDR(__ebss));
 
   vaddr_t dtb_va = VIRTADDR(boot_save_dtb(dtb));
@@ -292,8 +293,6 @@ extern void *board_stack(void);
 
 static __noreturn void aarch64_boot(void *dtb, paddr_t pde,
                                     vaddr_t kernel_end) {
-  bzero(__bss, (intptr_t)__ebss - (intptr_t)__bss);
-
   vm_kernel_end = kernel_end;
 
 #if KASAN

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -1,7 +1,6 @@
 #include <sys/boot.h>
 #include <sys/fdt.h>
 #include <sys/mimiker.h>
-#include <sys/libkern.h>
 #include <sys/pcpu.h>
 #include <sys/pmap.h>
 #include <sys/kasan.h>

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -185,7 +185,7 @@ __boot_text static pde_t *build_page_table(vaddr_t kernel_end) {
   size_t kasan_sanitized_size = BOOT_KASAN_SANITIZED_SIZE(__ebss);
   size_t kasan_shadow_size = kasan_sanitized_size / KASAN_SHADOW_SCALE_SIZE;
   /* Allocate physical memory for shadow area */
-  paddr_t kasan_shadow_pa = (paddr_t)bootmem_alloc(kasan_shadow_size);
+  paddr_t kasan_shadow_pa = (paddr_t)boot_sbrk(kasan_shadow_size);
 
   early_kenter(pde, KASAN_SHADOW_START, KASAN_SHADOW_START + kasan_shadow_size,
                kasan_shadow_pa, ATTR_AP_RW | ATTR_XN | pte_default);

--- a/sys/gen/Makefile
+++ b/sys/gen/Makefile
@@ -3,6 +3,7 @@
 TOPDIR = $(realpath ../..)
 
 SOURCES = \
+	boot.c \
 	pmap.c \
 	thread.c
 

--- a/sys/gen/Makefile
+++ b/sys/gen/Makefile
@@ -10,3 +10,7 @@ SOURCES = \
 CPPFLAGS += -D_MACHDEP
 
 include $(TOPDIR)/build/build.kern.mk
+
+boot.o : CFLAGS_KASAN =
+boot.o : CFLAGS_KCSAN =
+boot.o : CFLAGS_KGPROF =

--- a/sys/gen/boot.c
+++ b/sys/gen/boot.c
@@ -2,7 +2,7 @@
 #include <libfdt/libfdt.h>
 
 /* Last physical address used by kernel for boot memory allocation. */
-__boot_data void *_bootmem_end;
+paddr_t boot_sbrk_end;
 
 __boot_data static uintptr_t _boot_sbrk;
 

--- a/sys/gen/boot.c
+++ b/sys/gen/boot.c
@@ -1,0 +1,53 @@
+#include <sys/boot.h>
+#include <libfdt/libfdt.h>
+
+/* Last physical address used by kernel for boot memory allocation. */
+__boot_data void *_bootmem_end;
+
+__boot_data static uintptr_t _boot_sbrk;
+
+/* Initialize boot memory allocator. */
+__boot_text void boot_sbrk_init(paddr_t ebss_pa) {
+  _boot_sbrk = align(ebss_pa, sizeof(long));
+}
+
+/* Clears and allocates clears physical memory just after kernel image end. */
+__boot_text void *boot_sbrk(size_t n) {
+  long *addr = (long *)_boot_sbrk;
+  _boot_sbrk += align(n, sizeof(long));
+  for (unsigned i = 0; i < n / sizeof(long); i++)
+    addr[i] = 0;
+  return addr;
+}
+
+__boot_text paddr_t boot_sbrk_align(size_t n) {
+  _boot_sbrk = align(_boot_sbrk, n);
+  return (paddr_t)_boot_sbrk;
+}
+
+__boot_text static inline uint32_t fdt32toh(fdt32_t u) {
+  return ((((u)&0xff000000) >> 24) | (((u)&0x00ff0000) >> 8) |
+          (((u)&0x0000ff00) << 8) | (((u)&0x000000ff) << 24));
+}
+
+/* Copy DTB to kernel .bss section */
+__boot_text paddr_t boot_save_dtb(paddr_t dtb) {
+  const struct fdt_header *fdt = (void *)dtb;
+
+  if (fdt32toh(fdt->magic) != FDT_MAGIC)
+    halt();
+
+  size_t n = fdt32toh(fdt->totalsize);
+  uint8_t *src = (void *)dtb;
+  uint8_t *dst = boot_sbrk(n);
+
+  for (size_t i = 0; i < n; i++)
+    dst[i] = src[i];
+
+  return (paddr_t)dst;
+}
+
+__boot_text __noreturn void halt(void) {
+  for (;;)
+    continue;
+}

--- a/sys/gen/boot.c
+++ b/sys/gen/boot.c
@@ -25,6 +25,13 @@ __boot_text paddr_t boot_sbrk_align(size_t n) {
   return (paddr_t)_boot_sbrk;
 }
 
+__boot_text void boot_clear(paddr_t start, paddr_t end) {
+  long *s = (long *)start;
+  long *e = (long *)end;
+  for (; s < e; s++)
+    *s = 0;
+}
+
 __boot_text static inline uint32_t fdt32toh(fdt32_t u) {
   return ((((u)&0xff000000) >> 24) | (((u)&0x00ff0000) >> 8) |
           (((u)&0x0000ff00) << 8) | (((u)&0x000000ff) << 24));

--- a/sys/gen/boot.c
+++ b/sys/gen/boot.c
@@ -11,7 +11,7 @@ __boot_text void boot_sbrk_init(paddr_t ebss_pa) {
   _boot_sbrk = align(ebss_pa, sizeof(long));
 }
 
-/* Clears and allocates clears physical memory just after kernel image end. */
+/* Allocates and clears physical memory just after kernel image end. */
 __boot_text void *boot_sbrk(size_t n) {
   long *addr = (long *)_boot_sbrk;
   _boot_sbrk += align(n, sizeof(long));
@@ -26,18 +26,26 @@ __boot_text paddr_t boot_sbrk_align(size_t n) {
 }
 
 __boot_text void boot_clear(paddr_t start, paddr_t end) {
+  if (!is_aligned(start, sizeof(long)) || !is_aligned(end, sizeof(long)))
+    halt();
+
   long *s = (long *)start;
   long *e = (long *)end;
   for (; s < e; s++)
     *s = 0;
 }
 
+/*
+ * The compiler may choose to provide `bswap32` builtin as a function, which
+ * will be placed in `.text` section. This is exactly what we need to avoid.
+ * Please note this is only needed for little endian systems.
+ */
 __boot_text static inline uint32_t fdt32toh(fdt32_t u) {
   return ((((u)&0xff000000) >> 24) | (((u)&0x00ff0000) >> 8) |
           (((u)&0x0000ff00) << 8) | (((u)&0x000000ff) << 24));
 }
 
-/* Copy DTB to kernel .bss section */
+/* Copy DTB to kernel .bss section. */
 __boot_text paddr_t boot_save_dtb(paddr_t dtb) {
   const struct fdt_header *fdt = (void *)dtb;
 

--- a/sys/kern/fdt.c
+++ b/sys/kern/fdt.c
@@ -22,10 +22,7 @@
 
 #define FDT_DEF_INTR_CELLS 1
 
-static paddr_t fdt_pa;  /* FDT blob physical address (`PAGESIZE`-aligned) */
-static size_t fdt_off;  /* FDT blob offset within the first page */
-static void *fdtp;      /* FDT blob virtual memory pointer */
-static size_t fdt_size; /* FDT blob size (rounded to `PAGESIZE`) */
+static void *fdtp; /* FDT blob virtual memory pointer */
 
 static inline void FDT_perror(int err) {
 #if defined(FDT_DEBUG) && FDT_DEBUG
@@ -37,33 +34,11 @@ static inline void FDT_panic(int err) {
   panic("FDT operation failed: %s", fdt_strerror(err));
 }
 
-void FDT_early_init(paddr_t pa, void *va) {
+void FDT_init(void *va) {
   int err = fdt_check_header(va);
   if (err < 0)
     FDT_panic(err);
-
-  const size_t totalsize = fdt_totalsize(va);
-
-  fdt_pa = rounddown(pa, PAGESIZE);
-  fdt_off = fdt_pa - pa;
   fdtp = va;
-  paddr_t fdt_end = roundup(pa + totalsize, PAGESIZE);
-  fdt_size = fdt_end - fdt_pa;
-}
-
-paddr_t FDT_get_physaddr(void) {
-  assert(fdt_pa);
-  return fdt_pa + fdt_off;
-}
-
-void FDT_changeroot(void *root) {
-  assert(fdtp);
-  fdtp = root;
-}
-
-void FDT_get_blob_range(paddr_t *startp, paddr_t *endp) {
-  *startp = fdt_pa;
-  *endp = fdt_pa + fdt_size;
 }
 
 phandle_t FDT_finddevice(const char *device) {

--- a/sys/mips/board.c
+++ b/sys/mips/board.c
@@ -5,6 +5,7 @@
 #include <dev/malta.h>
 #include <mips/mcontext.h>
 #include <mips/tlb.h>
+#include <sys/boot.h>
 #include <sys/klog.h>
 #include <sys/console.h>
 #include <sys/context.h>

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -1,3 +1,4 @@
+#include <mips/abi.h>
 #include <mips/m32c0.h>
 #include <mips/pmap.h>
 #include <sys/boot.h>
@@ -7,7 +8,7 @@
 #include <sys/kasan.h>
 
 /* The boot stack is used before we switch out to thread0. */
-static alignas(PAGESIZE) uint8_t _boot_stack[PAGESIZE];
+static alignas(STACK_ALIGN) uint8_t _boot_stack[PAGESIZE];
 
 __boot_data void *_bootmem_end;
 

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -1,12 +1,10 @@
 #include <mips/m32c0.h>
 #include <mips/pmap.h>
+#include <sys/boot.h>
 #include <sys/mimiker.h>
 #include <sys/pmap.h>
 #include <sys/vm.h>
 #include <sys/kasan.h>
-
-/* Last address in kseg0 used by kernel for boot allocation. */
-__boot_data void *_bootmem_end;
 
 /* The boot stack is used before we switch out to thread0. */
 static alignas(PAGESIZE) uint8_t _boot_stack[PAGESIZE];
@@ -16,11 +14,6 @@ static __boot_text void *bootmem_alloc(size_t bytes) {
   void *addr = _bootmem_end;
   _bootmem_end += align(bytes, PAGESIZE);
   return addr;
-}
-
-__boot_text static void halt(void) {
-  for (;;)
-    continue;
 }
 
 __boot_text void *mips_init(void) {

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -9,6 +9,8 @@
 /* The boot stack is used before we switch out to thread0. */
 static alignas(PAGESIZE) uint8_t _boot_stack[PAGESIZE];
 
+__boot_data void *_bootmem_end;
+
 /* Allocates pages in kseg0. The argument will be aligned to PAGESIZE. */
 static __boot_text void *bootmem_alloc(size_t bytes) {
   void *addr = _bootmem_end;

--- a/sys/riscv/board.c
+++ b/sys/riscv/board.c
@@ -10,13 +10,11 @@
 #include <sys/thread.h>
 #include <sys/types.h>
 #include <sys/vm_physmem.h>
+#include <riscv/boot.h>
 #include <riscv/mcontext.h>
 #include <riscv/pmap.h>
 #include <riscv/sbi.h>
 #include <riscv/vm_param.h>
-
-#define RISCV_PHYSADDR(x)                                                      \
-  ((paddr_t)((vaddr_t)(x) & ~KERNEL_SPACE_BEGIN) + KERNEL_PHYS)
 
 paddr_t kern_phys_end;
 
@@ -112,7 +110,7 @@ typedef struct {
 
 static void ar_get_kernel_img(addr_range_t *ar) {
   assert(kern_phys_end);
-  ar->start = RISCV_PHYSADDR(__kernel_start);
+  ar->start = PHYSADDR(__kernel_start);
   ar->end = kern_phys_end;
 }
 

--- a/sys/riscv/board.c
+++ b/sys/riscv/board.c
@@ -124,13 +124,6 @@ static void ar_get_initrd(addr_range_t *ar) {
   ar->end = END(rd_end);
 }
 
-static void ar_get_dtb(addr_range_t *ar) {
-  paddr_t dtb_start, dtb_end;
-  FDT_get_blob_range(&dtb_start, &dtb_end);
-  ar->start = dtb_start;
-  ar->end = dtb_end;
-}
-
 static size_t ar_get_reserved_mem(addr_range_t *ars) {
   fdt_mem_reg_t mrs[FDT_MAX_RSV_MEM_REGS];
   size_t cnt;
@@ -179,10 +172,9 @@ static void physmem_regions(void) {
   addr_range_t memory[MAX_PHYS_MEM_REGS];
   ar_get_kernel_img(&memory[0]);
   ar_get_initrd(&memory[1]);
-  ar_get_dtb(&memory[2]);
-  const size_t rsvmem_cnt = ar_get_reserved_mem(&memory[3]);
+  const size_t rsvmem_cnt = ar_get_reserved_mem(&memory[2]);
 
-  const size_t nranges = rsvmem_cnt + 3;
+  const size_t nranges = rsvmem_cnt + 2;
   qsort(memory, nranges, sizeof(addr_range_t), ar_cmp);
 
   addr_range_t *range = &memory[0];

--- a/sys/riscv/boot.c
+++ b/sys/riscv/boot.c
@@ -91,6 +91,10 @@ static alignas(STACK_ALIGN) uint8_t boot_stack[PAGESIZE];
 /* Without `volatile` Clang applies constant propagation optimization and
  * that ends up generating relocations in `.text` instead of `.data` section.
  * This is exactly what we're trying to avoid here! */
+__boot_data static volatile vaddr_t _kernel_start = (vaddr_t)__kernel_start;
+__boot_data static volatile vaddr_t _kernel_end = (vaddr_t)__kernel_end;
+__boot_data static volatile vaddr_t _boot = (vaddr_t)__boot;
+__boot_data static volatile vaddr_t _eboot = (vaddr_t)__eboot;
 __boot_data static volatile vaddr_t _text = (vaddr_t)__text;
 __boot_data static volatile vaddr_t _data = (vaddr_t)__data;
 __boot_data static volatile vaddr_t _bss = (vaddr_t)__bss;
@@ -168,6 +172,9 @@ __boot_text static pde_t *build_page_table(vaddr_t kernel_end) {
 }
 
 __boot_text __noreturn void riscv_init(paddr_t dtb) {
+  if (!(_eboot < _kernel_start || _kernel_end < _boot))
+    halt();
+
   boot_clear(PHYSADDR(_bss), PHYSADDR(_ebss));
   boot_sbrk_init(PHYSADDR(_ebss));
 

--- a/sys/riscv/boot.c
+++ b/sys/riscv/boot.c
@@ -165,7 +165,7 @@ __boot_text static pde_t *build_page_table(vaddr_t kernel_end) {
 #if KASAN
   size_t shadow_size =
     BOOT_KASAN_SANITIZED_SIZE(kernel_end) / KASAN_SHADOW_SCALE_SIZE;
-  paddr_t shadow_mem = (paddr_t)bootmem_alloc(shadow_size);
+  paddr_t shadow_mem = (paddr_t)boot_sbrk(shadow_size);
 
   early_kenter(pde, KASAN_SHADOW_START, shadow_size, shadow_mem, PTE_KERN);
 #endif /* !KASAN */


### PR DESCRIPTION
Main goal of this change is to unify how DTB is handled on AArch64 and RISCV architectures. In both cases DTB is moved to kernel `.bss` section, so it's kept together with other precious data that won't be freed during kernel lifetime. Thanks to that decision `fdt.c` could be cleaned up from workarounds.

Moreover this change moves common code for MD boot code into `gen/boot.c` and also fixes `__tp` inline assembly (should not indicate that "tp" register is modified, otherwise it could be restored).