### PR TITLE
preempt_enable could switch out with interrupts disabled

### DIFF
--- a/include/sys/sched.h
+++ b/include/sys/sched.h
@@ -109,6 +109,13 @@ void sched_switch(void);
  */
 void sched_maybe_preempt(void);
 
+/*! \brief Switch out to another thread when interrupts are disabled.
+ *
+ * \note The only user of this function should be `intr_root_handler`
+ *       procedure that returns from an interrupt context.
+ */
+void sched_maybe_switch(void);
+
 /*! \brief Turns calling thread into idle thread. */
 __noreturn void sched_run(void);
 

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -172,7 +172,7 @@ __no_profile void intr_root_handler(ctx_t *ctx) {
   PCPU_SET(no_switch, false);
 
   /* If filter routine requested a context switch it's now time to handle it. */
-  sched_maybe_preempt();
+  sched_maybe_switch();
 
   /* To avoid `intr_root_handler` nesting while in kernel mode,
    * we have to complete this routine without interrupts enabled.

--- a/sys/kern/sched.c
+++ b/sys/kern/sched.c
@@ -201,7 +201,7 @@ __noreturn void sched_run(void) {
   }
 }
 
-void sched_maybe_preempt(void) {
+static void _sched_maybe_switch(void) {
   /* If thread requested not to be preempted, then do not switch out! */
   if (preempt_disabled())
     return;
@@ -215,6 +215,17 @@ void sched_maybe_preempt(void) {
   } else {
     mtx_unlock(td->td_lock);
   }
+}
+
+void sched_maybe_switch(void) {
+  assert(intr_disabled());
+  _sched_maybe_switch();
+}
+
+void sched_maybe_preempt(void) {
+  /* We should not make attempts to switch out if interrupts are disabled! */
+  if (!intr_disabled())
+    _sched_maybe_switch();
 }
 
 /*

--- a/sys/kern/sleepq.c
+++ b/sys/kern/sleepq.c
@@ -228,9 +228,7 @@ bool sleepq_signal(void *wchan) {
   sq_wakeup(best_td, sc, sq, 0);
   sc_release(sc);
 
-  if (!intr_disabled())
-    sched_maybe_preempt();
-
+  sched_maybe_preempt();
   return true;
 }
 


### PR DESCRIPTION
As reported by @MichalBlk a recent change https://github.com/cahirwpz/mimiker/commit/dedbf1c51e4f9df92fd40d39b40749df608eca9a introduced a bug that could cause the kernel to make an attempt to switch out while executing `preempt_enable` from interrupt filters. This PR attempt to fix it.