### PR TITLE
Create a hook to verify code style

### DIFF
--- a/git-setup.sh
+++ b/git-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Check if pre-commit hook exists
+[ -f .git/hooks/pre-commit ] \
+  && echo "You already have a pre-commit hook installed. Please remove it if you want to use our hook." \
+  && exit 1
+
+# Install the pre-commit hook
+ln -s ./scripts/pre-commit .git/hooks/pre-commit \
+  || echo "Failed to install pre-commit hook" \
+  && exit 1
+
+echo Hooks successfully installed.
+exit 0

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+err=false
+
+# Verify C code style
+
+echo "Verifying C code style..."
+CFILES=$(git diff --cached --name-only | grep -E ".*\.[hc]")
+
+if ! [ "$CFILES" == "" ]; then
+  for file in $CFILES; do
+    clang-format-14 -n --Werror --style=file -i $file || err=true
+  done
+fi
+
+# Verify Python code style
+
+echo "Verifying Python code style..."
+PYFILES=$(git diff --cached --name-only | grep -E ".*\.py")
+PYEXTRA=$(git diff --cached --name-only | grep -E "launch")
+
+if ! [ "$PYFILES" == "" ] || ! [ "$PYEXTRA" == "" ]; then
+  pycodestyle ${PYEXTRA} ${PYFILES} || err=true
+fi
+
+echo $err
+if $err ; then
+  exit 1
+fi
+
+echo "Code style OK"
+exit 0

--- a/verify-pycodestyle.sh
+++ b/verify-pycodestyle.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-PYFILES=$(find . \( -name 'toolchain' -prune \)\
-              -o \( -name '.*.py' -prune \) \
-              -o \( -name '*.py' -printf '%P\n' \))
+PYFILES=$(find . \( -name '*.py' \
+                -or -name 'toolchain' -prune \
+                -or -name '.*.py' -prune \
+              \) \
+              -and \( \
+                -not -path './mimiker-env/*' \
+              \) \
+            -printf '%P\n' \
+          )
+
 PYEXTRA="launch"
 
 pycodestyle ${PYEXTRA} ${PYFILES}


### PR DESCRIPTION
This PR:
  - creates a pre-commit hook
  - adds script to install that hook
  - updates implementation of `verify-pycodestyle.py`

**NOTE**: The script that installs the git hooks is the only way that came to my mind to make sure every one has hooks installed. Although it still has to be run manually.  That means we cannot get rid of verify code style stage in CI.
