### PR TITLE
Bump up GH Actions to Clang 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@ WORKDIR /root
 
 RUN apt-get -q update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends -t bullseye-backports \
-      git make cpio curl universal-ctags cscope socat patch gperf quilt \
-      bmake byacc python3-pip clang clang-format llvm lld \
-      device-tree-compiler tmux libmpfr6 libfdt1 libpython3.9 \
-      libsdl2-2.0-0 libglib2.0-0 libpixman-1-0
+      git make cpio curl gnupg universal-ctags cscope socat patch gperf quilt \
+      bmake byacc python3-pip device-tree-compiler tmux libmpfr6 libfdt1 \
+      libpython3.9 libsdl2-2.0-0 libglib2.0-0 libpixman-1-0
+RUN apt-key adv --fetch-keys https://apt.llvm.org/llvm-snapshot.gpg.key
+RUN echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main" > \
+      /etc/apt/sources.list.d/llvm-14.list && apt-get update
+RUN apt-get install -y --no-install-recommends -t bullseye-backports \
+      clang-14 clang-format-14 llvm-14 lld-14
 # patch & quilt required by lua and programs in contrib/
 # gperf required by libterminfo
 # socat & tmux required by launch

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: sys-build initrd.cpio
 
 PHONY-TARGETS += setup test
 
-IMGVER = 1.9.1
+IMGVER = 1.10.0
 IMGNAME = cahirwpz/mimiker-ci
 
 docker-build:

--- a/build/arch.riscv.mk
+++ b/build/arch.riscv.mk
@@ -36,9 +36,6 @@ ifeq ($(BOARD), sifive_u)
     CPPFLAGS += -DFPU=1
     ASAN_SHADOW_OFFSET := 0xdfffffe000000000
   endif
-  ifeq ($(LLVM), 1)
-    CPPFLAGS += -D__riscv_d -D__riscv_f
-  endif
 endif
 
 ifeq ($(LLVM), 1)

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -6,6 +6,8 @@
 # The following make variables are set by the including makefile:
 # - TARGET, ABIFLAGS: Set by arch.*.mk files.
 
+LLVM_VER := -14
+
 ifndef ARCH
   $(error ARCH variable not defined. Have you included config.mk?)
 endif
@@ -13,29 +15,29 @@ endif
 # Pass "LLVM=1" at command line to switch to llvm toolchain.
 ifeq ($(LLVM), 1)
 
-ifneq ($(shell which clang > /dev/null; echo $$?), 0)
+ifneq ($(shell which clang$(LLVM_VER) > /dev/null; echo $$?), 0)
   $(error clang compiler not found - please refer to README.md!)
 endif
 
-ifneq ($(shell which lld > /dev/null; echo $$?), 0)
+ifneq ($(shell which ld.lld$(LLVM_VER) > /dev/null; echo $$?), 0)
   $(error lld linker not found)
 endif
 
-ifneq ($(shell which llvm-ar > /dev/null; echo $$?), 0)
+ifneq ($(shell which llvm-ar$(LLVM_VER) > /dev/null; echo $$?), 0)
   $(error llvm toolchain not found)
 endif
 
-CC	= clang -target $(TARGET) $(ABIFLAGS) -g
+CC	= clang$(LLVM_VER) -target $(TARGET) $(ABIFLAGS) -g
 CPP	= $(CC) -x c -E
 AS	= $(CC)
-LD	= ld.lld
-AR	= llvm-ar
-NM	= llvm-nm
-RANLIB	= llvm-ranlib
-READELF	= llvm-readelf
-OBJCOPY	= llvm-objcopy
-OBJDUMP	= llvm-objdump
-STRIP	= llvm-strip
+LD	= ld.lld$(LLVM_VER)
+AR	= llvm-ar$(LLVM_VER)
+NM	= llvm-nm$(LLVM_VER)
+RANLIB	= llvm-ranlib$(LLVM_VER)
+READELF	= llvm-readelf$(LLVM_VER)
+OBJCOPY	= llvm-objcopy$(LLVM_VER)
+OBJDUMP	= llvm-objdump$(LLVM_VER)
+STRIP	= llvm-strip$(LLVM_VER)
 
 # The genassym script produces C code with asm statements that have
 # garbage instructions, which Clang checks using its built-in assembler
@@ -65,7 +67,7 @@ CP      = cp
 CPIO    = cpio --format=crc
 CSCOPE  = cscope -b
 CTAGS   = ctags
-FORMAT  = clang-format -style=file 
+FORMAT  = clang-format$(LLVM_VER) -style=file 
 INSTALL = install -D
 LN	= ln
 RM      = rm -f

--- a/include/sys/mimiker.h
+++ b/include/sys/mimiker.h
@@ -54,7 +54,7 @@
     intptr_t _addr = (intptr_t)(addr);                                         \
     intptr_t _size = (intptr_t)(size);                                         \
     _addr = (_addr + (_size - 1)) & -_size;                                    \
-    (typeof(addr)) _addr;                                                      \
+    (typeof(addr))_addr;                                                       \
   })
 
 #define is_aligned(addr, size)                                                 \

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -33,6 +33,20 @@ static alignas(STACK_ALIGN) uint8_t _boot_stack[PAGESIZE];
 extern char exception_vectors[];
 extern char hypervisor_vectors[];
 
+/* Without `volatile` Clang applies constant propagation optimization and
+ * that ends up generating relocations in `.text` instead of `.data` section.
+ * This is exactly what we're trying to avoid here! */
+__boot_data static volatile paddr_t _boot = (paddr_t)__boot;
+__boot_data static volatile paddr_t _eboot = (paddr_t)__eboot;
+__boot_data static volatile vaddr_t _text = (vaddr_t)__text;
+__boot_data static volatile vaddr_t _etext = (vaddr_t)__etext;
+__boot_data static volatile vaddr_t _rodata = (vaddr_t)__rodata;
+__boot_data static volatile vaddr_t _data = (vaddr_t)__data;
+__boot_data static volatile vaddr_t _ebss = (vaddr_t)__ebss;
+__boot_data static volatile vaddr_t _evec = (vaddr_t)exception_vectors;
+__boot_data static volatile vaddr_t _hvec = (vaddr_t)hypervisor_vectors;
+__boot_data static volatile vaddr_t _pcpu = (vaddr_t)_pcpu_data;
+
 __boot_text static void halt(void) {
   for (;;)
     continue;
@@ -61,7 +75,7 @@ __boot_text static void configure_cpu(void) {
     halt();
 #endif
 
-  WRITE_SPECIALREG(tpidr_el1, _pcpu_data);
+  WRITE_SPECIALREG(tpidr_el1, _pcpu);
 }
 
 __boot_text static void drop_to_el1(void) {
@@ -109,7 +123,7 @@ el2_entry:
     WRITE_SPECIALREG(CNTVOFF_EL2, 0);
 
     /* Hypervisor trap functions. */
-    WRITE_SPECIALREG(VBAR_EL2, hypervisor_vectors);
+    WRITE_SPECIALREG(VBAR_EL2, _hvec);
 
     /* Prepare for jump into EL1. */
     WRITE_SPECIALREG(SP_EL1, __sp());
@@ -176,19 +190,18 @@ __boot_text static pde_t *build_page_table(void) {
     L3_PAGE | ATTR_AF | ATTR_SH_IS | ATTR_IDX(ATTR_NORMAL_MEM_WB);
 
   /* boot sections */
-  early_kenter(pde, VIRTADDR(__boot), VIRTADDR(__eboot), (paddr_t)__boot,
+  early_kenter(pde, VIRTADDR(_boot), VIRTADDR(_eboot), _boot,
                ATTR_AP_RW | pte_default);
 
   /* text section */
-  early_kenter(pde, (vaddr_t)__text, (vaddr_t)__etext, PHYSADDR(__text),
-               ATTR_AP_RO | pte_default);
+  early_kenter(pde, _text, _etext, PHYSADDR(_text), ATTR_AP_RO | pte_default);
 
   /* rodata section */
-  early_kenter(pde, (vaddr_t)__rodata, (vaddr_t)__data, PHYSADDR(__rodata),
+  early_kenter(pde, _rodata, _data, PHYSADDR(_rodata),
                ATTR_AP_RO | ATTR_XN | pte_default);
 
   /* data & bss sections */
-  early_kenter(pde, (vaddr_t)__data, (vaddr_t)__ebss, PHYSADDR(__data),
+  early_kenter(pde, _data, _ebss, PHYSADDR(_data),
                ATTR_AP_RW | ATTR_XN | pte_default);
 
   /* direct map construction */
@@ -196,7 +209,7 @@ __boot_text static pde_t *build_page_table(void) {
                ATTR_AP_RW | ATTR_XN | pte_default);
 
 #if KASAN /* Prepare KASAN shadow mappings */
-  size_t kasan_sanitized_size = BOOT_KASAN_SANITIZED_SIZE(__ebss);
+  size_t kasan_sanitized_size = BOOT_KASAN_SANITIZED_SIZE(_ebss);
   size_t kasan_shadow_size = kasan_sanitized_size / KASAN_SHADOW_SCALE_SIZE;
   /* Allocate physical memory for shadow area */
   paddr_t kasan_shadow_pa = (paddr_t)bootmem_alloc(kasan_shadow_size);
@@ -212,7 +225,7 @@ __boot_text static pde_t *build_page_table(void) {
 __boot_text static void enable_mmu(pde_t *pde) {
   __dsb("sy");
 
-  WRITE_SPECIALREG(VBAR_EL1, exception_vectors);
+  WRITE_SPECIALREG(VBAR_EL1, _evec);
   WRITE_SPECIALREG(TTBR0_EL1, pde);
   WRITE_SPECIALREG(TTBR1_EL1, pde);
   __isb();
@@ -278,7 +291,7 @@ __boot_text __noreturn void aarch64_init(paddr_t dtb) {
   configure_cpu();
 
   /* Set end address of kernel for boot allocation purposes. */
-  _bootmem_end = (void *)align(PHYSADDR(__ebss), PAGESIZE);
+  _bootmem_end = (void *)align(PHYSADDR(_ebss), PAGESIZE);
 
   pde_t *kernel_pde = build_page_table();
   enable_mmu(kernel_pde);

--- a/sys/kern/initrd.c
+++ b/sys/kern/initrd.c
@@ -367,7 +367,9 @@ size_t ramdisk_get_size(void) {
 void ramdisk_dump(void) {
   cpio_node_t *it;
 
-  TAILQ_FOREACH (it, &initrd_head, c_list) { cpio_node_dump(it); }
+  TAILQ_FOREACH (it, &initrd_head, c_list) {
+    cpio_node_dump(it);
+  }
 }
 
 static vfsops_t initrd_vfsops = {

--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -835,7 +835,9 @@ void proc_stop(signo_t sig) {
     proc_wakeup_parent(p->p_parent);
     sig_child(p, CLD_STOPPED);
   }
-  WITH_SPIN_LOCK (td->td_lock) { td->td_flags |= TDF_STOPPING; }
+  WITH_SPIN_LOCK (td->td_lock) {
+    td->td_flags |= TDF_STOPPING;
+  }
   proc_unlock(p);
   /* We're holding no locks here, so our process can be continued before we
    * actually stop the thread. This is why we need the TDF_STOPPING flag. */
@@ -864,5 +866,7 @@ void proc_continue(proc_t *p) {
   WITH_PROC_LOCK(p->p_parent) {
     proc_wakeup_parent(p->p_parent);
   }
-  WITH_SPIN_LOCK (td->td_lock) { thread_continue(td); }
+  WITH_SPIN_LOCK (td->td_lock) {
+    thread_continue(td);
+  }
 }

--- a/verify-format.sh
+++ b/verify-format.sh
@@ -3,7 +3,7 @@
 PAGER=cat
 
 # Use make format to cleanup the copied tree
-make format > /dev/null
+make format > /dev/null || exit 1
 
 # See if there are any changes compared to checked out sources.
 if ! git diff --check --exit-code >/dev/null; then


### PR DESCRIPTION
Let's use Clang provided by https://apt.llvm.org - we can update it on demand without waiting for release of new stable Debian distribution. There's another motivation... new linker supports `--wrap` (as GNU ld does) which is useful to clean up KASAN code.