### PR TITLE
Unify syscall_handler for all three architectures

### DIFF
--- a/include/aarch64/syscall.h
+++ b/include/aarch64/syscall.h
@@ -29,4 +29,16 @@
 
 #endif /* !__ASSEMBLER__ */
 
+#if defined(_MACHDEP) && defined(_KERNEL)
+
+static inline void *sc_md_args(ctx_t *ctx) {
+  return &_REG(ctx, X0);
+}
+
+static inline void *sc_md_stack_args(ctx_t *ctx, size_t nregs) {
+  panic("not implemented!");
+}
+
+#endif /* !_MACHDEP && !_KERNEL */
+
 #endif /* !_AARCH64_SYSCALL_H_ */

--- a/include/aarch64/syscall.h
+++ b/include/aarch64/syscall.h
@@ -35,10 +35,6 @@ static inline void *sc_md_args(ctx_t *ctx) {
   return &_REG(ctx, X0);
 }
 
-static inline void *sc_md_stack_args(ctx_t *ctx, size_t nregs) {
-  panic("not implemented!");
-}
-
 #endif /* !_MACHDEP && !_KERNEL */
 
 #endif /* !_AARCH64_SYSCALL_H_ */

--- a/include/mips/syscall.h
+++ b/include/mips/syscall.h
@@ -36,10 +36,6 @@
 
 #if defined(_MACHDEP) && defined(_KERNEL)
 
-static inline register_t sc_md_code(ctx_t *ctx) {
-  return _REG(ctx, V0);
-}
-
 static inline void *sc_md_args(ctx_t *ctx) {
   return &_REG(ctx, A0);
 }

--- a/include/mips/syscall.h
+++ b/include/mips/syscall.h
@@ -34,4 +34,27 @@
 
 #endif /* !__ASSEMBLER__ */
 
+#if defined(_MACHDEP) && defined(_KERNEL)
+
+static inline register_t sc_md_code(ctx_t *ctx) {
+  return _REG(ctx, V0);
+}
+
+static inline void *sc_md_args(ctx_t *ctx) {
+  return &_REG(ctx, A0);
+}
+
+/*
+ * From ABI:
+ * Despite the fact that some or all of the arguments to a function are
+ * passed in registers, always allocate space on the stack for all
+ * arguments.
+ * For this reason, we read from the user stack with some offset.
+ */
+static inline void *sc_md_stack_args(ctx_t *ctx, size_t nregs) {
+  return (void *)(_REG(ctx, SP) + nregs * sizeof(register_t));
+}
+
+#endif /* !_MACHDEP && !_KERNEL */
+
 #endif /* !_MIPS_SYSCALL_H_ */

--- a/include/riscv/syscall.h
+++ b/include/riscv/syscall.h
@@ -32,4 +32,27 @@
 
 #endif /* !__ASSEMBLER__ */
 
+#if defined(_MACHDEP) && defined(_KERNEL)
+
+static inline void *sc_md_args(ctx_t *ctx) {
+  return &_REG(ctx, A0);
+}
+
+/*
+ * RISC-V syscall ABI:
+ *  - a7: code
+ *  - a0-5: args
+ *
+ * NOTE: the following code assumes all arguments to syscalls are passed
+ * via registers.
+ */
+static_assert(SYS_MAXSYSARGS <= FUNC_MAXREGARGS - 1,
+              "Syscall args don't fit in registers!");
+
+static inline void *sc_md_stack_args(ctx_t *ctx, size_t nregs) {
+  panic("not implemented!");
+}
+
+#endif /* !_MACHDEP && !_KERNEL */
+
 #endif /* !_RISCV_SYSCALL_H_ */

--- a/include/riscv/syscall.h
+++ b/include/riscv/syscall.h
@@ -34,23 +34,13 @@
 
 #if defined(_MACHDEP) && defined(_KERNEL)
 
-static inline void *sc_md_args(ctx_t *ctx) {
-  return &_REG(ctx, A0);
-}
-
 /*
  * RISC-V syscall ABI:
  *  - a7: code
  *  - a0-5: args
- *
- * NOTE: the following code assumes all arguments to syscalls are passed
- * via registers.
  */
-static_assert(SYS_MAXSYSARGS <= FUNC_MAXREGARGS - 1,
-              "Syscall args don't fit in registers!");
-
-static inline void *sc_md_stack_args(ctx_t *ctx, size_t nregs) {
-  panic("not implemented!");
+static inline void *sc_md_args(ctx_t *ctx) {
+  return &_REG(ctx, A0);
 }
 
 #endif /* !_MACHDEP && !_KERNEL */

--- a/include/sys/klog.h
+++ b/include/sys/klog.h
@@ -19,7 +19,7 @@ typedef enum {
   KL_SCHED,   /* scheduler tracing */
   KL_TIME,    /* system clock & timers */
   KL_THREAD,  /* kernel threads management */
-  KL_INTR,    /* interrupts management and handling */
+  KL_INTR,    /* exception & interrupts management and handling */
   KL_DEV,     /* device management */
   KL_VFS,     /* vfs & vnode operations tracing */
   KL_PROC,    /* user process management */

--- a/include/sys/malloc.h
+++ b/include/sys/malloc.h
@@ -21,13 +21,13 @@ typedef struct kmalloc_pool {
 
 /* Defines a local pool of memory for use by a subsystem. */
 #define KMALLOC_DEFINE(NAME, DESC)                                             \
-  kmalloc_pool_t *NAME = &(kmalloc_pool_t){                                    \
+  kmalloc_pool_t NAME[1] = {{                                    \
     .lock = MTX_INITIALIZER(kmalloc_pool, MTX_SPIN),                           \
     .desc = (DESC),                                                            \
-  };                                                                           \
+  }};                                                                           \
   SET_ENTRY(kmalloc_pool, NAME)
 
-#define KMALLOC_DECLARE(NAME) extern kmalloc_pool_t *NAME;
+#define KMALLOC_DECLARE(NAME) extern kmalloc_pool_t NAME[1];
 
 /*! \brief Called during kernel initialization. */
 void init_kmalloc(void);

--- a/include/sys/malloc.h
+++ b/include/sys/malloc.h
@@ -21,10 +21,10 @@ typedef struct kmalloc_pool {
 
 /* Defines a local pool of memory for use by a subsystem. */
 #define KMALLOC_DEFINE(NAME, DESC)                                             \
-  kmalloc_pool_t NAME[1] = {{                                    \
+  kmalloc_pool_t NAME[1] = {{                                                  \
     .lock = MTX_INITIALIZER(kmalloc_pool, MTX_SPIN),                           \
     .desc = (DESC),                                                            \
-  }};                                                                           \
+  }};                                                                          \
   SET_ENTRY(kmalloc_pool, NAME)
 
 #define KMALLOC_DECLARE(NAME) extern kmalloc_pool_t NAME[1];

--- a/include/sys/sysent.h
+++ b/include/sys/sysent.h
@@ -5,6 +5,7 @@
 #include <sys/syscall.h>
 #include <sys/syscallargs.h>
 
+typedef struct ctx ctx_t;
 typedef struct proc proc_t;
 
 typedef int syscall_t(proc_t *, void *, register_t *);
@@ -20,5 +21,7 @@ typedef struct sysent {
 } sysent_t;
 
 extern struct sysent sysent[];
+
+void syscall_handler(ctx_t *ctx, syscall_result_t *result);
 
 #endif /* !_SYS_SYSENT_H_ */

--- a/include/sys/sysent.h
+++ b/include/sys/sysent.h
@@ -22,6 +22,6 @@ typedef struct sysent {
 
 extern struct sysent sysent[];
 
-void syscall_handler(ctx_t *ctx, syscall_result_t *result);
+void syscall_handler(int code, ctx_t *ctx, syscall_result_t *result);
 
 #endif /* !_SYS_SYSENT_H_ */

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -3,7 +3,6 @@
 #include <sys/mimiker.h>
 #include <sys/thread.h>
 #include <sys/pmap.h>
-#include <sys/syscall.h>
 #include <sys/sysent.h>
 #include <sys/interrupt.h>
 #include <sys/cpu.h>
@@ -11,40 +10,6 @@
 
 static __noreturn void kernel_oops(ctx_t *ctx) {
   panic("KERNEL PANIC!!!");
-}
-
-static inline void *sc_md_args(ctx_t *ctx) {
-  return &_REG(ctx, X0);
-}
-
-static void syscall_handler(register_t code, ctx_t *ctx,
-                            syscall_result_t *result) {
-  register_t args[SYS_MAXSYSARGS];
-  /* On AArch64 we have more free registers than SYS_MAXSYSARGS */
-  const size_t nregs = min(SYS_MAXSYSARGS, FUNC_MAXREGARGS);
-  int error = 0;
-
-  memcpy(args, sc_md_args(ctx), nregs * sizeof(register_t));
-
-  if (code > SYS_MAXSYSCALL) {
-    args[0] = code;
-    code = 0;
-  }
-
-  sysent_t *se = &sysent[code];
-  size_t nargs = se->nargs;
-
-  assert(nargs <= nregs);
-
-  thread_t *td = thread_self();
-  register_t retval = 0;
-
-  assert(td->td_proc != NULL);
-
-  error = se->call(td->td_proc, (void *)args, &retval);
-
-  result->retval = error ? -1 : retval;
-  result->error = error;
 }
 
 static vm_prot_t exc_access(u_long exc_code, register_t esr) {

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -13,13 +13,17 @@ static __noreturn void kernel_oops(ctx_t *ctx) {
   panic("KERNEL PANIC!!!");
 }
 
+static inline void *sc_md_args(ctx_t *ctx) {
+  return &_REG(ctx, X0);
+}
+
 static void syscall_handler(register_t code, ctx_t *ctx,
                             syscall_result_t *result) {
   register_t args[SYS_MAXSYSARGS];
   /* On AArch64 we have more free registers than SYS_MAXSYSARGS */
   const size_t nregs = min(SYS_MAXSYSARGS, FUNC_MAXREGARGS);
 
-  memcpy(args, &_REG(ctx, X0), nregs * sizeof(register_t));
+  memcpy(args, sc_md_args(ctx), nregs * sizeof(register_t));
 
   if (code > SYS_MAXSYSCALL) {
     args[0] = code;

--- a/sys/aarch64/trap.c
+++ b/sys/aarch64/trap.c
@@ -1,4 +1,4 @@
-#define KL_LOG KL_VM
+#define KL_LOG KL_INTR
 #include <sys/klog.h>
 #include <sys/mimiker.h>
 #include <sys/thread.h>
@@ -22,6 +22,7 @@ static void syscall_handler(register_t code, ctx_t *ctx,
   register_t args[SYS_MAXSYSARGS];
   /* On AArch64 we have more free registers than SYS_MAXSYSARGS */
   const size_t nregs = min(SYS_MAXSYSARGS, FUNC_MAXREGARGS);
+  int error = 0;
 
   memcpy(args, sc_md_args(ctx), nregs * sizeof(register_t));
 
@@ -40,7 +41,7 @@ static void syscall_handler(register_t code, ctx_t *ctx,
 
   assert(td->td_proc != NULL);
 
-  int error = se->call(td->td_proc, (void *)args, &retval);
+  error = se->call(td->td_proc, (void *)args, &retval);
 
   result->retval = error ? -1 : retval;
   result->error = error;

--- a/sys/gen/Makefile
+++ b/sys/gen/Makefile
@@ -5,6 +5,7 @@ TOPDIR = $(realpath ../..)
 SOURCES = \
 	boot.c \
 	pmap.c \
+	syscall.c \
 	thread.c
 
 include $(TOPDIR)/build/build.kern.mk

--- a/sys/gen/syscall.c
+++ b/sys/gen/syscall.c
@@ -22,12 +22,15 @@ void syscall_handler(int code, ctx_t *ctx, syscall_result_t *result) {
   }
 
   sysent_t *se = &sysent[code];
+
+#if SYS_MAXSYSARGS > FUNC_MAXREGARGS
   size_t nargs = se->nargs;
 
   if (nargs > nregs) {
     error = copyin(sc_md_stack_args(ctx, nregs), &args[nregs],
                    (nargs - nregs) * sizeof(register_t));
   }
+#endif
 
   /* Call the handler. */
   thread_t *td = thread_self();

--- a/sys/gen/syscall.c
+++ b/sys/gen/syscall.c
@@ -1,0 +1,44 @@
+#define KL_LOG KL_SYSCALL
+#include <sys/klog.h>
+#include <sys/errno.h>
+#include <sys/thread.h>
+#include <sys/sysent.h>
+#include <machine/syscall.h>
+
+void syscall_handler(ctx_t *ctx, syscall_result_t *result) {
+  int code = sc_md_code(ctx);
+  register_t args[SYS_MAXSYSARGS];
+  const size_t nregs = min(SYS_MAXSYSARGS, FUNC_MAXREGARGS);
+  int error = 0;
+
+  /*
+   * Copy the arguments passed via register from the
+   * trapctx to our argument array
+   */
+  memcpy(args, sc_md_args(ctx), nregs * sizeof(register_t));
+
+  if (code > SYS_MAXSYSCALL) {
+    args[0] = code;
+    code = 0;
+  }
+
+  sysent_t *se = &sysent[code];
+  size_t nargs = se->nargs;
+
+  if (nargs > nregs) {
+    error = copyin(sc_md_stack_args(ctx, nregs), &args[nregs],
+                   (nargs - nregs) * sizeof(register_t));
+  }
+
+  /* Call the handler. */
+  thread_t *td = thread_self();
+  register_t retval = 0;
+
+  assert(td->td_proc != NULL);
+
+  if (!error)
+    error = se->call(td->td_proc, (void *)args, &retval);
+
+  result->retval = error ? -1 : retval;
+  result->error = error;
+}

--- a/sys/gen/syscall.c
+++ b/sys/gen/syscall.c
@@ -5,8 +5,7 @@
 #include <sys/sysent.h>
 #include <machine/syscall.h>
 
-void syscall_handler(ctx_t *ctx, syscall_result_t *result) {
-  int code = sc_md_code(ctx);
+void syscall_handler(int code, ctx_t *ctx, syscall_result_t *result) {
   register_t args[SYS_MAXSYSARGS];
   const size_t nregs = min(SYS_MAXSYSARGS, FUNC_MAXREGARGS);
   int error = 0;

--- a/sys/mips/trap.c
+++ b/sys/mips/trap.c
@@ -119,7 +119,7 @@ static void user_trap_handler(ctx_t *ctx) {
       break;
 
     case EXC_SYS:
-      syscall_handler(ctx, &result);
+      syscall_handler(_REG(ctx, V0), ctx, &result);
       break;
 
     case EXC_FPE:

--- a/sys/mips/trap.c
+++ b/sys/mips/trap.c
@@ -1,4 +1,4 @@
-#define KL_LOG KL_VM
+#define KL_LOG KL_INTR
 #include <sys/klog.h>
 #include <sys/errno.h>
 #include <sys/interrupt.h>

--- a/sys/riscv/trap.c
+++ b/sys/riscv/trap.c
@@ -1,4 +1,4 @@
-#define KL_LOG KL_VM
+#define KL_LOG KL_INTR
 #include <sys/cpu.h>
 #include <sys/errno.h>
 #include <sys/interrupt.h>
@@ -90,6 +90,7 @@ static void syscall_handler(register_t code, ctx_t *ctx,
                             syscall_result_t *result) {
   register_t args[SYS_MAXSYSARGS];
   const size_t nregs = SYS_MAXSYSARGS;
+  int error = 0;
 
   memcpy(args, sc_md_args(ctx), nregs * sizeof(register_t));
 
@@ -108,7 +109,7 @@ static void syscall_handler(register_t code, ctx_t *ctx,
 
   assert(td->td_proc != NULL);
 
-  int error = se->call(td->td_proc, (void *)args, &retval);
+  error = se->call(td->td_proc, (void *)args, &retval);
 
   result->retval = error ? -1 : retval;
   result->error = error;


### PR DESCRIPTION
Why we have three versions of `syscall_handler` when we can have only one? Let's move `syscall_handler` to `sys/gen/syscall.c`!