### PR TITLE
Enable lockdep checking for almost all spin mutexes

### DIFF
--- a/include/sys/mutex.h
+++ b/include/sys/mutex.h
@@ -41,7 +41,8 @@ typedef struct mtx {
 /* Flags stored in lower 3 bits of m_owner. */
 #define MTX_SLEEP 0
 #define MTX_SPIN 1
-#define MTX_CONTESTED 2
+#define MTX_NODEBUG 2
+#define MTX_CONTESTED 4
 #define MTX_FLAGMASK 7
 
 #if LOCKDEP

--- a/sys/debug/sync.py
+++ b/sys/debug/sync.py
@@ -32,15 +32,14 @@ class Turnstile(metaclass=GdbStructMeta):
 
 class Mutex(metaclass=GdbStructMeta):
     __ctype__ = 'struct mtx'
-    __cast__ = {'m_count': int}
 
     def __str__(self):
         if self.m_owner:
             owner = self.m_owner & -8
             owner = owner.cast(gdb.lookup_type('thread_t').pointer())
-            return 'mtx{owner = %s, count = %d, blocked = %s}' % (
+            return 'mtx{owner = %s, blocked = %s}' % (
                     Thread(owner.dereference()),
-                    self.m_count, Turnstile(self._obj.address))
+                    Turnstile(self._obj.address))
         return 'mtx{owner = None}'
 
 

--- a/sys/kern/lockdep.c
+++ b/sys/kern/lockdep.c
@@ -29,7 +29,7 @@ typedef struct lock_class_edge {
   lock_class_t *to;
 } lock_class_edge_t;
 
-static MTX_DEFINE(main_lock, MTX_SPIN|MTX_NODEBUG);
+static MTX_DEFINE(main_lock, MTX_SPIN | MTX_NODEBUG);
 
 #define CLASSHASH_SIZE 64
 /* We have to divide the key by the alignment of lock_class_key_t to prevent the

--- a/sys/kern/lockdep.c
+++ b/sys/kern/lockdep.c
@@ -29,7 +29,7 @@ typedef struct lock_class_edge {
   lock_class_t *to;
 } lock_class_edge_t;
 
-static MTX_DEFINE(main_lock, MTX_SPIN);
+static MTX_DEFINE(main_lock, MTX_SPIN|MTX_NODEBUG);
 
 #define CLASSHASH_SIZE 64
 /* We have to divide the key by the alignment of lock_class_key_t to prevent the
@@ -201,6 +201,8 @@ static lock_class_edge_t *alloc_edge(lock_class_t *to) {
   return edge;
 }
 
+static bool cycle_detected = false;
+
 static void add_edge_to(thread_t *thread, lock_class_t *lock) {
   lock_class_t *prevlock;
   lock_class_edge_t *edge;
@@ -227,6 +229,7 @@ static void add_edge_to(thread_t *thread, lock_class_t *lock) {
   SIMPLEQ_INSERT_HEAD(&(prevlock->locked_after), edge, link);
 
   if (check_path(lock, prevlock)) {
+    cycle_detected = true;
     panic("lockdep: cycle between locks %s and %s", prevlock->name, lock->name);
   }
 }
@@ -238,6 +241,9 @@ void lockdep_init(void) {
 }
 
 void lockdep_acquire(lock_class_mapping_t *lock) {
+  if (__unlikely(cycle_detected))
+    return;
+
   lock_class_t *class;
   thread_t *thread = thread_self();
 
@@ -256,6 +262,9 @@ void lockdep_acquire(lock_class_mapping_t *lock) {
 
 /* This function is called with the `lock` held. */
 void lockdep_release(lock_class_mapping_t *lock) {
+  if (__unlikely(cycle_detected))
+    return;
+
   lock_class_t *class = lock->lock_class;
   thread_t *thread = thread_self();
   assert(class);

--- a/sys/kern/mutex.c
+++ b/sys/kern/mutex.c
@@ -11,7 +11,7 @@ bool mtx_owned(mtx_t *m) {
 
 void _mtx_init(mtx_t *m, intptr_t flags, const char *name,
                lock_class_key_t *key) {
-  assert((flags & ~(MTX_SPIN|MTX_NODEBUG)) == 0);
+  assert((flags & ~(MTX_SPIN | MTX_NODEBUG)) == 0);
   m->m_owner = flags;
 
 #if LOCKDEP
@@ -21,7 +21,7 @@ void _mtx_init(mtx_t *m, intptr_t flags, const char *name,
 }
 
 void _mtx_lock(mtx_t *m, const void *waitpt) {
-  intptr_t flags = m->m_owner & (MTX_SPIN|MTX_NODEBUG);
+  intptr_t flags = m->m_owner & (MTX_SPIN | MTX_NODEBUG);
 
   if (flags & MTX_SPIN) {
     intr_disable();
@@ -72,7 +72,7 @@ void _mtx_lock(mtx_t *m, const void *waitpt) {
 }
 
 void mtx_unlock(mtx_t *m) {
-  intptr_t flags = m->m_owner & (MTX_SPIN|MTX_NODEBUG);
+  intptr_t flags = m->m_owner & (MTX_SPIN | MTX_NODEBUG);
 
   assert(mtx_owned(m));
 

--- a/sys/kern/sleepq.c
+++ b/sys/kern/sleepq.c
@@ -64,7 +64,7 @@ void init_sleepq(void) {
 
   for (int i = 0; i < SC_TABLESIZE; i++) {
     sleepq_chain_t *sc = &sleepq_chains[i];
-    mtx_init(&sc->sc_lock, MTX_SPIN|MTX_NODEBUG);
+    mtx_init(&sc->sc_lock, MTX_SPIN | MTX_NODEBUG);
     TAILQ_INIT(&sc->sc_queues);
   }
 }

--- a/sys/kern/sleepq.c
+++ b/sys/kern/sleepq.c
@@ -64,7 +64,7 @@ void init_sleepq(void) {
 
   for (int i = 0; i < SC_TABLESIZE; i++) {
     sleepq_chain_t *sc = &sleepq_chains[i];
-    mtx_init(&sc->sc_lock, MTX_SPIN);
+    mtx_init(&sc->sc_lock, MTX_SPIN|MTX_NODEBUG);
     TAILQ_INIT(&sc->sc_queues);
   }
 }

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -85,7 +85,7 @@ thread_t *thread_create(const char *name, void (*fn)(void *), void *arg,
   td->td_base_prio = prio;
 
   td->td_lock = kmalloc(M_TEMP, sizeof(mtx_t), M_ZERO);
-  mtx_init(td->td_lock, MTX_SPIN);
+  mtx_init(td->td_lock, MTX_SPIN|MTX_NODEBUG);
 
   cv_init(&td->td_waitcv, "thread waiters");
   LIST_INIT(&td->td_contested);

--- a/sys/kern/thread.c
+++ b/sys/kern/thread.c
@@ -85,7 +85,7 @@ thread_t *thread_create(const char *name, void (*fn)(void *), void *arg,
   td->td_base_prio = prio;
 
   td->td_lock = kmalloc(M_TEMP, sizeof(mtx_t), M_ZERO);
-  mtx_init(td->td_lock, MTX_SPIN|MTX_NODEBUG);
+  mtx_init(td->td_lock, MTX_SPIN | MTX_NODEBUG);
 
   cv_init(&td->td_waitcv, "thread waiters");
   LIST_INIT(&td->td_contested);

--- a/sys/kern/turnstile.c
+++ b/sys/kern/turnstile.c
@@ -280,7 +280,7 @@ static void wakeup_blocked(td_queue_t *blocked_threads) {
 
 /* Looks for turnstile associated with wchan in turnstile chains and returns
  * it or NULL if no turnstile is found in chains. */
-static turnstile_t *turnstile_lookup(void *wchan) {
+static __used turnstile_t *turnstile_lookup(void *wchan) {
   turnstile_chain_t *tc = TC_LOOKUP(wchan);
   turnstile_t *ts;
   LIST_FOREACH (ts, &tc->tc_turnstiles, ts_chain_link) {


### PR DESCRIPTION
So far lockdep was not enabled for spin mutexes. This PR changes that, although some spin mutexes need to be marked as `NODEBUG` since there's a mess with `td_lock` and `sc_lock` acquire order.