### PR TITLE
[usb] Fix UHCI USB host controller driver.

### DIFF
--- a/include/dev/uhci.h
+++ b/include/dev/uhci.h
@@ -29,7 +29,9 @@ struct uhci_td {
   volatile uint32_t td_status;
   volatile uint32_t td_token;
   volatile uint32_t td_buffer;
-  uint32_t __reserved[4]; /* 16 bytes for user usage */
+  /* 16 bytes for user usage */
+  uhci_physaddr_t td_paddr;
+  uint32_t __reserved[3];
 } __aligned(UHCI_TD_ALIGN);
 
 #define UHCI_TD_GET_ACTLEN(s) (((s) + 1) & 0x3ff)
@@ -83,6 +85,7 @@ typedef struct usb_buf usb_buf_t;
 struct uhci_qh {
   volatile uint32_t qh_h_next;
   volatile uint32_t qh_e_next;
+  uhci_physaddr_t qh_paddr;
   union {
     /* Main queue items. */
     struct {
@@ -91,7 +94,8 @@ struct uhci_qh {
     };
     /* External queue items. */
     struct {
-      TAILQ_ENTRY(uhci_qh) qh_link; /* link on a main queue's list */
+      TAILQ_ENTRY(uhci_qh) qh_link;         /* link on a main queue's list */
+      TAILQ_ENTRY(uhci_qh) qh_release_link; /* link on a release list */
       usb_buf_t *qh_buf; /* usb buffer associated with the transaction */
       void *qh_data;     /* I/O data buffer of the transaction */
     };

--- a/include/dev/uhci.h
+++ b/include/dev/uhci.h
@@ -29,9 +29,7 @@ struct uhci_td {
   volatile uint32_t td_status;
   volatile uint32_t td_token;
   volatile uint32_t td_buffer;
-  /* 16 bytes for user usage */
-  uhci_physaddr_t td_paddr;
-  uint32_t __reserved[3];
+  uint32_t __reserved[4]; /* 16 bytes for user usage */
 } __aligned(UHCI_TD_ALIGN);
 
 #define UHCI_TD_GET_ACTLEN(s) (((s) + 1) & 0x3ff)
@@ -85,7 +83,6 @@ typedef struct usb_buf usb_buf_t;
 struct uhci_qh {
   volatile uint32_t qh_h_next;
   volatile uint32_t qh_e_next;
-  uhci_physaddr_t qh_paddr;
   union {
     /* Main queue items. */
     struct {
@@ -94,8 +91,7 @@ struct uhci_qh {
     };
     /* External queue items. */
     struct {
-      TAILQ_ENTRY(uhci_qh) qh_link;         /* link on a main queue's list */
-      TAILQ_ENTRY(uhci_qh) qh_release_link; /* link on a release list */
+      TAILQ_ENTRY(uhci_qh) qh_link; /* link on a main queue's list */
       usb_buf_t *qh_buf; /* usb buffer associated with the transaction */
       void *qh_data;     /* I/O data buffer of the transaction */
     };

--- a/sys/drv/uhci.c
+++ b/sys/drv/uhci.c
@@ -36,6 +36,7 @@
 
 typedef struct uhci_state {
   uhci_qh_t *mainqs[UHCI_NMAINQS]; /* main queues (i.e. schedule queues) */
+  uhci_qh_list_t release_list;     /* queues to release */
   uint32_t *frames;                /* UHCI frame list */
   resource_t *regs;                /* host controller registers */
   resource_t *irq;                 /* host controller interrupt */
@@ -226,7 +227,8 @@ static POOL_DEFINE(P_DATA, "UHCI data buffers", UHCI_DATA_BUF_SIZE);
 /* Obtain the physical address corresponding to `vaddr`. */
 static uhci_physaddr_t uhci_physaddr(void *vaddr) {
   paddr_t paddr = 0;
-  pmap_kextract((vaddr_t)vaddr, &paddr);
+  bool success = pmap_kextract((vaddr_t)vaddr, &paddr);
+  assert(success);
   return (uhci_physaddr_t)paddr;
 }
 
@@ -254,6 +256,7 @@ static void td_init(uhci_td_t *td, usb_device_t *udev, uint32_t ioc,
   td->td_status = UHCI_TD_SET_ERRCNT(3) | ioc | ls | UHCI_TD_ACTIVE;
   td->td_token = token;
   td->td_buffer = (data ? uhci_physaddr(data) : 0);
+  td->td_paddr = uhci_physaddr(td);
 }
 
 /* Create a SETUP transfer descriptor. */
@@ -313,7 +316,7 @@ static inline bool td_last(uhci_td_t *td) {
 /* Point the queue's element link pointer
  * at the specified transfer descriptor. */
 static inline void qh_add_td(uhci_qh_t *qh, uhci_td_t *td) {
-  qh->qh_e_next = uhci_physaddr(td) | UHCI_PTR_TD;
+  qh->qh_e_next = td->td_paddr | UHCI_PTR_TD;
 }
 
 /* Return a pointer to the first transfer descriptor composing `qh`. */
@@ -325,8 +328,8 @@ static inline uhci_td_t *qh_first_td(uhci_qh_t *qh) {
 static void qh_init(uhci_qh_t *qh, usb_buf_t *buf) {
   qh->qh_h_next = UHCI_PTR_T;
   qh->qh_e_next = UHCI_PTR_T;
+  qh->qh_paddr = uhci_physaddr(qh);
   qh->qh_buf = buf;
-  qh_add_td(qh, qh_first_td(qh));
 }
 
 /* Allocate a new queue (including transfer I/O data buffer). */
@@ -358,18 +361,19 @@ static void qh_init_main(uhci_qh_t *mq) {
   bzero(mq, sizeof(uhci_qh_t));
   mq->qh_h_next = UHCI_PTR_T;
   mq->qh_e_next = UHCI_PTR_T;
+  mq->qh_paddr = uhci_physaddr(mq);
   mtx_init(&mq->qh_lock, MTX_SPIN);
   TAILQ_INIT(&mq->qh_list);
 }
 
 /* Point the queue's element link pointer at the specified queue. */
 static inline void qh_add_qh(uhci_qh_t *qh1, uhci_qh_t *qh2) {
-  qh1->qh_e_next = uhci_physaddr(qh2) | UHCI_PTR_QH;
+  qh1->qh_e_next = qh2->qh_paddr | UHCI_PTR_QH;
 }
 
 /* Point the queue's head link pointer at the specified queue. */
 static inline void qh_chain(uhci_qh_t *qh1, uhci_qh_t *qh2) {
-  qh1->qh_h_next = uhci_physaddr(qh2) | UHCI_PTR_QH;
+  qh1->qh_h_next = qh2->qh_paddr | UHCI_PTR_QH;
 }
 
 /* Tell the controller to omit the specified queue from now on. */
@@ -431,7 +435,6 @@ static uint32_t qh_error_status(uhci_qh_t *qh) {
 static void qh_discard(uhci_qh_t *mq, uhci_qh_t *qh) {
   assert(mtx_owned(&mq->qh_lock));
   qh_remove(mq, qh);
-  qh_free(qh);
 }
 
 /* Set a queue to be executed. */
@@ -513,7 +516,8 @@ static usb_error_t uhcie2usbe(uint32_t error) {
 }
 
 /* Process the transfer identified by queue `qh`. */
-static void uhci_process(uhci_state_t *uhci, uhci_qh_t *mq, uhci_qh_t *qh) {
+static intr_filter_t uhci_process(uhci_state_t *uhci, uhci_qh_t *mq,
+                                  uhci_qh_t *qh) {
   assert(mtx_owned(&mq->qh_lock));
 
   qh_halt(qh);
@@ -527,14 +531,13 @@ static void uhci_process(uhci_state_t *uhci, uhci_qh_t *mq, uhci_qh_t *qh) {
   if (error) {
     usb_error_t uerr = uhcie2usbe(error);
     usb_buf_process(buf, NULL, uerr);
-    qh_discard(mq, qh);
-    return;
+    goto discard;
   }
 
   /* If the transfer isn't done yet, we'll come back to it later. */
   if (!qh_executed(qh)) {
     qh_unhalt(qh);
-    return;
+    return IF_FILTERED;
   }
 
   /* Let the USB bus layer handle the received data. */
@@ -544,9 +547,13 @@ static void uhci_process(uhci_state_t *uhci, uhci_qh_t *mq, uhci_qh_t *qh) {
   if (usb_buf_periodic(buf)) {
     /* Adding a transfer descriptor will unhalt the queue automatically. */
     qh_reactivate(qh);
-  } else {
-    qh_discard(mq, qh);
+    return IF_FILTERED;
   }
+
+discard:
+  qh_discard(mq, qh);
+  TAILQ_INSERT_TAIL(&uhci->release_list, qh, qh_release_link);
+  return IF_DELEGATE;
 }
 
 /* UHCI Interrupt Service Routine. */
@@ -562,6 +569,8 @@ static intr_filter_t uhci_isr(void *data) {
   /* Clear the interrupt flags so that new requests can be queued. */
   wclr16(UHCI_STS, intrmask);
 
+  intr_filter_t status = IF_FILTERED;
+
   for (int i = 0; i < UHCI_NMAINQS; i++) {
     uhci_qh_t *mq = uhci->mainqs[i];
     qh_halt(mq);
@@ -570,14 +579,24 @@ static intr_filter_t uhci_isr(void *data) {
     WITH_MTX_LOCK (&mq->qh_lock) {
       uhci_qh_t *qh, *next;
       TAILQ_FOREACH_SAFE (qh, &mq->qh_list, qh_link, next)
-        uhci_process(uhci, mq, qh);
+        status |= uhci_process(uhci, mq, qh);
       /* Unhalt only non-empty main queues. */
       if (!TAILQ_EMPTY(&mq->qh_list))
         qh_unhalt(mq);
     }
   }
 
-  return IF_FILTERED;
+  return (status & IF_DELEGATE) ? IF_DELEGATE : IF_FILTERED;
+}
+
+static void uhci_service(void *data) {
+  uhci_state_t *uhci = data;
+
+  while (!TAILQ_EMPTY(&uhci->release_list)) {
+    uhci_qh_t *qh = TAILQ_FIRST(&uhci->release_list);
+    TAILQ_REMOVE(&uhci->release_list, qh, qh_release_link);
+    qh_free(qh);
+  }
 }
 
 /* Schedule a queue for execution in `flr(log(interval))` ms. */
@@ -644,6 +663,8 @@ static void uhci_control_transfer(device_t *hcdev, device_t *dev,
   /* Prepare a STATUS packet. */
   td_status(td, udev, endpt, buf->transfer_size, status_dir);
 
+  qh_add_td(qh, qh_first_td(qh));
+
   uhci_schedule(uhci, qh, 0);
 }
 
@@ -663,6 +684,8 @@ static void uhci_data_transfer(device_t *hcdev, device_t *dev, usb_buf_t *buf) {
   td--;
   td->td_next = UHCI_PTR_T;
   td->td_status |= UHCI_TD_IOC;
+
+  qh_add_td(qh, qh_first_td(qh));
 
   uhci_schedule(uhci, qh, endpt->interval);
 }
@@ -793,10 +816,10 @@ static int uhci_probe(device_t *dev) {
 }
 
 static int uhci_attach(device_t *dev) {
-  return ENXIO;
-
   uhci_state_t *uhci = dev->state;
   int err = 0;
+
+  TAILQ_INIT(&uhci->release_list);
 
   /* Gather I/O ports resources. */
   uhci->regs = device_take_ioports(dev, 4);
@@ -844,7 +867,7 @@ static int uhci_attach(device_t *dev) {
   /* Setup host controller's interrupt. */
   uhci->irq = device_take_irq(dev, 0);
   assert(uhci->irq);
-  pic_setup_intr(dev, uhci->irq, uhci_isr, NULL, uhci, "UHCI");
+  pic_setup_intr(dev, uhci->irq, uhci_isr, uhci_service, uhci, "UHCI");
 
   /* Turn on the IOC and error interrupts. */
   set16(UHCI_INTR, UHCI_INTR_TOCRCIE | UHCI_INTR_IOCE);


### PR DESCRIPTION
The current code attempts to acquire blocking locks while holding a spin lock. The solution is to move IRQ handling into an ithread context.