### PR TITLE
[mem] Add a procedure to obtain the size of a pointed vmem segment.

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -14,6 +14,7 @@ void init_kmem(void);
 
 void *kmem_alloc(size_t size, kmem_flags_t flags) __warn_unused;
 void kmem_free(void *ptr, size_t size);
+size_t kmem_size(void *ptr);
 
 /* Allocates contiguous physical memory of `size` bytes aligned to at least
  * `PAGESIZE` boundary. First physical address of the region will be stored

--- a/include/sys/vmem.h
+++ b/include/sys/vmem.h
@@ -21,6 +21,9 @@ void init_vmem(void);
  * You need to specify quantum, the smallest unit of allocation. */
 vmem_t *vmem_create(const char *name, vmem_size_t quantum);
 
+/*! \brief Obtain the size of the segment starting at `addr`. */
+vmem_size_t vmem_size(vmem_t *vm, vmem_addr_t addr);
+
 /*! \brief Add a new address span to the arena. */
 int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size);
 

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -152,6 +152,10 @@ void kmem_free(void *ptr, size_t size) {
   vmem_free(kvspace, (vmem_addr_t)ptr, size);
 }
 
+size_t kmem_size(void *ptr) {
+  return (size_t)vmem_size(kvspace, (vmem_addr_t)ptr);
+}
+
 vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) {
   assert(page_aligned_p(pa) && page_aligned_p(size));
 

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -231,6 +231,12 @@ vmem_t *vmem_create(const char *name, vmem_size_t quantum) {
   return vm;
 }
 
+vmem_size_t vmem_size(vmem_t *vm, vmem_addr_t addr) {
+  SCOPED_MTX_LOCK(&vm->vm_lock);
+  bt_t *bt = bt_lookupbusy(vm, addr);
+  return bt->bt_size;
+}
+
 int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size) {
   bt_t *btspan = pool_alloc(P_BT, M_ZERO);
   bt_t *btfree = pool_alloc(P_BT, M_ZERO);


### PR DESCRIPTION
The new implementation of the general purpose kernel memory allocator (#1323) needs a way to fetch the size of a selected vmem segment.