### PR TITLE
[exec] Fix user stack setup.

### DIFF
--- a/sys/kern/ustack.c
+++ b/sys/kern/ustack.c
@@ -85,6 +85,8 @@ void ustack_relocate_ptr(ustack_t *us, vaddr_t *ptr_p) {
 
 void ustack_finalize(ustack_t *us) {
   assert(!finalized_p(us));
+  /* We have to align the stack size as that much memory will be copied
+   * to the stack segment affecting the final SP alignment. */
   ptrdiff_t size = us->us_bottom - us->us_top;
   us->us_bottom = us->us_top + roundup2(size, STACK_ALIGN);
   us->us_finalized = true;

--- a/sys/kern/ustack.c
+++ b/sys/kern/ustack.c
@@ -85,8 +85,8 @@ void ustack_relocate_ptr(ustack_t *us, vaddr_t *ptr_p) {
 
 void ustack_finalize(ustack_t *us) {
   assert(!finalized_p(us));
-  /* Cannot fail because initially stack is aligned to STACK_ALIGN. */
-  ustack_align(us, STACK_ALIGN);
+  ptrdiff_t size = us->us_bottom - us->us_top;
+  us->us_bottom = us->us_top + roundup2(size, STACK_ALIGN);
   us->us_finalized = true;
 }
 


### PR DESCRIPTION
The current code assumes that malloc's `ALIGNMENT` is divisible by `STACK_ALIGN`. Although it turns out to be always valid for the present implementation, this assumption should be dropped.