### PR TITLE
[vm] Fix VM map switching.

### DIFF
--- a/sys/kern/vm_map.c
+++ b/sys/kern/vm_map.c
@@ -42,8 +42,7 @@ void vm_map_activate(vm_map_t *map) {
 
 void vm_map_switch(thread_t *td) {
   proc_t *p = td->td_proc;
-  if (p)
-    vm_map_activate(p->p_uspace);
+  vm_map_activate(p ? p->p_uspace : NULL);
 }
 
 void vm_map_lock(vm_map_t *map) {

--- a/sys/riscv/pmap.c
+++ b/sys/riscv/pmap.c
@@ -96,12 +96,13 @@ static void update_kernel_pd(pmap_t *umap) {
 
 void pmap_md_activate(pmap_t *umap) {
   pmap_t *kmap = pmap_kernel();
+  paddr_t satp = umap ? umap->md.satp : kmap->md.satp;
   assert(kmap->md.generation);
 
-  if (umap->md.generation < kmap->md.generation)
+  if (umap && umap->md.generation < kmap->md.generation)
     update_kernel_pd(umap);
 
-  __set_satp(umap->md.satp);
+  __set_satp(satp);
   __sfence_vma();
 }
 


### PR DESCRIPTION
If we switch to a kernel thread, the current user pmap should and userspace virtual memory map should be set to `NULL`.