### PR TITLE
New functions and changes needed for suckless sbase

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -3,6 +3,9 @@
 
 #include <sys/syslimits.h>
 
+#define _POSIX_NAME_MAX 14
+#define _POSIX_PATH_MAX 256
+
 #define _POSIX2_BC_BASE_MAX 99
 #define _POSIX2_BC_DIM_MAX 2048
 #define _POSIX2_BC_SCALE_MAX 99

--- a/include/limits.h
+++ b/include/limits.h
@@ -3,6 +3,7 @@
 
 #include <sys/syslimits.h>
 
+#define _POSIX_ARG_MAX 4096
 #define _POSIX_NAME_MAX 14
 #define _POSIX_PATH_MAX 256
 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -294,6 +294,7 @@ __END_DECLS
 
 __BEGIN_DECLS
 char *fgetln(FILE *__restrict, size_t *__restrict);
+FILE *fmemopen(void * __restrict, size_t, const char * __restrict);
 ssize_t getdelim(char **__restrict, size_t *__restrict, int, FILE *__restrict);
 ssize_t getline(char **__restrict, size_t *__restrict, FILE *__restrict);
 __END_DECLS

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -294,7 +294,7 @@ __END_DECLS
 
 __BEGIN_DECLS
 char *fgetln(FILE *__restrict, size_t *__restrict);
-FILE *fmemopen(void * __restrict, size_t, const char * __restrict);
+FILE *fmemopen(void *__restrict, size_t, const char *__restrict);
 ssize_t getdelim(char **__restrict, size_t *__restrict, int, FILE *__restrict);
 ssize_t getline(char **__restrict, size_t *__restrict, FILE *__restrict);
 __END_DECLS

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -82,7 +82,7 @@ double strtod(const char *__restrict, char **__restrict);
 float strtof(const char *__restrict, char **__restrict);
 long double strtold(const char *__restrict, char **__restrict);
 long strtol(const char *__restrict, char **__restrict, int);
-long long int	llabs(long long int);
+long long int llabs(long long int);
 long long int strtoll(const char *__restrict, char **__restrict, int);
 unsigned long strtoul(const char *__restrict, char **__restrict, int);
 unsigned long long int strtoull(const char *__restrict, char **__restrict, int);

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -82,6 +82,7 @@ double strtod(const char *__restrict, char **__restrict);
 float strtof(const char *__restrict, char **__restrict);
 long double strtold(const char *__restrict, char **__restrict);
 long strtol(const char *__restrict, char **__restrict, int);
+long long int	llabs(long long int);
 long long int strtoll(const char *__restrict, char **__restrict, int);
 unsigned long strtoul(const char *__restrict, char **__restrict, int);
 unsigned long long int strtoull(const char *__restrict, char **__restrict, int);

--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -1,6 +1,8 @@
 #ifndef _SYS_IOCTL_H_
 #define _SYS_IOCTL_H_
 
+#include <sys/ttycom.h>
+
 #ifndef _KERNEL
 
 #include <sys/cdefs.h>

--- a/lib/libc/stdio/fmemopen.c
+++ b/lib/libc/stdio/fmemopen.c
@@ -1,0 +1,236 @@
+/* $NetBSD: fmemopen.c,v 1.8 2012/03/29 14:27:33 christos Exp $ */
+
+/*-
+ * Copyright (c)2007, 2010 Takehiko NOZAKI,
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/cdefs.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "reentrant.h"
+#include "local.h"
+
+struct fmemopen_cookie {
+	char *head, *tail, *cur, *eob;
+};
+
+static ssize_t
+fmemopen_read(void *cookie, void *buf, size_t nbytes)
+{
+	struct fmemopen_cookie *p;
+	char *s, *b = buf;
+
+	_DIAGASSERT(cookie != NULL);
+	_DIAGASSERT(buf != NULL && nbytes > 0);
+
+	p = (struct fmemopen_cookie *)cookie;
+	s = p->cur;
+	do {
+		if (p->cur == p->tail)
+			break;
+		*b++ = *p->cur++;
+	} while (--nbytes > 0);
+
+	return (ssize_t)(p->cur - s);
+}
+
+static ssize_t
+fmemopen_write(void *cookie, const void *buf, size_t nbytes)
+{
+	struct fmemopen_cookie *p;
+	char *s;
+	const char *b = buf;
+
+	_DIAGASSERT(cookie != NULL);
+	_DIAGASSERT(buf != NULL && nbytes > 0);
+
+	p = (struct fmemopen_cookie *)cookie;
+	if (p->cur >= p->tail)
+		return 0;
+	s = p->cur;
+	do {
+		if (p->cur == p->tail - 1) {
+			if (*b == '\0') {
+				*p->cur++ = '\0';
+				goto ok;
+			}
+			break;
+		}
+		*p->cur++ = *b++;
+	} while (--nbytes > 0);
+	*p->cur = '\0';
+ok:
+	if (p->cur > p->eob)
+		p->eob = p->cur;
+
+	return (ssize_t)(p->cur - s);
+}
+
+#ifdef notyet
+static int
+fmemopen_flush(void *cookie)
+{
+	struct fmemopen_cookie *p;
+
+	_DIAGASSERT(cookie != NULL);
+
+	p = (struct fmemopen_cookie *)cookie;
+	if (p->cur >= p->tail)
+		return -1;
+	*p->cur = '\0';
+	return 0;
+}
+#endif
+
+static off_t
+fmemopen_seek(void *cookie, off_t offset, int whence)
+{
+	struct fmemopen_cookie *p;
+ 
+	_DIAGASSERT(cookie != NULL);
+
+	p = (struct fmemopen_cookie *)cookie;
+	switch (whence) {
+	case SEEK_SET:
+		break;
+	case SEEK_CUR:
+		offset += p->cur - p->head;
+		break;
+	case SEEK_END:
+		offset += p->eob - p->head;
+		break;
+	default:
+		errno = EINVAL;
+		goto error;
+	}
+	if (offset >= (off_t)0 && offset <= p->tail - p->head) {
+		p->cur = p->head + (ptrdiff_t)offset;
+		return (off_t)(p->cur - p->head);
+	}
+error:
+	return (off_t)-1;
+}
+
+static int
+fmemopen_close0(void *cookie)
+{
+	_DIAGASSERT(cookie != NULL);
+
+	free(cookie);
+
+	return 0;
+}
+
+static int
+fmemopen_close1(void *cookie)
+{
+	struct fmemopen_cookie *p;
+
+	_DIAGASSERT(cookie != NULL);
+
+	p = (struct fmemopen_cookie *)cookie;
+	free(p->head);
+	free(p);
+
+	return 0;
+}
+
+
+FILE *
+fmemopen(void * __restrict buf, size_t size, const char * __restrict mode)
+{
+	int flags, oflags;
+	FILE *fp;
+	struct fmemopen_cookie *cookie;
+
+	if (size < (size_t)1)
+		goto invalid;
+
+	flags = __sflags(mode, &oflags);
+	if (flags == 0)
+		return NULL;
+
+	if ((oflags & O_RDWR) == 0 && buf == NULL)
+		goto invalid;
+
+	fp = __sfp();
+	if (fp == NULL)
+		return NULL;
+	fp->_file = -1;
+
+	cookie = malloc(sizeof(*cookie));
+	if (cookie == NULL)
+		goto release;
+
+	if (buf == NULL) {
+		cookie->head = malloc(size);
+		if (cookie->head == NULL) {
+			free(cookie);
+			goto release;
+		}
+		*cookie->head = '\0';
+		fp->_close = fmemopen_close1;
+	} else {
+		cookie->head = (char *)buf;
+		if (oflags & O_TRUNC)
+			*cookie->head = '\0';
+		fp->_close = fmemopen_close0;
+	}
+
+	cookie->tail = cookie->head + size;
+	cookie->eob  = cookie->head;
+	do {
+		if (*cookie->eob == '\0')
+			break;
+		++cookie->eob;
+	} while (--size > 0);
+
+	cookie->cur = (oflags & O_APPEND) ? cookie->eob : cookie->head;
+
+	fp->_flags  = flags;
+	fp->_write  = (flags & __SRD) ? NULL : fmemopen_write;
+	fp->_read   = (flags & __SWR) ? NULL : fmemopen_read;
+	fp->_seek   = fmemopen_seek;
+#ifdef notyet
+	fp->_flush  = fmemopen_flush;
+#endif
+	fp->_cookie = (void *)cookie;
+
+	return fp;
+
+invalid:
+	errno = EINVAL;
+	return NULL;
+
+release:
+	fp->_flags = 0;
+	return NULL;
+}

--- a/lib/libc/stdlib/llabs.c
+++ b/lib/libc/stdlib/llabs.c
@@ -1,0 +1,40 @@
+/*	$NetBSD: llabs.c,v 1.4 2012/06/25 22:32:45 abs Exp $	*/
+
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <stdlib.h>
+
+/* LONGLONG */
+long long int
+llabs(long long int j)
+{
+	return (j < 0 ? -j : j);
+}

--- a/lib/libc/string/aarch64/bcopy.S
+++ b/lib/libc/string/aarch64/bcopy.S
@@ -278,7 +278,7 @@ backward_tiny:
 	ret
 9:
 	/* length is small(<32), and src or dst may be unaligned */
-	eor	TMP_X, SRC0, DST0
+	eor	TMP_X, SRC0, DST
 	ands	TMP_X, TMP_X, #7
 	bne	notaligned_backward_small
 

--- a/lib/libc/string/aarch64/bcopy.S
+++ b/lib/libc/string/aarch64/bcopy.S
@@ -277,6 +277,28 @@ backward_tiny:
 8:
 	ret
 9:
+	/* At this moment SRC0 and DST0 point at the end of 'src' buffer and the 
+	beginning of 'dest' buffer respectively. Therefore, after executing:
+
+	eor	 TMP_X, SRC0, DST0
+	ands TMP_X, TMP_X, #7
+	bne	notaligned_backward_small
+	
+	we may end up executing samealign_backward_small even though the ends of 
+	'src' and 'dest' buffers are not same-aligned!
+	Example values, for which this bug is triggered:
+	SRC0 = 0x8002510
+	DST0 = 0x8007813
+	LEN  = 0xB
+
+	A pointer to the end of 'dest' buffer is DST - that's the value, which shall be
+	used in the eor instruction instead of DST0 (because we want to check the alignment
+	of buffers' ends).
+
+	I discovered this bug while analyzing ksh crash due to SIGBUS. It turned out, that 
+	when I triggered autocompletion for a path, which was 11 characters long, ksh tried
+	to execute memmove with the above-mentioned values.*/
+	
 	/* length is small(<32), and src or dst may be unaligned */
 	eor	TMP_X, SRC0, DST
 	ands	TMP_X, TMP_X, #7

--- a/lib/libc/sys/creat.c
+++ b/lib/libc/sys/creat.c
@@ -1,0 +1,44 @@
+/*	$NetBSD: creat.c,v 1.10 2003/08/07 16:42:39 agc Exp $	*/
+
+/*
+ * Copyright (c) 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+
+int
+creat(const char *path, mode_t mode)
+{
+
+	_DIAGASSERT(path != NULL);
+
+	return(open(path, O_WRONLY|O_CREAT|O_TRUNC, mode));
+}


### PR DESCRIPTION
This PR adds functions, defines and fixes needed for porting suckless sbase:
- POSIX ARG_MAX, NAME_MAX, PATH_MAX values
- fmemopen()
- llabs()
- add missing include in include/sys/ioctl.h
- fix for aarch64/bcopy.S (memmove function)
- creat() - wrapper for open syscall