### PR TITLE
[vmem] Boundary tag allocator.

### DIFF
--- a/include/sys/kmem.h
+++ b/include/sys/kmem.h
@@ -38,7 +38,7 @@ vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) __warn_unused;
 
 /* Allocates a range of kernel virtual address space of `size` pages (in bytes)
  * and returns virtual address. kva_alloc never fails. */
-vaddr_t kva_alloc(size_t size);
+vaddr_t kva_alloc(size_t size, kmem_flags_t flags);
 void kva_free(vaddr_t va);
 vm_page_t *kva_find_page(vaddr_t ptr);
 

--- a/include/sys/kmem_flags.h
+++ b/include/sys/kmem_flags.h
@@ -6,7 +6,6 @@ typedef enum {
   M_WAITOK = 0x00000000, /* always returns memory block, but can sleep */
   M_NOWAIT = 0x00000001, /* may return NULL, but cannot sleep */
   M_ZERO = 0x00000002,   /* clear allocated block */
-  M_NOGROW = 0x00000004, /* don't grow mempool on alloc request, but fail */
 } kmem_flags_t;
 
 #endif /* !_SYS_KMEM_FLAGS_H_ */

--- a/include/sys/pmap.h
+++ b/include/sys/pmap.h
@@ -26,7 +26,7 @@ typedef struct pmap pmap_t;
 /* Machine-dependent flags */
 #define _PMAP_KERNEL (1 << 24)
 
-__long_call void pmap_bootstrap(paddr_t pd_pa, void *pd);
+__long_call void pmap_bootstrap(vaddr_t vma_end, paddr_t pd_pa, void *pd);
 void init_pmap(void);
 
 vaddr_t pmap_start(pmap_t *pmap);
@@ -76,7 +76,15 @@ pmap_t *pmap_user(void);
  */
 int pmap_fault_handler(ctx_t *ctx, vaddr_t vaddr, vm_prot_t access);
 
-void pmap_growkernel(vaddr_t maxvaddr);
+/*
+ * Increase maximum kernel virtual addresses by at least `size` bytes.
+ * Allocate page tables if needed.
+ *
+ * Returns:
+ *  - current maximum KVA if `size` == 0
+ *  - new maximum KVA otherwise
+ */
+vaddr_t pmap_growkernel(size_t size);
 
 /*
  * Direct map.

--- a/include/sys/pmap.h
+++ b/include/sys/pmap.h
@@ -76,7 +76,8 @@ pmap_t *pmap_user(void);
  */
 int pmap_fault_handler(ctx_t *ctx, vaddr_t vaddr, vm_prot_t access);
 
-void pmap_growkernel(vaddr_t maxkvaddr);
+vaddr_t pmap_roundup_growkernel_stride(vaddr_t addr);
+void pmap_growkernel(vaddr_t addr);
 
 /*
  * Direct map.

--- a/include/sys/pmap.h
+++ b/include/sys/pmap.h
@@ -76,7 +76,7 @@ pmap_t *pmap_user(void);
  */
 int pmap_fault_handler(ctx_t *ctx, vaddr_t vaddr, vm_prot_t access);
 
-void pmap_growkernel(vaddr_t addr);
+void pmap_growkernel(vaddr_t maxvaddr);
 
 /*
  * Direct map.

--- a/include/sys/pmap.h
+++ b/include/sys/pmap.h
@@ -76,7 +76,6 @@ pmap_t *pmap_user(void);
  */
 int pmap_fault_handler(ctx_t *ctx, vaddr_t vaddr, vm_prot_t access);
 
-vaddr_t pmap_roundup_growkernel_stride(vaddr_t addr);
 void pmap_growkernel(vaddr_t addr);
 
 /*

--- a/include/sys/vm.h
+++ b/include/sys/vm.h
@@ -11,10 +11,6 @@ typedef struct mtx mtx_t;
 
 #define page_aligned_p(addr) is_aligned((addr), PAGESIZE)
 
-/* Real kernel end in kernel virtual address space. */
-extern atomic_vaddr_t vm_kernel_end;
-extern mtx_t vm_kernel_end_lock;
-
 typedef enum {
   PG_ALLOCATED = 0x01,  /* page has been allocated */
   PG_MANAGED = 0x02,    /* a page is on a freeq */

--- a/include/sys/vmem.h
+++ b/include/sys/vmem.h
@@ -25,7 +25,8 @@ vmem_t *vmem_create(const char *name, vmem_size_t quantum);
 vmem_size_t vmem_size(vmem_t *vm, vmem_addr_t addr);
 
 /*! \brief Add a new address span to the arena. */
-int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size);
+int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size,
+             kmem_flags_t flags);
 
 /*! \brief Allocate an address segment from the arena. */
 int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp,

--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -308,7 +308,6 @@ extern void *board_stack(void);
 
 static __noreturn void aarch64_boot(void *dtb, paddr_t pde, paddr_t sbrk_end,
                                     vaddr_t vma_end) {
-  vm_kernel_end = vma_end;
   boot_sbrk_end = sbrk_end;
 
 #if KASAN
@@ -320,7 +319,7 @@ static __noreturn void aarch64_boot(void *dtb, paddr_t pde, paddr_t sbrk_end,
 
   void *sp = board_stack();
 
-  pmap_bootstrap(pde, (pde_t *)(pde + DMAP_BASE));
+  pmap_bootstrap(vma_end, pde, (pde_t *)(pde + DMAP_BASE));
 
   /*
    * Switch to thread0's stack and perform `board_init`.

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -24,7 +24,7 @@ paddr_t dmap_paddr_base;
 paddr_t dmap_paddr_end;
 
 /* Real kernel end in kernel virtual address space. */
-static atomic_vaddr_t vm_kernel_end = (vaddr_t)__kernel_end;
+static atomic_vaddr_t vm_kernel_end;
 static MTX_DEFINE(vm_kernel_end_lock, 0);
 
 static pmap_t kernel_pmap;

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -501,6 +501,7 @@ __long_call void pmap_bootstrap(paddr_t pd_pa, void *pd) {
 
 void init_pmap(void) {
   pmap_setup(&kernel_pmap);
+  mtx_init(&kernel_pmap.mtx, 0);
 }
 
 pmap_t *pmap_new(void) {

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -504,7 +504,6 @@ __long_call void pmap_bootstrap(paddr_t pd_pa, void *pd) {
 
 void init_pmap(void) {
   pmap_setup(&kernel_pmap);
-  mtx_init(&kernel_pmap.mtx, 0);
 }
 
 pmap_t *pmap_new(void) {

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -23,6 +23,10 @@ static POOL_DEFINE(P_PV, "pv_entry", sizeof(pv_entry_t));
 paddr_t dmap_paddr_base;
 paddr_t dmap_paddr_end;
 
+/* Real kernel end in kernel virtual address space. */
+static atomic_vaddr_t vm_kernel_end = (vaddr_t)__kernel_end;
+static MTX_DEFINE(vm_kernel_end_lock, 0);
+
 static pmap_t kernel_pmap;
 
 /* Bitmap of used ASIDs. */
@@ -497,7 +501,8 @@ static void pmap_setup(pmap_t *pmap) {
   pmap_md_setup(pmap);
 }
 
-__long_call void pmap_bootstrap(paddr_t pd_pa, void *pd) {
+__long_call void pmap_bootstrap(vaddr_t vma_end, paddr_t pd_pa, void *pd) {
+  vm_kernel_end = align(vma_end, PAGESIZE);
   kernel_pmap.pde = pd_pa;
   pmap_md_bootstrap(pd);
 }
@@ -553,16 +558,15 @@ void pmap_delete(pmap_t *pmap) {
   pool_free(P_PMAP, pmap);
 }
 
-/*
- * Increase usable kernel virtual address space to at least `maxkvaddr`.
- * Allocate page tables if needed.
- */
-void pmap_growkernel(vaddr_t maxkvaddr) {
-  assert(mtx_owned(&vm_kernel_end_lock));
-  assert(maxkvaddr > vm_kernel_end);
-
-  maxkvaddr = roundup2(maxkvaddr, GROWKERNEL_STRIDE);
+vaddr_t pmap_growkernel(size_t size) {
   pmap_t *pmap = pmap_kernel();
+
+  SCOPED_MTX_LOCK(&vm_kernel_end_lock);
+
+  if (size == 0)
+    return vm_kernel_end;
+
+  vaddr_t maxkvaddr = roundup2(vm_kernel_end + size, GROWKERNEL_STRIDE);
 
   WITH_MTX_LOCK (&pmap->mtx) {
     for (vaddr_t va = vm_kernel_end; va < maxkvaddr; va += GROWKERNEL_STRIDE)
@@ -579,4 +583,6 @@ void pmap_growkernel(vaddr_t maxkvaddr) {
   pmap_md_growkernel(maxkvaddr);
 
   vm_kernel_end = maxkvaddr;
+
+  return vm_kernel_end;
 }

--- a/sys/kern/kasan.c
+++ b/sys/kern/kasan.c
@@ -247,8 +247,8 @@ static void call_ctors(void) {
   }
 }
 
+/* Should only be called from `pmap_growkernel`! */
 void kasan_grow(vaddr_t maxkvaddr) {
-  assert(mtx_owned(&vm_kernel_end_lock));
   maxkvaddr = roundup2(maxkvaddr, PAGESIZE * KASAN_SHADOW_SCALE_SIZE);
   assert(maxkvaddr < KASAN_MAX_SANITIZED_END);
   vaddr_t va = (vaddr_t)addr_to_shad(_kasan_sanitized_end);

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -17,17 +17,17 @@ void init_kmem(void) {
   kvspace = vmem_create("kvspace", PAGESIZE);
   if (KERNEL_SPACE_BEGIN < (vaddr_t)__kernel_start)
     vmem_add(kvspace, KERNEL_SPACE_BEGIN,
-             (vaddr_t)__kernel_start - KERNEL_SPACE_BEGIN);
+             (vaddr_t)__kernel_start - KERNEL_SPACE_BEGIN, M_NOWAIT);
 }
 
 static void kick_swapper(void) {
   panic("Cannot allocate more kernel memory: swapper not implemented!");
 }
 
-vaddr_t kva_alloc(size_t size) {
+vaddr_t kva_alloc(size_t size, kmem_flags_t flags) {
   assert(page_aligned_p(size));
-  vmem_addr_t start;
   vaddr_t old = atomic_load(&vm_kernel_end);
+  vmem_addr_t start = 0;
 
   /*
    * Let's assume that vmem_alloc failed.
@@ -38,8 +38,9 @@ vaddr_t kva_alloc(size_t size) {
    * vmem_alloc fails so we need to repeat pmap_growkernel and restart
    * vmem_alloc. We do that until success because kva_alloc should never failed.
    */
-  while (vmem_alloc(kvspace, size, &start, M_NOGROW)) {
+  while (vmem_alloc(kvspace, size, &start, flags)) {
     mtx_lock(&vm_kernel_end_lock);
+
     /* Check if other thread called pmap_growkernel between vmem_alloc and
      * mtx_lock. */
     if (vm_kernel_end > old) {
@@ -48,12 +49,15 @@ vaddr_t kva_alloc(size_t size) {
       continue;
     }
 
-    pmap_growkernel(old + size);
-    klog("%s: increase kernel end %08lx -> %08lx", __func__, old,
-         vm_kernel_end);
+    vaddr_t new = pmap_roundup_growkernel_stride(old + size);
+    if (vmem_add(kvspace, old, new - old, M_NOWAIT)) {
+      mtx_unlock(&vm_kernel_end_lock);
+      continue;
+    }
 
-    int error = vmem_add(kvspace, old, vm_kernel_end - old);
-    assert(error == 0);
+    pmap_growkernel(new);
+
+    klog("%s: increase kernel end %08lx -> %08lx", __func__, old, new);
     mtx_unlock(&vm_kernel_end_lock);
   }
 
@@ -124,15 +128,14 @@ void kva_unmap(vaddr_t ptr, size_t size) {
 
 void *kmem_alloc(size_t size, kmem_flags_t flags) {
   assert(page_aligned_p(size));
-  assert(!(flags & M_NOGROW));
 
-  vaddr_t va = kva_alloc(size);
+  vaddr_t va = kva_alloc(size, flags);
   kva_map(va, size, flags);
 
   return (void *)va;
 }
 
-vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, unsigned flags) {
+vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, kmem_flags_t flags) {
   assert(page_aligned_p(size) && powerof2(size));
 
   size_t n = size / PAGESIZE;
@@ -156,10 +159,10 @@ size_t kmem_size(void *ptr) {
   return (size_t)vmem_size(kvspace, (vmem_addr_t)ptr);
 }
 
-vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) {
+vaddr_t kmem_map_contig(paddr_t pa, size_t size, kmem_flags_t flags) {
   assert(page_aligned_p(pa) && page_aligned_p(size));
 
-  vaddr_t va = kva_alloc(size);
+  vaddr_t va = kva_alloc(size, flags);
 
   /* Mark the entire block as valid */
   kasan_mark_valid((void *)va, size);

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -1,4 +1,5 @@
 #define KL_LOG KL_KMEM
+#include <sys/errno.h>
 #include <sys/klog.h>
 #include <sys/mimiker.h>
 #include <sys/libkern.h>
@@ -12,12 +13,15 @@
 #include <sys/mutex.h>
 
 static vmem_t *kvspace; /* Kernel virtual address space allocator. */
+static vmem_addr_t kvspace_end;
+static MTX_DEFINE(kvspace_end_lock, 0);
 
 void init_kmem(void) {
   kvspace = vmem_create("kvspace", PAGESIZE);
   if (KERNEL_SPACE_BEGIN < (vaddr_t)__kernel_start)
     vmem_add(kvspace, KERNEL_SPACE_BEGIN,
              (vaddr_t)__kernel_start - KERNEL_SPACE_BEGIN, M_NOWAIT);
+  kvspace_end = vm_kernel_end;
 }
 
 static void kick_swapper(void) {
@@ -28,6 +32,7 @@ vaddr_t kva_alloc(size_t size, kmem_flags_t flags) {
   assert(page_aligned_p(size));
   vaddr_t old = atomic_load(&vm_kernel_end);
   vmem_addr_t start = 0;
+  int error;
 
   /*
    * Let's assume that vmem_alloc failed.
@@ -38,7 +43,11 @@ vaddr_t kva_alloc(size_t size, kmem_flags_t flags) {
    * vmem_alloc fails so we need to repeat pmap_growkernel and restart
    * vmem_alloc. We do that until success because kva_alloc should never failed.
    */
-  while (vmem_alloc(kvspace, size, &start, flags)) {
+  while ((error = vmem_alloc(kvspace, size, &start, flags))) {
+    if (error == EAGAIN)
+      continue;
+    assert(error == ENOMEM);
+
     mtx_lock(&vm_kernel_end_lock);
 
     /* Check if other thread called pmap_growkernel between vmem_alloc and
@@ -49,15 +58,27 @@ vaddr_t kva_alloc(size_t size, kmem_flags_t flags) {
       continue;
     }
 
-    vaddr_t new = pmap_roundup_growkernel_stride(old + size);
-    if (vmem_add(kvspace, old, new - old, M_NOWAIT)) {
-      mtx_unlock(&vm_kernel_end_lock);
-      continue;
+    WITH_MTX_LOCK (&kvspace_end_lock) {
+      if (kvspace_end < vm_kernel_end) {
+        if (!vmem_add(kvspace, vm_kernel_end, vm_kernel_end - kvspace_end,
+                      M_NOWAIT)) {
+          kvspace_end = vm_kernel_end;
+        }
+        mtx_unlock(&kvspace_end_lock);
+        mtx_unlock(&vm_kernel_end_lock);
+        continue;
+      }
     }
 
-    pmap_growkernel(new);
+    pmap_growkernel(old + size);
+    klog("%s: increase kernel end %08lx -> %08lx", __func__, old,
+         vm_kernel_end);
 
-    klog("%s: increase kernel end %08lx -> %08lx", __func__, old, new);
+    if (!vmem_add(kvspace, old, vm_kernel_end - old, M_NOWAIT)) {
+      WITH_MTX_LOCK (&kvspace_end_lock)
+        kvspace_end = vm_kernel_end;
+    }
+
     mtx_unlock(&vm_kernel_end_lock);
   }
 
@@ -135,7 +156,7 @@ void *kmem_alloc(size_t size, kmem_flags_t flags) {
   return (void *)va;
 }
 
-vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, kmem_flags_t flags) {
+vaddr_t kmem_alloc_contig(paddr_t *pap, size_t size, unsigned flags) {
   assert(page_aligned_p(size) && powerof2(size));
 
   size_t n = size / PAGESIZE;
@@ -159,10 +180,10 @@ size_t kmem_size(void *ptr) {
   return (size_t)vmem_size(kvspace, (vmem_addr_t)ptr);
 }
 
-vaddr_t kmem_map_contig(paddr_t pa, size_t size, kmem_flags_t flags) {
+vaddr_t kmem_map_contig(paddr_t pa, size_t size, unsigned flags) {
   assert(page_aligned_p(pa) && page_aligned_p(size));
 
-  vaddr_t va = kva_alloc(size, flags);
+  vaddr_t va = kva_alloc(size, M_WAITOK);
 
   /* Mark the entire block as valid */
   kasan_mark_valid((void *)va, size);

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -40,12 +40,11 @@ vaddr_t kva_alloc(size_t size, kmem_flags_t flags) {
    * vmem_alloc where other thread can call kva_alloc and steal memory prepared
    * by us for vmem. In that scenario it's possible that second call to
    * vmem_alloc fails so we need to repeat pmap_growkernel and restart
-   * vmem_alloc. We do that until success because kva_alloc should never failed.
+   * vmem_alloc. We do that until success because kva_alloc should never fail.
    */
   while ((error = vmem_alloc(kvspace, size, &start, flags))) {
-    if (error == EAGAIN)
+    if (error != ENOMEM)
       continue;
-    assert(error == ENOMEM);
 
     WITH_MTX_LOCK (&max_kva_lock) {
       vmem_addr_t max_kva_prev = pmap_growkernel(0);

--- a/sys/kern/tmpfs.c
+++ b/sys/kern/tmpfs.c
@@ -158,7 +158,7 @@ static void ensure_vaddr_mapped(vaddr_t va) {
 /* tmpfs memory allocation routines */
 
 static mem_arena_t *tmpfs_add_mem_arena(tmpfs_mount_t *tfm) {
-  mem_arena_t *arena = (mem_arena_t *)kva_alloc(ARENA_SIZE);
+  mem_arena_t *arena = (mem_arena_t *)kva_alloc(ARENA_SIZE, M_WAITOK);
   if (arena == NULL)
     return NULL;
 

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -126,6 +126,9 @@ static bt_t *bt_alloc(kmem_flags_t flags) {
       break;
     }
 
+    /* If the calling thread cannot sleep, we return `NULL` and the calling
+     * function can choose to return an error or loop waiting for the refiller
+     * to provide more boundary tags. */
     if (flags & M_NOWAIT)
       return NULL;
 

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -1,14 +1,16 @@
 #define KL_LOG KL_VMEM
+#include <sys/condvar.h>
 #include <sys/klog.h>
+#include <sys/kmem.h>
 #include <sys/vmem.h>
 #include <sys/queue.h>
-#include <sys/pool.h>
 #include <sys/malloc.h>
 #include <sys/mimiker.h>
 #include <sys/libkern.h>
 #include <sys/errno.h>
 #include <sys/hash.h>
 #include <sys/mutex.h>
+#include <sys/thread.h>
 #include <machine/vm_param.h>
 
 #define VMEM_DEBUG 0
@@ -60,9 +62,13 @@ typedef enum {
  *
  * Field markings and the corresponding locks:
  *  (a) vm_lock
+ *  (@) bt_lock
  */
 typedef struct bt {
-  TAILQ_ENTRY(bt) bt_seglink; /* (a) link for vm_seglist */
+  union {
+    LIST_ENTRY(bt) bt_alloclink; /* (@) link on bt_alloclist */
+    TAILQ_ENTRY(bt) bt_seglink;  /* (a) link for vm_seglist */
+  };
   union {
     /* (a) link for vm_freelist[] (array index based on bt_size) */
     LIST_ENTRY(bt) bt_freelink;
@@ -75,16 +81,83 @@ typedef struct bt {
 } bt_t;
 
 static KMALLOC_DEFINE(M_VMEM, "vmem");
-static POOL_DEFINE(P_BT, "vmem boundary tag", sizeof(bt_t));
-/* Note: in the future, the amount of static memory for boundary tags should
- * be reduced by more clever tag allocation technique that always keeps some
- * number of free tags. For more information, please see bt_alloc and bt_refill
- * methods in NetBSD's vmem and M_NOGROW flag in Mimiker. */
-#define PT_BT_BOOTPAGE_SIZE ((sizeof(void *) / sizeof(int)) * PAGESIZE)
-static alignas(PT_BT_BOOTPAGE_SIZE) uint8_t P_BT_BOOTPAGE[PT_BT_BOOTPAGE_SIZE];
+
+#define BT_PAGESIZE ((sizeof(void *) / sizeof(int)) * PAGESIZE)
+#define BT_PAGECAPACITY (BT_PAGESIZE / sizeof(bt_t))
+#define BT_RESERVE_THRESHOLD 3
+
+static MTX_DEFINE(bt_lock, 0);
+static LIST_HEAD(, bt) bt_alloclist = LIST_HEAD_INITIALIZER(bt_alloclist);
+static size_t bt_freecnt;
+static thread_t *bt_refiller;
+static condvar_t bt_cv;
+
+static alignas(BT_PAGESIZE) uint8_t bt_bootpage[BT_PAGESIZE];
+
+static void bt_add_page(void *page) {
+  bt_t *bt = page;
+  for (size_t i = 0; i < BT_PAGECAPACITY; i++, bt++)
+    LIST_INSERT_HEAD(&bt_alloclist, bt, bt_alloclink);
+  bt_freecnt += BT_PAGECAPACITY;
+}
 
 void init_vmem(void) {
-  pool_add_page(P_BT, P_BT_BOOTPAGE, sizeof(P_BT_BOOTPAGE));
+  cv_init(&bt_cv, 0);
+  bt_add_page(bt_bootpage);
+}
+
+static void bt_refill(void) {
+  thread_t *td = thread_self();
+  assert(td == bt_refiller);
+
+  void *page = kmem_alloc(BT_PAGESIZE, M_NOWAIT | M_ZERO);
+  assert(page);
+
+  WITH_MTX_LOCK (&bt_lock) {
+    bt_add_page(page);
+    bt_refiller = NULL;
+    cv_broadcast(&bt_cv);
+  }
+}
+
+static bt_t *bt_alloc(kmem_flags_t flags) {
+  thread_t *td = thread_self();
+
+  mtx_lock(&bt_lock);
+
+  for (;;) {
+    if (bt_freecnt > BT_RESERVE_THRESHOLD)
+      break;
+
+    if (!bt_refiller) {
+      bt_refiller = td;
+      mtx_unlock(&bt_lock);
+      bt_refill();
+      mtx_lock(&bt_lock);
+      continue;
+    }
+
+    if (bt_refiller == td)
+      break;
+
+    if (flags & M_NOWAIT)
+      return NULL;
+
+    cv_wait(&bt_cv, &bt_lock);
+  }
+
+  bt_t *bt = LIST_FIRST(&bt_alloclist);
+  assert(bt);
+  LIST_REMOVE(bt, bt_alloclink);
+  bt_freecnt--;
+  mtx_unlock(&bt_lock);
+  return bt;
+}
+
+static void bt_free(bt_t *bt) {
+  SCOPED_MTX_LOCK(&bt_lock);
+  LIST_INSERT_HEAD(&bt_alloclist, bt, bt_alloclink);
+  bt_freecnt++;
 }
 
 static vmem_freelist_t *bt_freehead(vmem_t *vm, vmem_size_t size) {
@@ -237,9 +310,18 @@ vmem_size_t vmem_size(vmem_t *vm, vmem_addr_t addr) {
   return bt->bt_size;
 }
 
-int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size) {
-  bt_t *btspan = pool_alloc(P_BT, M_ZERO);
-  bt_t *btfree = pool_alloc(P_BT, M_ZERO);
+int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size,
+             kmem_flags_t flags) {
+  bt_t *btspan = bt_alloc(flags);
+  if (!btspan)
+    return EAGAIN;
+
+  bt_t *btfree = bt_alloc(flags);
+  if (!btfree) {
+    if (btspan)
+      bt_free(btspan);
+    return EAGAIN;
+  }
 
   btspan->bt_type = BT_TYPE_SPAN;
   btspan->bt_start = addr;
@@ -271,8 +353,8 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp,
   /* Allocate new boundary tag before acquiring the vmem lock */
   bt_t *bt, *btnew;
 
-  if (!(btnew = pool_alloc(P_BT, flags | M_ZERO)))
-    return ENOMEM;
+  if (!(btnew = bt_alloc(flags)))
+    return EAGAIN;
 
   WITH_MTX_LOCK (&vm->vm_lock) {
     vmem_check_sanity(vm);
@@ -280,7 +362,7 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp,
     bt = bt_find_freeseg(vm, size);
 
     if (bt == NULL) {
-      pool_free(P_BT, btnew);
+      bt_free(btnew);
       klog("%s: block of %lu bytes not found in '%s'", __func__, size,
            vm->vm_name);
       return ENOMEM;
@@ -311,7 +393,7 @@ int vmem_alloc(vmem_t *vm, vmem_size_t size, vmem_addr_t *addrp,
   }
 
   if (btnew != NULL)
-    pool_free(P_BT, btnew);
+    bt_free(btnew);
 
   assert(bt->bt_size >= size);
   assert(bt->bt_type == BT_TYPE_BUSY);
@@ -372,9 +454,9 @@ void vmem_free(vmem_t *vm, vmem_addr_t addr) {
   }
 
   if (prev != NULL)
-    pool_free(P_BT, prev);
+    bt_free(prev);
   if (next != NULL)
-    pool_free(P_BT, next);
+    bt_free(next);
 
   klog("%s: block of %lu bytes deallocated from '%s'", __func__, size,
        vm->vm_name);
@@ -431,6 +513,6 @@ void vmem_destroy(vmem_t *vm) {
   /* free the memory */
   bt_t *next;
   TAILQ_FOREACH_SAFE (bt, &vm->vm_seglist, bt_seglink, next)
-    pool_free(P_BT, bt);
+    bt_free(bt);
   kfree(M_VMEM, vm);
 }

--- a/sys/kern/vmem.c
+++ b/sys/kern/vmem.c
@@ -301,16 +301,15 @@ vmem_size_t vmem_size(vmem_t *vm, vmem_addr_t addr) {
 
 int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size,
              kmem_flags_t flags) {
+  bt_t *btspan, *btfree;
   int error = 0;
 
-  bt_t *btspan = bt_alloc(flags);
-  if (!btspan) {
+  if (!(btspan = bt_alloc(flags))) {
     error = EAGAIN;
     goto end;
   }
 
-  bt_t *btfree = bt_alloc(flags);
-  if (!btfree) {
+  if (!(btfree = bt_alloc(flags))) {
     error = EAGAIN;
     goto end;
   }
@@ -330,6 +329,7 @@ int vmem_add(vmem_t *vm, vmem_addr_t addr, vmem_size_t size,
     vm->vm_size += size;
     vmem_check_sanity(vm);
   }
+
   btspan = NULL;
 
   klog("%s: added [%p-%p] span to '%s'", __func__, addr, addr + size - 1,

--- a/sys/mips/boot.c
+++ b/sys/mips/boot.c
@@ -126,7 +126,7 @@ __boot_text void *mips_init(void) {
   mips32_setindex(0);
   mips32_tlbwi();
 
-  pmap_bootstrap((paddr_t)pde, pde);
+  pmap_bootstrap((vaddr_t)__kernel_end, (paddr_t)pde, pde);
 #if KASAN
   _kasan_sanitized_end = KASAN_SANITIZED_START + kasan_sanitized_size;
 #endif /* !KASAN */

--- a/sys/riscv/boot.c
+++ b/sys/riscv/boot.c
@@ -250,7 +250,6 @@ static __noreturn void riscv_boot(void *dtb, paddr_t pde, paddr_t sbrk_end,
                                   vaddr_t vma_end) {
   configure_cpu();
 
-  vm_kernel_end = vma_end;
   boot_sbrk_end = sbrk_end;
 
 #if KASAN
@@ -262,7 +261,7 @@ static __noreturn void riscv_boot(void *dtb, paddr_t pde, paddr_t sbrk_end,
 
   void *sp = board_stack();
 
-  pmap_bootstrap(pde, (void *)BOOT_PD_VADDR);
+  pmap_bootstrap(vma_end, pde, (void *)BOOT_PD_VADDR);
 
   /*
    * Switch to thread0's stack and perform `board_init`.

--- a/sys/tests/pmap.c
+++ b/sys/tests/pmap.c
@@ -17,7 +17,7 @@ static vm_page_t *x_vm_page_alloc(size_t npages) {
 }
 
 static vaddr_t x_kva_alloc(size_t size) {
-  vaddr_t vaddr = kva_alloc(size);
+  vaddr_t vaddr = kva_alloc(size, M_WAITOK);
   assert(vaddr != 0);
   return vaddr;
 }

--- a/sys/tests/vmem.c
+++ b/sys/tests/vmem.c
@@ -23,12 +23,12 @@ static int test_vmem(void) {
 
   /* add span #1 */
   span_t span1 = {.addr = 2 * quantum, .size = 8 * quantum};
-  rc = vmem_add(vm, span1.addr, span1.size);
+  rc = vmem_add(vm, span1.addr, span1.size, M_WAITOK);
   assert(rc == 0);
 
   /* add span #2 */
   span_t span2 = {.addr = 100 * quantum, .size = 20 * quantum};
-  rc = vmem_add(vm, span2.addr, span2.size);
+  rc = vmem_add(vm, span2.addr, span2.size, M_WAITOK);
   assert(rc == 0);
 
   /* alloc 17 quantums, should return addr from span #2 */


### PR DESCRIPTION
The primary problem with our current boundary tag allocation solution which is based on the pool allocator is that it creates a cyclic dependency between `pool` and `vmem`. If a pool happens to run out of free items in slabs, it calls `vmem` to allocate kernel virtual address space. However, if at that time `vmem` runs out of boundary tags, we reenter `pool_alloc` and panic due to an attempt to acquire a nonrecursive mutex for the second time. Moreover, changing the allocation scheme to allocate new slabs from some other area (e.g. `dmap`) doesn't fix all problems as there's still a cycle between vmem's and boundary tag pool's lock (which is sometimes detected by `lockdep`).

This PR contains changes introduced in #1327.