### PR TITLE
[RISCV] Use sstatus register value from user context in ctx_switch

### DIFF
--- a/sys/riscv/switch.S
+++ b/sys/riscv/switch.S
@@ -119,6 +119,7 @@ ENTRY(ctx_switch)
 
 	/* Get UCTX pointer for `from` thread. */
 	PTR_L	t4, TD_UCTX(a0)
+	INT_L	t0, CTX_SR(t4)
 
 	/* Save the FPE context only if it's dirty. */
 	li	t2, SSTATUS_FS_MASK


### PR DESCRIPTION
In most cases a value of `sstatus` register as seen by user would be used to calculate if kernel should save FPU context.

When calling `ctx_switch` while returning from interrupt, in `t0` register there would be kernel context. That caused user `sstatus` register to be corrupted. Namely SPP was set to supervisor, so the kernel attempted to return to execute user code with kernel privileges. In turn that leaded to a completely non-intuitive looping while trying to handle `exec_page_fault`.