### PR TITLE
Fix crash during bootstrap when compiled with GCC

### DIFF
--- a/sys/aarch64/boot.c
+++ b/sys/aarch64/boot.c
@@ -188,7 +188,7 @@ __boot_text static pde_t *build_page_table(vaddr_t kernel_end) {
                ATTR_AP_RO | ATTR_XN | pte_default);
 
   /* data & bss sections */
-  early_kenter(pde, _data, _ebss, PHYSADDR(_data),
+  early_kenter(pde, _data, kernel_end, PHYSADDR(_data),
                ATTR_AP_RW | ATTR_XN | pte_default);
 
   /* direct map construction */


### PR DESCRIPTION
The bug is also present when compiled with Clang, but apparently does not crash the kernel.

Real size of kernel bss section must cover copied dtb as well.