### PR TITLE
Update uio_offset in devfs read/write operations

### DIFF
--- a/sys/kern/devfs.c
+++ b/sys/kern/devfs.c
@@ -140,20 +140,32 @@ void devfs_free(devfs_node_t *dn) {
 
 static int devfs_fop_read(file_t *fp, uio_t *uio) {
   devnode_t *dev = fp->f_data;
+  int err;
 
   if (dev->ops->d_type & DT_SEEKABLE)
     uio->uio_offset = fp->f_offset;
 
-  return dev->ops->d_read(dev, uio);
+  err = dev->ops->d_read(dev, uio);
+
+  if (dev->ops->d_type & DT_SEEKABLE)
+    fp->f_offset = uio->uio_offset;
+
+  return err;
 }
 
 static int devfs_fop_write(file_t *fp, uio_t *uio) {
   devnode_t *dev = fp->f_data;
+  int err;
 
   if (dev->ops->d_type & DT_SEEKABLE)
     uio->uio_offset = fp->f_offset;
 
-  return dev->ops->d_write(dev, uio);
+  err = dev->ops->d_write(dev, uio);
+
+  if (dev->ops->d_type & DT_SEEKABLE)
+    fp->f_offset = uio->uio_offset;
+
+  return err;
 }
 
 static int devfs_fop_close(file_t *fp) {

--- a/sys/kern/devfs.c
+++ b/sys/kern/devfs.c
@@ -140,11 +140,19 @@ void devfs_free(devfs_node_t *dn) {
 
 static int devfs_fop_read(file_t *fp, uio_t *uio) {
   devnode_t *dev = fp->f_data;
+
+  if (dev->ops->d_type & DT_SEEKABLE)
+    uio->uio_offset = fp->f_offset;
+
   return dev->ops->d_read(dev, uio);
 }
 
 static int devfs_fop_write(file_t *fp, uio_t *uio) {
   devnode_t *dev = fp->f_data;
+
+  if (dev->ops->d_type & DT_SEEKABLE)
+    uio->uio_offset = fp->f_offset;
+
   return dev->ops->d_write(dev, uio);
 }
 


### PR DESCRIPTION
For seekable devices read and write operations might need to take the `f_offset` into account when performing reads or writes. Up until this PR the `uio_offset` field of `uio_t` passed to `d_read` and `d_write` methods was always set to zero. This PR sets it to the value of `file_t`'s `f_offset`, which represents the position of a cursor in a given file.