### PR TITLE
Fix kernel memory allocation on large blocks

### DIFF
--- a/include/sys/syslimits.h
+++ b/include/sys/syslimits.h
@@ -37,11 +37,7 @@
 #ifndef _SYS_SYSLIMITS_H_
 #define _SYS_SYSLIMITS_H_
 
-#if 0
 #define ARG_MAX 65536 /* max bytes for an exec function */
-#else
-#define ARG_MAX 3072 /* XXX: less than a page until kmalloc is fixed */
-#endif
 #ifndef CHILD_MAX
 #define CHILD_MAX 40 /* max simultaneous processes */
 #endif

--- a/sys/kern/kmem.c
+++ b/sys/kern/kmem.c
@@ -88,9 +88,10 @@ void kva_map(vaddr_t ptr, size_t size, kmem_flags_t flags) {
     kick_swapper();
 
   vaddr_t va = ptr;
-  vm_page_t *pg;
-  TAILQ_FOREACH (pg, &pglist, pageq) {
+  vm_page_t *pg, *pg_next;
+  TAILQ_FOREACH_SAFE (pg, &pglist, pageq, pg_next) {
     kva_map_page(va, pg->paddr, pg->size, 0);
+    pg->slab = NULL;
     va += pg->size * PAGESIZE;
   }
 

--- a/sys/kern/malloc.c
+++ b/sys/kern/malloc.c
@@ -106,6 +106,8 @@ void kfree(kmalloc_pool_t *mp, void *ptr) {
   if ((slab = blk_slab(ptr))) {
     pool_t *pool = slab->ph_pool;
 
+    assert(pool != NULL);
+
     blksz = slab->ph_itemsize;
 #if KASAN
     blksz -= pool->pp_redzone;


### PR DESCRIPTION
ARG_MAX value is changed from 3072 to 65536, `kva_map` and `kfree` are fixed