### PR TITLE
Bump up QEmu version to 6.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: sys-build initrd.cpio
 
 PHONY-TARGETS += setup test
 
-IMGVER = 1.11.0
+IMGVER = 1.12.0
 IMGNAME = cahirwpz/mimiker-ci
 
 docker-build:

--- a/build/arch.aarch64.mk
+++ b/build/arch.aarch64.mk
@@ -31,6 +31,8 @@ else
   CFLAGS += -mcpu=cortex-a53 -march=armv8-a
 endif
 
+CFLAGS += -mstrict-align
+
 ifeq ($(BOARD), rpi3)
   KERNEL-IMAGES := mimiker.img mimiker.img.gz
 endif

--- a/launch
+++ b/launch
@@ -117,7 +117,7 @@ CONFIG = {
             'rpi3': {
                 'binary': 'qemu-mimiker-aarch64',
                 'options': [
-                    '-machine', 'raspi3',
+                    '-machine', 'raspi3b',
                     '-smp', '4',
                     '-cpu', 'cortex-a53'],
                 'network_options': [],

--- a/lib/libc/sys/aarch64/sc_error.S
+++ b/lib/libc/sys/aarch64/sc_error.S
@@ -4,9 +4,9 @@
 ENTRY(__sc_error)
         sub     sp, sp, #16
         stp     x19, lr, [sp]
-        mov     x19, x1
+        mov     w19, w1
         bl      __errno
-        str     x19, [x0]
+        str     w19, [x0]
         mov     x0, #-1
         ldp     x19, lr, [sp]
         add     sp, sp, #16

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -67,6 +67,9 @@ static abort_handler_t *abort_handlers[ISS_DATA_DFSC_MASK + 1] = {
   [ISS_DATA_DFSC_AFF_L1] = pmap_fault_handler,
   [ISS_DATA_DFSC_AFF_L2] = pmap_fault_handler,
   [ISS_DATA_DFSC_AFF_L3] = pmap_fault_handler,
+  [ISS_DATA_DFSC_PF_L1] = pmap_fault_handler,
+  [ISS_DATA_DFSC_PF_L2] = pmap_fault_handler,
+  [ISS_DATA_DFSC_PF_L3] = pmap_fault_handler,
   [ISS_DATA_DFSC_ALIGN] = unaligned_handler,
 };
 

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -95,7 +95,7 @@ void user_trap_handler(mcontext_t *uctx) {
       if (abort_handlers[dfsc]) {
         abort_handlers[dfsc](ctx, far, exc_access(exc_code, esr));
       } else {
-        panic("Unhandled EL0 %s abort (0x%x) at %p caused by reference to %p!" ,
+        panic("Unhandled EL0 %s abort (0x%x) at %p caused by reference to %p!",
               exc_code == EXCP_INSN_ABORT_L ? "instruction" : "data", dfsc,
               _REG(ctx, PC), far);
       }

--- a/sys/kern/klog.c
+++ b/sys/kern/klog.c
@@ -161,6 +161,7 @@ __noreturn void klog_panic(klog_origin_t origin, const char *file,
                            unsigned line, const char *format, uintptr_t arg1,
                            uintptr_t arg2, uintptr_t arg3, uintptr_t arg4,
                            uintptr_t arg5, uintptr_t arg6) {
+  klog.mask = -1;
   klog_append(origin, file, line, format, arg1, arg2, arg3, arg4, arg5, arg6);
   ktest_log_failure();
   halt();

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -526,8 +526,8 @@ void sig_post(ksiginfo_t *ksi) {
 }
 
 __noreturn void sig_exit(thread_t *td, signo_t sig) {
-  klog("PID(%d) terminated due to signal %s ", td->td_proc->p_pid,
-       sig_name[sig]);
+  klog("PID(%d) terminated due to signal %s at %p!", td->td_proc->p_pid,
+       sig_name[sig], ctx_get_pc((ctx_t *)td->td_uctx));
   proc_exit(MAKE_STATUS_SIG_TERM(sig));
 }
 

--- a/toolchain/qemu-mimiker/Makefile
+++ b/toolchain/qemu-mimiker/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-VER := 6.0.0
+VER := 6.2.0
 QEMU := qemu-$(VER)
 ARCHIVE := $(QEMU).tar.xz
 

--- a/toolchain/qemu-mimiker/debian/changelog
+++ b/toolchain/qemu-mimiker/debian/changelog
@@ -1,3 +1,9 @@
+qemu-mimiker (6.2.0+mimiker1) unstable; urgency=medium
+
+  * Bump up simulator version.
+
+ -- Krystian Bacławski <cahirwpz@cs.uni.wroc.pl>  Thu, 21 Jul 2022 08:07:44 +0200
+
 qemu-mimiker (6.0.0+mimiker2) unstable; urgency=medium
 
   * Add system simulator for 64-bit RISC-V.

--- a/toolchain/qemu-mimiker/patches/cmdline-set-dts-bootargs.patch
+++ b/toolchain/qemu-mimiker/patches/cmdline-set-dts-bootargs.patch
@@ -1,8 +1,8 @@
-Index: qemu-mimiker/qemu-6.0.0/hw/riscv/sifive_u.c
+Index: qemu-mimiker/qemu-6.2.0/hw/riscv/sifive_u.c
 ===================================================================
---- qemu-mimiker.orig/qemu-6.0.0/hw/riscv/sifive_u.c
-+++ qemu-mimiker/qemu-6.0.0/hw/riscv/sifive_u.c
-@@ -466,7 +466,7 @@ static void create_fdt(SiFiveUState *s,
+--- qemu-mimiker.orig/qemu-6.2.0/hw/riscv/sifive_u.c
++++ qemu-mimiker/qemu-6.2.0/hw/riscv/sifive_u.c
+@@ -510,7 +510,7 @@ static void create_fdt(SiFiveUState *s,
      g_free(nodename);
  
  update_bootargs:

--- a/toolchain/qemu-mimiker/patches/fix-virtual-clock-in-gdb.patch
+++ b/toolchain/qemu-mimiker/patches/fix-virtual-clock-in-gdb.patch
@@ -1,9 +1,9 @@
 Stop virtual clock as soon as debug exception is triggered.
-Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
+Index: qemu-mimiker/qemu-6.2.0/gdbstub.c
 ===================================================================
---- qemu-mimiker.orig/qemu-6.0.0/gdbstub.c
-+++ qemu-mimiker/qemu-6.0.0/gdbstub.c
-@@ -359,6 +359,7 @@ typedef struct GDBState {
+--- qemu-mimiker.orig/qemu-6.2.0/gdbstub.c
++++ qemu-mimiker/qemu-6.2.0/gdbstub.c
+@@ -358,6 +358,7 @@ typedef struct GDBState {
      char *socket_path;
      int running_state;
  #else
@@ -11,7 +11,7 @@ Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
      CharBackend chr;
      Chardev *mon_chr;
  #endif
-@@ -502,8 +503,6 @@ static int gdb_continue_partial(char *ne
+@@ -510,8 +511,6 @@ static int gdb_continue_partial(char *ne
      }
      gdbserver_state.running_state = 1;
  #else
@@ -20,7 +20,7 @@ Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
      if (!runstate_needs_reset()) {
          if (vm_prepare_start()) {
              return 0;
-@@ -518,12 +517,12 @@ static int gdb_continue_partial(char *ne
+@@ -526,12 +525,12 @@ static int gdb_continue_partial(char *ne
                  trace_gdbstub_op_stepping(cpu->cpu_index);
                  cpu_single_step(cpu, get_sstep_flags());
                  cpu_resume(cpu);
@@ -35,7 +35,7 @@ Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
                  break;
              default:
                  res = -1;
-@@ -531,9 +530,6 @@ static int gdb_continue_partial(char *ne
+@@ -539,9 +538,6 @@ static int gdb_continue_partial(char *ne
              }
          }
      }
@@ -45,7 +45,7 @@ Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
  #endif
      return res;
  }
-@@ -3074,6 +3070,9 @@ static void gdb_read_byte(uint8_t ch)
+@@ -3068,6 +3064,9 @@ static void gdb_read_byte(uint8_t ch)
              abort();
          }
      }
@@ -55,11 +55,11 @@ Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
  }
  
  /* Tell the remote gdb that the process has exited.  */
-Index: qemu-mimiker/qemu-6.0.0/target/mips/op_helper.c
+Index: qemu-mimiker/qemu-6.2.0/target/mips/tcg/exception.c
 ===================================================================
---- qemu-mimiker.orig/qemu-6.0.0/target/mips/op_helper.c
-+++ qemu-mimiker/qemu-6.0.0/target/mips/op_helper.c
-@@ -42,6 +42,7 @@ void helper_raise_exception(CPUMIPSState
+--- qemu-mimiker.orig/qemu-6.2.0/target/mips/tcg/exception.c
++++ qemu-mimiker/qemu-6.2.0/target/mips/tcg/exception.c
+@@ -55,6 +55,7 @@ void helper_raise_exception(CPUMIPSState
  
  void helper_raise_exception_debug(CPUMIPSState *env)
  {

--- a/toolchain/qemu-mimiker/patches/gdbstub-stop-on-sigxcpu.patch
+++ b/toolchain/qemu-mimiker/patches/gdbstub-stop-on-sigxcpu.patch
@@ -1,9 +1,9 @@
 Stop the VM upon receiving a SIGXCPU signal.
-Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
+Index: qemu-mimiker/qemu-6.2.0/gdbstub.c
 ===================================================================
---- qemu-mimiker.orig/qemu-6.0.0/gdbstub.c
-+++ qemu-mimiker/qemu-6.0.0/gdbstub.c
-@@ -3406,6 +3406,15 @@ static void gdb_sigterm_handler(int sign
+--- qemu-mimiker.orig/qemu-6.2.0/gdbstub.c
++++ qemu-mimiker/qemu-6.2.0/gdbstub.c
+@@ -3404,6 +3404,15 @@ static void gdb_sigterm_handler(int sign
          vm_stop(RUN_STATE_PAUSED);
      }
  }
@@ -19,7 +19,7 @@ Index: qemu-mimiker/qemu-6.0.0/gdbstub.c
  #endif
  
  static void gdb_monitor_open(Chardev *chr, ChardevBackend *backend,
-@@ -3515,6 +3524,11 @@ int gdbserver_start(const char *device)
+@@ -3513,6 +3522,11 @@ int gdbserver_start(const char *device)
              act.sa_handler = gdb_sigterm_handler;
              sigaction(SIGINT, &act, NULL);
          }

--- a/toolchain/qemu-mimiker/patches/page-table-walk-for-gdb.patch
+++ b/toolchain/qemu-mimiker/patches/page-table-walk-for-gdb.patch
@@ -1,11 +1,11 @@
 Allow GDB to perform address translation without modyfing TLB.
-Index: qemu-mimiker/qemu-6.0.0/target/mips/tlb_helper.c
+Index: qemu-mimiker/qemu-6.2.0/target/mips/sysemu/physaddr.c
 ===================================================================
---- qemu-mimiker.orig/qemu-6.0.0/target/mips/tlb_helper.c
-+++ qemu-mimiker/qemu-6.0.0/target/mips/tlb_helper.c
-@@ -486,15 +486,46 @@ static void raise_mmu_exception(CPUMIPSS
- 
- #if !defined(CONFIG_USER_ONLY)
+--- qemu-mimiker.orig/qemu-6.2.0/target/mips/sysemu/physaddr.c
++++ qemu-mimiker/qemu-6.2.0/target/mips/sysemu/physaddr.c
+@@ -242,15 +242,46 @@ int get_physical_address(CPUMIPSState *e
+     return ret;
+ }
  
 +#define PDE_VADDR(addr) \
 +    ((((addr) <= USEG_LIMIT) ? 0xffffe000 : 0xfffff000) + PD_INDEX(addr))


### PR DESCRIPTION
This needed a bunch of fixes for AArch64 namely due to new version of QEmu being more strict on unaligned accesses.