### PR TITLE
[mem] Remove the size argument from vmem_free.

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -38,7 +38,7 @@ vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) __warn_unused;
 /* Allocates a range of kernel virtual address space of `size` pages (in bytes)
  * and returns virtual address. kva_alloc never fails. */
 vaddr_t kva_alloc(size_t size);
-void kva_free(vaddr_t va, size_t size);
+void kva_free(vaddr_t va);
 vm_page_t *kva_find_page(vaddr_t ptr);
 
 /*

--- a/include/sys/vmem.h
+++ b/include/sys/vmem.h
@@ -29,7 +29,7 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp,
                kmem_flags_t flags);
 
 /*! \brief Free segment previously allocated by vmem_alloc(). */
-void vmem_free(vmem_t *vm, vmem_addr_t addr, vmem_size_t size);
+void vmem_free(vmem_t *vm, vmem_addr_t addr);
 
 /*! \brief Destroy existing vmem arena. */
 void vmem_destroy(vmem_t *vm);

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -61,9 +61,9 @@ vaddr_t kva_alloc(size_t size) {
   return start;
 }
 
-void kva_free(vaddr_t ptr, size_t size) {
-  assert(page_aligned_p(ptr) && page_aligned_p(size));
-  vmem_free(kvspace, ptr, size);
+void kva_free(vaddr_t ptr) {
+  assert(page_aligned_p(ptr));
+  vmem_free(kvspace, ptr);
 }
 
 static void kva_map_page(vaddr_t va, paddr_t pa, size_t n, unsigned flags) {
@@ -149,7 +149,7 @@ vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, unsigned flags) {
 void kmem_free(void *ptr, size_t size) {
   klog("%s: free %p of size %ld", __func__, ptr, size);
   kva_unmap((vaddr_t)ptr, size);
-  vmem_free(kvspace, (vmem_addr_t)ptr, size);
+  vmem_free(kvspace, (vmem_addr_t)ptr);
 }
 
 vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) {

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -317,16 +317,18 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp,
   return 0;
 }
 
-void vmem_free(vmem_t *vm, vmem_addr_t addr, vmem_size_t size) {
+void vmem_free(vmem_t *vm, vmem_addr_t addr) {
   bt_t *prev = NULL;
   bt_t *next = NULL;
+  vmem_size_t size;
 
   WITH_MTX_LOCK (&vm->vm_lock) {
     vmem_check_sanity(vm);
 
     bt_t *bt = bt_lookupbusy(vm, addr);
     assert(bt != NULL);
-    assert(bt->bt_size == align(size, vm->vm_quantum));
+
+    size = bt->bt_size;
 
     bt_rembusy(vm, bt);
     bt->bt_type = BT_TYPE_FREE;

--- a/sys/tests/pmap.c
+++ b/sys/tests/pmap.c
@@ -61,7 +61,7 @@ static int test_pmap_kenter(void) {
   assert(!done);
 
   pmap_kremove(va, PAGESIZE);
-  kva_free(va, PAGESIZE);
+  kva_free(va);
   vm_page_free(pg);
 
   return KTEST_SUCCESS;
@@ -77,7 +77,7 @@ static int test_pmap_kextract(void) {
   assert(ok && pa == pg->paddr);
 
   pmap_kremove(va, PAGESIZE);
-  kva_free(va, PAGESIZE);
+  kva_free(va);
   vm_page_free(pg);
 
   return KTEST_SUCCESS;
@@ -112,7 +112,7 @@ static int test_pmap_page_copy(void) {
   }
 
   pmap_kremove(va, PAGESIZE);
-  kva_free(va, PAGESIZE);
+  kva_free(va);
   vm_page_free(pg1);
   vm_page_free(pg2);
 

--- a/sys/tests/vmem.c
+++ b/sys/tests/vmem.c
@@ -59,7 +59,7 @@ static int test_vmem(void) {
   assert(rc == ENOMEM);
 
   /* free 17 quantums */
-  vmem_free(vm, addr17, 17 * quantum);
+  vmem_free(vm, addr17);
 
   /* alloc 10 quantums, should return addr from span #2 */
   size = 10 * quantum;
@@ -68,9 +68,9 @@ static int test_vmem(void) {
   assert_addr_is_in_span(addr10, size, &span2);
 
   /* free all segments */
-  vmem_free(vm, addr1, 1 * quantum);
-  vmem_free(vm, addr8, 8 * quantum);
-  vmem_free(vm, addr10, 10 * quantum);
+  vmem_free(vm, addr1);
+  vmem_free(vm, addr8);
+  vmem_free(vm, addr10);
 
   vmem_destroy(vm);
 


### PR DESCRIPTION
It turns out that our current implementation of `vmem_free` assumes that only entire segments will be freed. This assumption makes the `size` argument useless as the size is contained in the corresponding boundary tag.