### PR TITLE
[evdev] Fix evtest build.

### DIFF
--- a/contrib/evtest/Makefile
+++ b/contrib/evtest/Makefile
@@ -19,7 +19,6 @@ download-here: evtest patch
 evtest:
 	@echo "[GIT] clone $(EVTEST_URL) -> $@"
 	$(GIT) clone $(EVTEST_URL) $@
-	make -C .
 
 patch: patch-stamp
 patch-stamp:


### PR DESCRIPTION
If we call make recursively from `evtest` during the download phase, the build fails while obtaining dependencies for `evtest.c` as the sources aren't patched yet.