### PR TITLE
[lockdep] Create a separate lock class for kernel pmap.

### DIFF
--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -486,9 +486,12 @@ static void pmap_setup(pmap_t *pmap) {
     vm_page_t *pg = pmap_pagealloc();
     pmap->pde = pg->paddr;
     TAILQ_INSERT_TAIL(&pmap->pte_pages, pg, pageq);
+    mtx_init(&pmap->mtx, 0);
+  } else {
+    /* Create a separate lock class for kernel pmap. */
+    mtx_init(&kernel_pmap.mtx, 0);
   }
   pmap->asid = alloc_asid();
-  mtx_init(&pmap->mtx, 0);
   TAILQ_INIT(&pmap->pv_list);
 
   pmap_md_setup(pmap);
@@ -501,8 +504,6 @@ __long_call void pmap_bootstrap(paddr_t pd_pa, void *pd) {
 
 void init_pmap(void) {
   pmap_setup(&kernel_pmap);
-  /* Create a separate lock class for kernel pmap. */
-  mtx_init(&kernel_pmap.mtx, 0);
 }
 
 pmap_t *pmap_new(void) {

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -501,6 +501,7 @@ __long_call void pmap_bootstrap(paddr_t pd_pa, void *pd) {
 
 void init_pmap(void) {
   pmap_setup(&kernel_pmap);
+  mtx_init(&kernel_pmap.mtx, 0);
 }
 
 pmap_t *pmap_new(void) {

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -501,6 +501,7 @@ __long_call void pmap_bootstrap(paddr_t pd_pa, void *pd) {
 
 void init_pmap(void) {
   pmap_setup(&kernel_pmap);
+  /* Create a separate lock class for kernel pmap. */
   mtx_init(&kernel_pmap.mtx, 0);
 }
 


### PR DESCRIPTION
With the current assignment of lock classes, we have a cycle between `pool::pp_mtx` and `pmap::mtx`. The problem is as follows:

1. A call to `pool_alloc` can run out of segments with free items. This results in a kernel memory allocation (`kmem_alloc`) which maps a memory range using `pmap_kenter` (`pool::pp_mtx` -> `pmap::mtx`).
2. Whenever entering a pageable mapping to pmap `pma_enter` gets called. For each pageable mapping of a page, we maintain a physical-to-virtual entry (`pv_entry_t`) which is allocated from a dedicated pool (pmap::mtx` -> `pool::pp_mtx`).

However, the kernel only uses wired memory, thereby, introducing a separate lock class for kernel pmap solves the problem.