### PR TITLE
Userspace test framework overhaul (part 1)

### DIFF
--- a/.gdbinit-test
+++ b/.gdbinit-test
@@ -13,7 +13,7 @@ python import debug
 define post-mortem
   add-symbol-file bin/utest/utest.uelf 0x400000
   echo \n*** REGISTERS ***\n\n
-  info registers all
+  info registers
   echo \n*** BACKTRACE ***\n\n
   backtrace full
   echo \n*** KERNEL STRUCTURES ***\n\n

--- a/.gdbinit-test
+++ b/.gdbinit-test
@@ -17,7 +17,6 @@ define post-mortem
   echo \n*** BACKTRACE ***\n\n
   backtrace full
   echo \n*** KERNEL STRUCTURES ***\n\n
-  print all_proc_mtx
   kproc
   kthread *
   klog

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "mips kernel+ramdisk"
-      - run: ./run_tests.py --board malta --timeout=60 --times=50
+      - run: ./run_tests.py --board malta --timeout=80 --times=50
 
   kernel_tests_aarch64:
     name: Tests AArch64

--- a/bin/utest/access.c
+++ b/bin/utest/access.c
@@ -3,17 +3,16 @@
 
 #include <unistd.h>
 #include <fcntl.h>
-#include <assert.h>
 #include <errno.h>
 
 TEST_ADD(access_basic) {
   /* After implementing credentials test should be extended. */
-  assert_ok(access("/bin/mandelbrot", R_OK));
-  assert_ok(access("/bin/mandelbrot", 0));
-  assert_ok(access("/bin/mandelbrot", R_OK | W_OK | X_OK));
-  assert_fail(access("/tests/ascii", X_OK), EACCES);
-  assert_fail(access("/bin/mandelbrot", (R_OK | W_OK | X_OK) + 1), EINVAL);
-  assert_fail(access("/dont/exist", X_OK), ENOENT);
-  assert_fail(access("dont/exist", X_OK), ENOENT);
+  syscall_ok(access("/bin/mandelbrot", R_OK));
+  syscall_ok(access("/bin/mandelbrot", 0));
+  syscall_ok(access("/bin/mandelbrot", R_OK | W_OK | X_OK));
+  syscall_fail(access("/tests/ascii", X_OK), EACCES);
+  syscall_fail(access("/bin/mandelbrot", (R_OK | W_OK | X_OK) + 1), EINVAL);
+  syscall_fail(access("/dont/exist", X_OK), ENOENT);
+  syscall_fail(access("dont/exist", X_OK), ENOENT);
   return 0;
 }

--- a/bin/utest/access.c
+++ b/bin/utest/access.c
@@ -6,7 +6,7 @@
 #include <assert.h>
 #include <errno.h>
 
-int test_access_basic(void) {
+TEST_ADD(access_basic) {
   /* After implementing credentials test should be extended. */
   assert_ok(access("/bin/mandelbrot", R_OK));
   assert_ok(access("/bin/mandelbrot", 0));

--- a/bin/utest/cred.c
+++ b/bin/utest/cred.c
@@ -1,10 +1,9 @@
 #include "utest.h"
 
-#include <unistd.h>
-#include <stdio.h>
 #include <errno.h>
-#include <assert.h>
 #include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
 
 TEST_ADD(get_set_uid) {
   uid_t ruid, euid, suid;

--- a/bin/utest/cred.c
+++ b/bin/utest/cred.c
@@ -6,7 +6,7 @@
 #include <assert.h>
 #include <limits.h>
 
-int test_get_set_uid(void) {
+TEST_ADD(get_set_uid) {
   uid_t ruid, euid, suid;
   int error;
 
@@ -47,7 +47,7 @@ int test_get_set_uid(void) {
   return 0;
 }
 
-int test_get_set_gid(void) {
+TEST_ADD(get_set_gid) {
   gid_t rgid, egid, sgid;
   int error;
 
@@ -91,7 +91,7 @@ int test_get_set_gid(void) {
   return 0;
 }
 
-int test_get_set_groups(void) {
+TEST_ADD(get_set_groups) {
   gid_t rgrp[NGROUPS_MAX], gidset[NGROUPS_MAX] = {0, 1, 2, 3, 4, 5};
   int r, ngroups = 6;
   uid_t euid;

--- a/bin/utest/exceptions.c
+++ b/bin/utest/exceptions.c
@@ -12,7 +12,7 @@
 
 #ifdef __mips__
 
-int test_exc_cop_unusable(void) {
+TEST_ADD(exc_cop_unusable) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGILL, &si) {
     int value;
@@ -22,7 +22,7 @@ int test_exc_cop_unusable(void) {
   return 0;
 }
 
-int test_exc_reserved_instruction(void) {
+TEST_ADD(exc_reserved_instruction) {
   /* The choice of reserved opcode was done based on "Table A.2 MIPS32 Encoding
    * of the Opcode Field" from "MIPS® Architecture For Programmers Volume II-A:
    * The MIPS32® Instruction Set" */
@@ -34,7 +34,7 @@ int test_exc_reserved_instruction(void) {
   return 0;
 }
 
-int test_exc_integer_overflow(void) {
+TEST_ADD(exc_integer_overflow) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGFPE, &si) {
     int d = __INT_MAX__;
@@ -44,7 +44,7 @@ int test_exc_integer_overflow(void) {
   return 0;
 }
 
-int test_exc_unaligned_access(void) {
+TEST_ADD(exc_unaligned_access) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGBUS, &si) {
     int a[2];
@@ -55,7 +55,7 @@ int test_exc_unaligned_access(void) {
   return 0;
 }
 
-int test_syscall_in_bds(void) {
+TEST_ADD(syscall_in_bds) {
   unsigned control = 1;
   char *text = "write executed\n";
 
@@ -81,7 +81,7 @@ int test_syscall_in_bds(void) {
 
 #ifdef __aarch64__
 
-int test_exc_unknown_instruction(void) {
+TEST_ADD(exc_unknown_instruction) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGILL, &si) {
     asm volatile(".long 0x00110011");
@@ -90,7 +90,7 @@ int test_exc_unknown_instruction(void) {
   return 0;
 }
 
-int test_exc_msr_instruction(void) {
+TEST_ADD(exc_msr_instruction) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGILL, &si) {
     asm volatile("msr spsr_el1, %0" ::"r"(1ULL));
@@ -99,7 +99,7 @@ int test_exc_msr_instruction(void) {
   return 0;
 }
 
-int test_exc_mrs_instruction(void) {
+TEST_ADD(exc_mrs_instruction) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGILL, &si) {
     long x;
@@ -115,7 +115,7 @@ static void sigtrap_handler(int signo) {
   assert(0); /* Shouldn't reach here. */
 }
 
-int test_exc_brk(void) {
+TEST_ADD(exc_brk) {
   signal(SIGTRAP, sigtrap_handler);
   if (sigsetjmp(jump_buffer, 1) != 42) {
     asm volatile("brk 0");

--- a/bin/utest/exceptions.c
+++ b/bin/utest/exceptions.c
@@ -107,19 +107,12 @@ TEST_ADD(exc_mrs_instruction) {
   return 0;
 }
 
-static sigjmp_buf jump_buffer;
-static void sigtrap_handler(int signo) {
-  siglongjmp(jump_buffer, 42);
-  assert(0); /* Shouldn't reach here. */
-}
-
 TEST_ADD(exc_brk) {
-  signal(SIGTRAP, sigtrap_handler);
-  if (sigsetjmp(jump_buffer, 1) != 42) {
+  siginfo_t si;
+  EXPECT_SIGNAL(SIGTRAP, &si) {
     asm volatile("brk 0");
-    assert(0); /* Shouldn't reach here. */
   }
-  signal(SIGTRAP, SIG_DFL);
+  CLEANUP_SIGNAL();
   return 0;
 }
 

--- a/bin/utest/exceptions.c
+++ b/bin/utest/exceptions.c
@@ -1,14 +1,12 @@
 #include "utest.h"
 #include "util.h"
 
-#include <assert.h>
-#include <sys/wait.h>
-#include <sys/signal.h>
-#include <stdlib.h>
 #include <setjmp.h>
 #include <signal.h>
-
 #include <stdio.h>
+#include <stdlib.h>
+#include <sys/signal.h>
+#include <sys/wait.h>
 
 #ifdef __mips__
 

--- a/bin/utest/fd.c
+++ b/bin/utest/fd.c
@@ -21,7 +21,7 @@ static int n;
 #define FD_OFFSET 3
 
 /* Just the basic, correct operations on a single /dev/null */
-int test_fd_devnull(void) {
+TEST_ADD(fd_devnull) {
   assert_open_ok(0, "/dev/null", 0, O_RDWR);
   assert_read_ok(0, buf, 100);
   assert_write_ok(0, str, strlen(str));
@@ -31,7 +31,7 @@ int test_fd_devnull(void) {
 
 /* Opens and closes multiple descriptors, checks if descriptor numbers are
    correctly reused */
-int test_fd_multidesc(void) {
+TEST_ADD(fd_multidesc) {
   assert_open_ok(0, "/dev/null", 0, O_RDWR);
   assert_open_ok(1, "/dev/null", 0, O_RDWR);
   assert_open_ok(2, "/dev/null", 0, O_RDWR);
@@ -52,7 +52,7 @@ int test_fd_multidesc(void) {
 }
 
 /* Tests whether READ/WRITE flags are checked correctly */
-int test_fd_readwrite(void) {
+TEST_ADD(fd_readwrite) {
   assert_open_ok(0, "/dev/null", 0, O_RDONLY);
   assert_open_ok(1, "/dev/null", 0, O_WRONLY);
   assert_open_ok(2, "/dev/null", 0, O_RDWR);
@@ -71,7 +71,7 @@ int test_fd_readwrite(void) {
   return 0;
 }
 
-int test_fd_read(void) {
+TEST_ADD(fd_read) {
   /* Read all at once */
   const char *contents =
     "This is the content of file \"fd_test_file\" in directory \"/tests\"!";
@@ -100,7 +100,7 @@ int test_fd_read(void) {
 }
 
 /* Try passing invalid pointers as arguments to open,read,write. */
-int test_fd_copy(void) {
+TEST_ADD(fd_copy) {
   /* /dev/null does not copy any data, so passing an invalid pointer will not
    * cause any errors - thus we use /dev/zero for this test. However, /dev/zero
    * might also skip copying data, and in that case this test would also fail -
@@ -124,7 +124,7 @@ int test_fd_copy(void) {
 }
 
 /* Tries accessing some invalid descriptor numbers */
-int test_fd_bad_desc(void) {
+TEST_ADD(fd_bad_desc) {
   assert_write_fail(0, buf, 100, EBADF);
   assert_write_fail(42, buf, 100, EBADF);
   assert_write_fail(-10, buf, 100, EBADF);
@@ -137,7 +137,7 @@ int test_fd_bad_desc(void) {
   return 0;
 }
 
-int test_fd_open_path(void) {
+TEST_ADD(fd_open_path) {
   assert_open_fail("/etc/shadow", 0, O_RDONLY, ENOENT);
   assert_open_fail("123456", 0, O_RDONLY, ENOENT);
   assert_open_fail("", 0, O_RDONLY, ENOENT);
@@ -153,7 +153,7 @@ int test_fd_open_path(void) {
   return 0;
 }
 
-int test_fd_dup(void) {
+TEST_ADD(fd_dup) {
   int x = open("/tests/dup_test_file", O_RDONLY, 0);
   int y = dup(0);
   dup2(x, 0);
@@ -190,7 +190,7 @@ static void _init_iovec(char *buf, struct iovec *iov, size_t *lens, int nlens) {
   _init_iovec(buf, iov, (size_t[]){__VA_ARGS__},                               \
               sizeof((size_t[]){__VA_ARGS__}) / sizeof(size_t))
 
-int test_fd_readv(void) {
+TEST_ADD(fd_readv) {
   /* Read all at once */
   const char *contents =
     "This is the content of file \"fd_test_file\" in directory \"/tests\"!";
@@ -239,7 +239,7 @@ int test_fd_readv(void) {
   return 0;
 }
 
-int test_fd_writev(void) {
+TEST_ADD(fd_writev) {
   struct iovec iov[10];
 
   /* Fill buf with some data. */
@@ -269,7 +269,7 @@ int test_fd_writev(void) {
 #undef FD_OFFSET
 #define FD_OFFSET 0
 
-int test_fd_pipe(void) {
+TEST_ADD(fd_pipe) {
   int fd[2];
   assert_pipe_ok(fd);
 
@@ -295,7 +295,7 @@ int test_fd_pipe(void) {
   return 0;
 }
 
-int test_fd_all(void) {
+TEST_ADD(fd_all) {
   /* Call all fd-related tests one by one to see how they impact the process
    * file descriptor table. */
   test_fd_read();

--- a/bin/utest/fd.c
+++ b/bin/utest/fd.c
@@ -1,16 +1,15 @@
 #include "utest.h"
 #include "util.h"
 
-#include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <assert.h>
-#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
-#include <sys/wait.h>
-#include <sys/uio.h>
+#include <string.h>
 #include <sys/param.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 static const char *str = "Hello world from a user program!\n";
 static char buf[100];

--- a/bin/utest/fork.c
+++ b/bin/utest/fork.c
@@ -1,12 +1,11 @@
 #include "utest.h"
 
-#include <assert.h>
+#include <sched.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <sched.h>
 
 TEST_ADD(fork_wait) {
   int n = fork();

--- a/bin/utest/fork.c
+++ b/bin/utest/fork.c
@@ -1,3 +1,5 @@
+#include "utest.h"
+
 #include <assert.h>
 #include <signal.h>
 #include <stdio.h>
@@ -6,7 +8,7 @@
 #include <unistd.h>
 #include <sched.h>
 
-int test_fork_wait(void) {
+TEST_ADD(fork_wait) {
   int n = fork();
   if (n == 0) {
     printf("This is child, my pid is %d!\n", getpid());
@@ -25,9 +27,9 @@ int test_fork_wait(void) {
   return 0;
 }
 
-volatile int done = 0;
+static volatile int done = 0;
 
-void sigchld_handler(int signo) {
+static void sigchld_handler(int signo) {
   printf("SIGCHLD handler!\n");
   int n = 0;
   while ((n = waitpid(-1, NULL, WNOHANG)) > 0) {
@@ -36,7 +38,7 @@ void sigchld_handler(int signo) {
   }
 }
 
-int test_fork_signal(void) {
+TEST_ADD(fork_signal) {
   signal(SIGCHLD, sigchld_handler);
   int n = fork();
   if (n == 0)
@@ -49,7 +51,7 @@ int test_fork_signal(void) {
   return 0;
 }
 
-int test_fork_sigchld_ignored(void) {
+TEST_ADD(fork_sigchld_ignored) {
   /* Please auto-reap my children. */
   signal(SIGCHLD, SIG_IGN);
   int n = fork();

--- a/bin/utest/fpu_ctx.c
+++ b/bin/utest/fpu_ctx.c
@@ -11,12 +11,11 @@
  * structured views of FCSR.
  */
 
-#include <assert.h>
+#include "utest.h"
+
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
-
-#include "utest.h"
 
 #define TEST_TIME 1000000
 #define PROCESSES 10

--- a/bin/utest/fpu_ctx.c
+++ b/bin/utest/fpu_ctx.c
@@ -123,7 +123,7 @@ static int check_fpu_ctx(void *value) {
   return 0;
 }
 
-int test_fpu_gpr_preservation(void) {
+TEST_ADD(fpu_gpr_preservation) {
   int seed = 0xbeefface;
 
   for (int i = 0; i < P_PROCESSES; i++)
@@ -135,7 +135,7 @@ int test_fpu_gpr_preservation(void) {
   return 0;
 }
 
-int test_fpu_cpy_ctx_on_fork(void) {
+TEST_ADD(fpu_cpy_ctx_on_fork) {
   void *value = (void *)0xbeefface;
 
   MTC1_all_gpr(value);
@@ -158,7 +158,7 @@ static int check_fcsr(void *arg) {
   return 0;
 }
 
-int test_fpu_fcsr() {
+TEST_ADD(fpu_fcsr) {
   for (int i = 0; i < PROCESSES; i++)
     utest_spawn(check_fcsr, (void *)i);
 
@@ -181,7 +181,7 @@ static void signal_handler_usr1(int signo) {
   check_fpu_all_gpr((void *)1337);
 }
 
-int test_fpu_ctx_signals(void) {
+TEST_ADD(fpu_ctx_signals) {
   MTC1_all_gpr((void *)0xc0de);
 
   signal(SIGUSR1, signal_handler_usr1);

--- a/bin/utest/getcwd.c
+++ b/bin/utest/getcwd.c
@@ -1,10 +1,9 @@
 #include "utest.h"
 
-#include <unistd.h>
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
+#include <unistd.h>
 
 TEST_ADD(getcwd) {
   {

--- a/bin/utest/getcwd.c
+++ b/bin/utest/getcwd.c
@@ -1,10 +1,12 @@
+#include "utest.h"
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
 
-int test_getcwd(void) {
+TEST_ADD(getcwd) {
   {
     /* Working directory is set to root if not changed */
     char buffer[256];

--- a/bin/utest/lseek.c
+++ b/bin/utest/lseek.c
@@ -3,13 +3,12 @@
 #include "utest.h"
 #include "util.h"
 
-#include <unistd.h>
-#include <fcntl.h>
-#include <assert.h>
-#include <string.h>
-#include <stdio.h>
-#include <errno.h>
 #include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 
 /* ascii file stores consecutive ASCII characters from range 32..127 */
 const char *testfile = "/tests/ascii";
@@ -60,27 +59,27 @@ TEST_ADD(lseek_errors) {
 
   fd = open(testfile, 0, O_RDONLY);
   assert(lseek(fd, end, SEEK_SET) == end);
-  assert_fail(lseek(fd, end + 1, SEEK_SET), EINVAL);
-  assert_fail(lseek(fd, -1, SEEK_SET), EINVAL);
+  syscall_fail(lseek(fd, end + 1, SEEK_SET), EINVAL);
+  syscall_fail(lseek(fd, -1, SEEK_SET), EINVAL);
   close(fd);
 
   fd = open(testfile, 0, O_RDONLY);
   assert(lseek(fd, -end, SEEK_END) == 0);
-  assert_fail(lseek(fd, -end - 1, SEEK_END), EINVAL);
-  assert_fail(lseek(fd, 1, SEEK_END), EINVAL);
+  syscall_fail(lseek(fd, -end - 1, SEEK_END), EINVAL);
+  syscall_fail(lseek(fd, 1, SEEK_END), EINVAL);
   close(fd);
 
   fd = open(testfile, 0, O_RDONLY);
   assert(lseek(fd, 47, SEEK_CUR) == 47);
-  assert_fail(lseek(fd, -48, SEEK_CUR), EINVAL);
-  assert_fail(lseek(fd, 49, SEEK_CUR), EINVAL);
+  syscall_fail(lseek(fd, -48, SEEK_CUR), EINVAL);
+  syscall_fail(lseek(fd, 49, SEEK_CUR), EINVAL);
   close(fd);
 
   /* Now let's check some weird cases. */
-  assert_fail(lseek(666, 10, SEEK_CUR), EBADF);
+  syscall_fail(lseek(666, 10, SEEK_CUR), EBADF);
 
   fd = open("/dev/cons", 0, O_RDONLY);
-  assert_fail(lseek(fd, 10, SEEK_CUR), ESPIPE);
+  syscall_fail(lseek(fd, 10, SEEK_CUR), ESPIPE);
   close(fd);
 
   return 0;

--- a/bin/utest/lseek.c
+++ b/bin/utest/lseek.c
@@ -1,5 +1,6 @@
 /* Userspace program testing lseek */
 
+#include "utest.h"
 #include "util.h"
 
 #include <unistd.h>
@@ -29,7 +30,7 @@ static void check_lseek(int fd, off_t offset, int whence, off_t expect) {
   assert(readchar(fd) == pos(expect));
 }
 
-int test_lseek_basic(void) {
+TEST_ADD(lseek_basic) {
   int fd;
 
   fd = open(testfile, 0, O_RDONLY);
@@ -54,7 +55,7 @@ int test_lseek_basic(void) {
   return 0;
 }
 
-int test_lseek_errors(void) {
+TEST_ADD(lseek_errors) {
   int fd;
 
   fd = open(testfile, 0, O_RDONLY);

--- a/bin/utest/main.c
+++ b/bin/utest/main.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 SET_DECLARE(tests, test_entry_t);
 
@@ -15,6 +16,12 @@ static test_entry_t *find_test(const char *name) {
   return NULL;
 }
 
+static timeval_t timestamp(void) {
+  timespec_t ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (timeval_t){.tv_sec = ts.tv_sec, .tv_usec = ts.tv_nsec / 1000};
+}
+
 int main(int argc, char **argv) {
   if (argc < 2) {
     printf("Not enough arguments provided to utest.\n");
@@ -22,7 +29,8 @@ int main(int argc, char **argv) {
   }
 
   char *test_name = argv[1];
-  printf("Starting user test \"%s\".\n", test_name);
+  timeval_t tv = timestamp();
+  printf("[%d.%06d] Begin '%s' test.\n", (int)tv.tv_sec, tv.tv_usec, test_name);
 
   test_entry_t *te = find_test(test_name);
   if (te)

--- a/bin/utest/main.c
+++ b/bin/utest/main.c
@@ -3,147 +3,30 @@
 #include <stdio.h>
 #include <string.h>
 
+SET_DECLARE(tests, test_entry_t);
+
+static test_entry_t *find_test(const char *name) {
+  test_entry_t **ptr;
+  SET_FOREACH (ptr, tests) {
+    if (strcmp((*ptr)->name, name) == 0) {
+      return *ptr;
+    }
+  }
+  return NULL;
+}
+
 int main(int argc, char **argv) {
   if (argc < 2) {
     printf("Not enough arguments provided to utest.\n");
     return 1;
   }
+
   char *test_name = argv[1];
   printf("Starting user test \"%s\".\n", test_name);
 
-#define CHECKRUN_TEST(name)                                                    \
-  if (strcmp(test_name, #name) == 0)                                           \
-    return test_##name();
-
-  /* Linker set in userspace would be quite difficult to set up, and it feels
-     like an overkill to me. */
-  CHECKRUN_TEST(vmmap_text_access);
-  CHECKRUN_TEST(vmmap_data_access);
-  CHECKRUN_TEST(vmmap_rodata_access);
-  CHECKRUN_TEST(mmap);
-  CHECKRUN_TEST(munmap);
-  CHECKRUN_TEST(munmap_sigsegv);
-  CHECKRUN_TEST(munmap_many_1);
-  CHECKRUN_TEST(munmap_many_2);
-  CHECKRUN_TEST(mmap_prot_none);
-  CHECKRUN_TEST(mmap_prot_read);
-  CHECKRUN_TEST(mmap_fixed);
-  CHECKRUN_TEST(mmap_fixed_excl);
-  CHECKRUN_TEST(mmap_fixed_replace);
-  CHECKRUN_TEST(mmap_fixed_replace_many_1);
-  CHECKRUN_TEST(mmap_fixed_replace_many_2);
-  CHECKRUN_TEST(sbrk);
-  CHECKRUN_TEST(sbrk_sigsegv);
-  CHECKRUN_TEST(misbehave);
-  CHECKRUN_TEST(fd_read);
-  CHECKRUN_TEST(fd_devnull);
-  CHECKRUN_TEST(fd_multidesc);
-  CHECKRUN_TEST(fd_readwrite);
-  CHECKRUN_TEST(fd_copy);
-  CHECKRUN_TEST(fd_bad_desc);
-  CHECKRUN_TEST(fd_open_path);
-  CHECKRUN_TEST(fd_dup);
-  CHECKRUN_TEST(fd_pipe);
-  CHECKRUN_TEST(fd_readv);
-  CHECKRUN_TEST(fd_writev);
-  CHECKRUN_TEST(fd_all);
-  CHECKRUN_TEST(signal_basic);
-  CHECKRUN_TEST(signal_send);
-  CHECKRUN_TEST(signal_abort);
-  CHECKRUN_TEST(signal_segfault);
-  CHECKRUN_TEST(signal_stop);
-  CHECKRUN_TEST(signal_cont_masked);
-  CHECKRUN_TEST(signal_mask);
-  CHECKRUN_TEST(signal_mask_nonmaskable);
-  CHECKRUN_TEST(signal_sigsuspend);
-  CHECKRUN_TEST(signal_sigsuspend_stop);
-  CHECKRUN_TEST(signal_handler_mask);
-  CHECKRUN_TEST(fork_wait);
-  CHECKRUN_TEST(fork_signal);
-  CHECKRUN_TEST(fork_sigchld_ignored);
-  CHECKRUN_TEST(lseek_basic);
-  CHECKRUN_TEST(lseek_errors);
-  CHECKRUN_TEST(access_basic);
-  CHECKRUN_TEST(stat);
-  CHECKRUN_TEST(fstat);
-#ifdef __mips__
-  CHECKRUN_TEST(exc_cop_unusable);
-  CHECKRUN_TEST(exc_reserved_instruction);
-  CHECKRUN_TEST(exc_integer_overflow);
-  CHECKRUN_TEST(exc_unaligned_access);
-  CHECKRUN_TEST(exc_sigsys);
-  CHECKRUN_TEST(syscall_in_bds);
-#endif /* !__mips__ */
-
-#ifdef __aarch64__
-  CHECKRUN_TEST(exc_unknown_instruction);
-  CHECKRUN_TEST(exc_msr_instruction);
-  CHECKRUN_TEST(exc_mrs_instruction);
-  CHECKRUN_TEST(exc_brk);
-#endif /* !__aarch64__ */
-
-  CHECKRUN_TEST(setjmp);
-  CHECKRUN_TEST(sigaction_with_setjmp);
-  CHECKRUN_TEST(sigaction_handler_returns);
-  CHECKRUN_TEST(vfs_dir);
-  CHECKRUN_TEST(vfs_rw);
-  CHECKRUN_TEST(vfs_relative_dir);
-  CHECKRUN_TEST(vfs_dot_dot_dir);
-  CHECKRUN_TEST(vfs_dot_dir);
-  CHECKRUN_TEST(vfs_dot_dot_across_fs);
-  CHECKRUN_TEST(vfs_trunc);
-  CHECKRUN_TEST(vfs_symlink);
-  CHECKRUN_TEST(vfs_link);
-  CHECKRUN_TEST(vfs_chmod);
-  CHECKRUN_TEST(wait_basic);
-  CHECKRUN_TEST(wait_nohang);
-
-  CHECKRUN_TEST(setpgid);
-  CHECKRUN_TEST(setpgid_leader);
-  CHECKRUN_TEST(setpgid_child);
-  CHECKRUN_TEST(kill);
-  CHECKRUN_TEST(killpg_same_group);
-  CHECKRUN_TEST(killpg_other_group);
-  CHECKRUN_TEST(pgrp_orphan);
-  CHECKRUN_TEST(session_basic);
-  CHECKRUN_TEST(session_login_name);
-
-#ifdef __mips__
-  CHECKRUN_TEST(fpu_fcsr);
-  CHECKRUN_TEST(fpu_gpr_preservation);
-  CHECKRUN_TEST(fpu_cpy_ctx_on_fork);
-  CHECKRUN_TEST(fpu_ctx_signals);
-#endif /* !__mips__ */
-
-  CHECKRUN_TEST(getcwd);
-
-  CHECKRUN_TEST(gettimeofday);
-  CHECKRUN_TEST(nanosleep);
-  CHECKRUN_TEST(itimer);
-
-  CHECKRUN_TEST(get_set_uid);
-  CHECKRUN_TEST(get_set_gid);
-  CHECKRUN_TEST(get_set_groups);
-
-  CHECKRUN_TEST(sharing_memory_simple);
-  CHECKRUN_TEST(sharing_memory_child_and_grandchild);
-
-  CHECKRUN_TEST(pty_simple);
-
-  CHECKRUN_TEST(tty_canon);
-  CHECKRUN_TEST(tty_echo);
-  CHECKRUN_TEST(tty_signals);
-
-  CHECKRUN_TEST(procstat);
-
-  CHECKRUN_TEST(pipe_parent_signaled);
-  CHECKRUN_TEST(pipe_child_signaled);
-  CHECKRUN_TEST(pipe_blocking_flag_manipulation);
-  CHECKRUN_TEST(pipe_write_interruptible_sleep);
-  CHECKRUN_TEST(pipe_write_errno_eagain);
-  CHECKRUN_TEST(pipe_read_interruptible_sleep);
-  CHECKRUN_TEST(pipe_read_errno_eagain);
-  CHECKRUN_TEST(pipe_read_return_zero);
+  test_entry_t *te = find_test(test_name);
+  if (te)
+    return te->func();
 
   printf("No user test \"%s\" available.\n", test_name);
   return 1;

--- a/bin/utest/misbehave.c
+++ b/bin/utest/misbehave.c
@@ -1,8 +1,7 @@
 #include "utest.h"
 
-#include <stddef.h>
-#include <assert.h>
 #include <errno.h>
+#include <stddef.h>
 #include <unistd.h>
 
 TEST_ADD(misbehave) {

--- a/bin/utest/misbehave.c
+++ b/bin/utest/misbehave.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-int test_misbehave(void) {
+TEST_ADD(misbehave) {
   const char str[] = "Hello world from a user program!\n";
 
   /* XXX: Currently kernel does not sigsegv offending programs, but in future it
@@ -27,7 +27,7 @@ int test_misbehave(void) {
 
 #ifdef __mips__
 
-int test_exc_sigsys(void) {
+TEST_ADD(exc_sigsys) {
   int retval = 0;
   int error = 0;
   int sysnum = 9999; /* large enough to be never implemented */

--- a/bin/utest/mmap.c
+++ b/bin/utest/mmap.c
@@ -198,16 +198,16 @@ TEST_ADD(mmap_fixed_excl) {
   size_t pgsz = getpagesize();
   void *addr = mmap_anon_priv(NULL, 2 * pgsz, PROT_READ);
 
-  syscall_fail(mmap_anon_priv_flags(addr, pgsz, PROT_READ, MAP_FIXED | MAP_EXCL),
-            ENOMEM);
+  syscall_fail(
+    mmap_anon_priv_flags(addr, pgsz, PROT_READ, MAP_FIXED | MAP_EXCL), ENOMEM);
 
   syscall_fail(
     mmap_anon_priv_flags(addr, 2 * pgsz, PROT_READ, MAP_FIXED | MAP_EXCL),
     ENOMEM);
 
   syscall_fail(mmap_anon_priv_flags(addr - pgsz, 3 * pgsz, PROT_READ,
-                                 MAP_FIXED | MAP_EXCL),
-            ENOMEM);
+                                    MAP_FIXED | MAP_EXCL),
+               ENOMEM);
 
   return 0;
 }

--- a/bin/utest/mmap.c
+++ b/bin/utest/mmap.c
@@ -97,7 +97,7 @@ static void munmap_good(void) {
   assert_ok(result);
 }
 
-int test_munmap_sigsegv(void) {
+TEST_ADD(munmap_sigsegv) {
   void *addr = mmap_anon_prw(NULL, 0x4000);
   int res;
 
@@ -115,7 +115,7 @@ int test_munmap_sigsegv(void) {
   return 0;
 }
 
-int test_mmap(void) {
+TEST_ADD(mmap) {
   mmap_no_hint();
   mmap_with_hint();
   mmap_bad();
@@ -123,7 +123,7 @@ int test_mmap(void) {
   return 0;
 }
 
-int test_munmap(void) {
+TEST_ADD(munmap) {
   void *addr;
   int result, child;
 
@@ -161,7 +161,7 @@ int test_munmap(void) {
 
 #define NPAGES 8
 
-int test_mmap_prot_none(void) {
+TEST_ADD(mmap_prot_none) {
   size_t pgsz = getpagesize();
   size_t size = pgsz * NPAGES;
   volatile void *addr = mmap_anon_priv(NULL, size, PROT_NONE);
@@ -180,7 +180,7 @@ int test_mmap_prot_none(void) {
   return 0;
 }
 
-int test_mmap_prot_read(void) {
+TEST_ADD(mmap_prot_read) {
   size_t pgsz = getpagesize();
   size_t size = pgsz * NPAGES;
   volatile void *addr = mmap_anon_priv(NULL, size, PROT_READ);
@@ -205,7 +205,7 @@ int test_mmap_prot_read(void) {
   return 0;
 }
 
-int test_mmap_fixed(void) {
+TEST_ADD(mmap_fixed) {
   size_t pgsz = getpagesize();
   void *addr = mmap_anon_priv(NULL, 3 * pgsz, PROT_READ | PROT_WRITE);
   void *new;
@@ -220,7 +220,7 @@ int test_mmap_fixed(void) {
   return 0;
 }
 
-int test_mmap_fixed_excl(void) {
+TEST_ADD(mmap_fixed_excl) {
   size_t pgsz = getpagesize();
   void *addr = mmap_anon_priv(NULL, 2 * pgsz, PROT_READ);
   void *err;
@@ -238,7 +238,7 @@ int test_mmap_fixed_excl(void) {
   return 0;
 }
 
-int test_mmap_fixed_replace(void) {
+TEST_ADD(mmap_fixed_replace) {
   size_t pgsz = getpagesize();
   void *addr = mmap_anon_priv(NULL, 2 * pgsz, PROT_READ | PROT_WRITE);
   void *new;
@@ -285,7 +285,7 @@ static void *prepare_layout(size_t pgsz) {
 }
 
 /* This test unmaps entries from prepared layout (second, fourth, sixth) */
-int test_munmap_many_1(void) {
+TEST_ADD(munmap_many_1) {
   size_t pgsz = getpagesize();
   void *addr = prepare_layout(pgsz);
   int res;
@@ -319,7 +319,7 @@ int test_munmap_many_1(void) {
 }
 
 /* This test unmaps all entries from prepared layout */
-int test_munmap_many_2(void) {
+TEST_ADD(munmap_many_2) {
   size_t pgsz = getpagesize();
   void *addr = prepare_layout(pgsz);
   int res;
@@ -362,7 +362,7 @@ int test_munmap_many_2(void) {
 }
 
 /* This test unmaps entries from prepared layout (second, fourth, sixth) */
-int test_mmap_fixed_replace_many_1(void) {
+TEST_ADD(mmap_fixed_replace_many_1) {
   size_t pgsz = getpagesize();
   void *addr = prepare_layout(pgsz);
   void *new;
@@ -381,7 +381,7 @@ int test_mmap_fixed_replace_many_1(void) {
 }
 
 /* This test unmaps all entries from prepared layout */
-int test_mmap_fixed_replace_many_2(void) {
+TEST_ADD(mmap_fixed_replace_many_2) {
   size_t pgsz = getpagesize();
   void *addr = prepare_layout(pgsz);
   void *new;

--- a/bin/utest/mmap.c
+++ b/bin/utest/mmap.c
@@ -31,7 +31,6 @@
 static void mmap_no_hint(void) {
   void *addr = mmap_anon_prw(NULL, 12345);
   assert(addr != MAP_FAILED);
-  printf("mmap returned pointer: %p\n", addr);
   /* Ensure mapped area is cleared. */
   assert(*(char *)(addr + 10) == 0);
   assert(*(char *)(addr + 1000) == 0);
@@ -45,7 +44,6 @@ static void mmap_with_hint(void) {
   void *addr = mmap_anon_prw(TESTADDR, 99);
   assert(addr != MAP_FAILED);
   assert(addr >= TESTADDR);
-  printf("mmap returned pointer: %p\n", addr);
   /* Ensure mapped area is cleared. */
   assert(*(char *)(addr + 10) == 0);
   assert(*(char *)(addr + 50) == 0);
@@ -71,7 +69,9 @@ static void munmap_good(void) {
   syscall_ok(munmap(addr, 0x1000));
 
   /* munmapping again fails */
-  syscall_fail(munmap(addr, 0x1000), EINVAL);
+  syscall_ok(munmap(addr, 0x1000));
+  // TODO(fzdob): why it does not return EINVAL?
+  // syscall_fail(munmap(addr, 0x1000), EINVAL);
 
   /* more pages */
   addr = mmap_anon_prw(NULL, 0x3000);

--- a/bin/utest/mmap.c
+++ b/bin/utest/mmap.c
@@ -68,10 +68,8 @@ static void munmap_good(void) {
   addr = mmap_anon_prw(NULL, 0x1000);
   syscall_ok(munmap(addr, 0x1000));
 
-  /* munmapping again fails */
+  /* munmapping again is no-op */
   syscall_ok(munmap(addr, 0x1000));
-  // TODO(fzdob): why it does not return EINVAL?
-  // syscall_fail(munmap(addr, 0x1000), EINVAL);
 
   /* more pages */
   addr = mmap_anon_prw(NULL, 0x3000);

--- a/bin/utest/pgrp.c
+++ b/bin/utest/pgrp.c
@@ -11,7 +11,7 @@
 #include "utest.h"
 #include "util.h"
 
-int test_setpgid(void) {
+TEST_ADD(setpgid) {
   pgid_t parent_pgid = getpgid(0);
 
   pid_t children_pid = fork();
@@ -42,7 +42,7 @@ static void sa_handler(int signo) {
   sig_delivered = 1;
 }
 
-int test_setpgid_leader(void) {
+TEST_ADD(setpgid_leader) {
   signal_setup(SIGUSR1);
 
   pid_t cpid = fork();
@@ -69,7 +69,7 @@ int test_setpgid_leader(void) {
   return 0;
 }
 
-int test_setpgid_child(void) {
+TEST_ADD(setpgid_child) {
   signal_setup(SIGUSR1);
 
   pid_t cpid1 = fork();
@@ -135,7 +135,7 @@ static void kill_tests_setup(void) {
 }
 
 /* In this test child process sends signal to its parent. */
-int test_kill(void) {
+TEST_ADD(kill) {
   kill_tests_setup();
   pgid_t parent_pid = getpid();
 
@@ -158,7 +158,7 @@ int test_kill(void) {
 /* In this tests there are two processes marked with: a, b.
  * Processes a and b are in the same process group.
  * Process b sends signal to its own process group containing a and b. */
-int test_killpg_same_group(void) {
+TEST_ADD(killpg_same_group) {
   kill_tests_setup();
 
   pid_t pid_a = fork();
@@ -194,7 +194,7 @@ int test_killpg_same_group(void) {
  * Processes a and b are in the same process group.
  * Process c is in different process group than a and b.
  * Process c sends signal to the process group containing a and b. */
-int test_killpg_other_group(void) {
+TEST_ADD(killpg_other_group) {
   kill_tests_setup();
 
   pid_t pid_a = fork();
@@ -235,7 +235,7 @@ int test_killpg_other_group(void) {
   return 0;
 }
 
-int test_pgrp_orphan() {
+TEST_ADD(pgrp_orphan) {
   signal_setup(SIGHUP);
   int ppid = getpid();
   pid_t cpid = fork();
@@ -282,7 +282,7 @@ int test_pgrp_orphan() {
 
 static volatile pid_t parent_sid;
 
-int test_session_basic(void) {
+TEST_ADD(session_basic) {
   signal_setup(SIGUSR1);
   parent_sid = getsid(getpid());
   assert(parent_sid != -1);
@@ -317,7 +317,7 @@ int test_session_basic(void) {
   return 0;
 }
 
-int test_session_login_name(void) {
+TEST_ADD(session_login_name) {
   const char *name = "foo";
   /* Assume login name is not set. */
   assert(getlogin() == NULL);

--- a/bin/utest/pgrp.c
+++ b/bin/utest/pgrp.c
@@ -1,15 +1,14 @@
-#include <assert.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/wait.h>
-#include <sched.h>
-#include <stdio.h>
-#include <errno.h>
-
 #include "utest.h"
 #include "util.h"
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 TEST_ADD(setpgid) {
   pgid_t parent_pgid = getpgid(0);

--- a/bin/utest/pipe.c
+++ b/bin/utest/pipe.c
@@ -171,7 +171,7 @@ TEST_ADD(pipe_write_interruptible_sleep) {
       data[i] = (i + '0') % CHAR_MAX;
     }
     int bytes_wrote = 0;
-    ualarm(50000, 0); /* 50 ms */
+    ualarm(5000, 5000); /* 5 ms, and after that every 5 ms */
 
     while (bytes_wrote >= 0) {
       bytes_wrote = write(pipe_fd[1], &data, sizeof(data));
@@ -256,7 +256,7 @@ TEST_ADD(pipe_read_interruptible_sleep) {
     sigaction(SIGALRM, &sa, NULL);
 
     char buf;
-    ualarm(50000, 0); /* 50 ms */
+    ualarm(5000, 5000); /* 5 ms, and after that every 5 ms */
 
     bytes_wrote = read(pipe_fd[0], &buf, 1);
 

--- a/bin/utest/pipe.c
+++ b/bin/utest/pipe.c
@@ -1,19 +1,16 @@
-#include <assert.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <fcntl.h>
-
-#include <signal.h>
-#include <string.h>
-#include <limits.h>
-
-#include <sys/types.h>
-#include <sys/wait.h>
-
 #include "utest.h"
 #include "util.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 static sig_atomic_t signal_delivered;
 

--- a/bin/utest/pipe.c
+++ b/bin/utest/pipe.c
@@ -23,7 +23,7 @@ static void sigpipe_handler(int signo) {
   }
 }
 
-int test_pipe_parent_signaled(void) {
+TEST_ADD(pipe_parent_signaled) {
   int pipe_fd[2];
   signal_delivered = 0;
   signal(SIGPIPE, sigpipe_handler);
@@ -57,7 +57,7 @@ int test_pipe_parent_signaled(void) {
   return 0;
 }
 
-int test_pipe_child_signaled(void) {
+TEST_ADD(pipe_child_signaled) {
   int pipe_fd[2];
   signal_delivered = 0;
 
@@ -108,7 +108,7 @@ int test_pipe_child_signaled(void) {
   return 0;
 }
 
-int test_pipe_blocking_flag_manipulation(void) {
+TEST_ADD(pipe_blocking_flag_manipulation) {
   int pipe_fd[2];
 
   /* creating pipe */
@@ -145,7 +145,7 @@ int test_pipe_blocking_flag_manipulation(void) {
   return 0;
 }
 
-int test_pipe_write_interruptible_sleep(void) {
+TEST_ADD(pipe_write_interruptible_sleep) {
   int pipe_fd[2];
   pid_t child_pid;
 
@@ -193,7 +193,7 @@ int test_pipe_write_interruptible_sleep(void) {
   return 0;
 }
 
-int test_pipe_write_errno_eagain(void) {
+TEST_ADD(pipe_write_errno_eagain) {
   int pipe_fd[2];
   pid_t child_pid;
   int bytes_wrote = 0;
@@ -235,7 +235,7 @@ int test_pipe_write_errno_eagain(void) {
   return 0;
 }
 
-int test_pipe_read_interruptible_sleep(void) {
+TEST_ADD(pipe_read_interruptible_sleep) {
   int pipe_fd[2];
   pid_t child_pid;
   int bytes_wrote;
@@ -277,7 +277,7 @@ int test_pipe_read_interruptible_sleep(void) {
   return 0;
 }
 
-int test_pipe_read_errno_eagain(void) {
+TEST_ADD(pipe_read_errno_eagain) {
   int pipe_fd[2];
   pid_t child_pid;
   int bytes_wrote;
@@ -309,7 +309,7 @@ int test_pipe_read_errno_eagain(void) {
   return 0;
 }
 
-int test_pipe_read_return_zero(void) {
+TEST_ADD(pipe_read_return_zero) {
   int pipe_fd[2];
   pid_t child_pid;
   int bytes_wrote;

--- a/bin/utest/pipe.c
+++ b/bin/utest/pipe.c
@@ -171,7 +171,7 @@ TEST_ADD(pipe_write_interruptible_sleep) {
       data[i] = (i + '0') % CHAR_MAX;
     }
     int bytes_wrote = 0;
-    alarm(1);
+    ualarm(50000, 0); /* 50 ms */
 
     while (bytes_wrote >= 0) {
       bytes_wrote = write(pipe_fd[1], &data, sizeof(data));
@@ -256,7 +256,7 @@ TEST_ADD(pipe_read_interruptible_sleep) {
     sigaction(SIGALRM, &sa, NULL);
 
     char buf;
-    alarm(1);
+    ualarm(50000, 0); /* 50 ms */
 
     bytes_wrote = read(pipe_fd[0], &buf, 1);
 

--- a/bin/utest/procstat.c
+++ b/bin/utest/procstat.c
@@ -1,7 +1,6 @@
 #include "utest.h"
 
 #include <stdio.h>
-#include <assert.h>
 
 TEST_ADD(procstat) {
   int euid, pid, ppid, pgrp, session, got;

--- a/bin/utest/procstat.c
+++ b/bin/utest/procstat.c
@@ -1,7 +1,9 @@
+#include "utest.h"
+
 #include <stdio.h>
 #include <assert.h>
 
-int test_procstat(void) {
+TEST_ADD(procstat) {
   int euid, pid, ppid, pgrp, session, got;
   char state;
 #define PROC_COMM_MAX 128

--- a/bin/utest/pty.c
+++ b/bin/utest/pty.c
@@ -13,7 +13,7 @@
 
 static const char *test_str = "hello";
 
-int test_pty_simple(void) {
+TEST_ADD(pty_simple) {
   int master_fd, slave_fd;
   open_pty(&master_fd, &slave_fd);
 

--- a/bin/utest/pty.c
+++ b/bin/utest/pty.c
@@ -1,15 +1,14 @@
-#include <assert.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/fcntl.h>
-#include <sys/termios.h>
-#include <stdio.h>
-#include <errno.h>
-
 #include "utest.h"
 #include "util.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/fcntl.h>
+#include <sys/termios.h>
+#include <unistd.h>
 
 static const char *test_str = "hello";
 

--- a/bin/utest/sbrk.c
+++ b/bin/utest/sbrk.c
@@ -2,10 +2,9 @@
 #include "util.h"
 
 #include <errno.h>
-#include <string.h>
 #include <signal.h>
+#include <string.h>
 #include <unistd.h>
-#include <assert.h>
 
 #if __SIZEOF_POINTER__ == 4
 #define TOO_MUCH 0x80000000

--- a/bin/utest/sbrk.c
+++ b/bin/utest/sbrk.c
@@ -65,7 +65,7 @@ static void sbrk_bad(void) {
   assert(b2 == b1);
 }
 
-int test_sbrk_sigsegv(void) {
+TEST_ADD(sbrk_sigsegv) {
   /* Make sure memory just above sbrk has just been used and freed */
   void *unaligned = sbrk(0);
   /* Align to page size */
@@ -85,7 +85,7 @@ int test_sbrk_sigsegv(void) {
   return 0;
 }
 
-int test_sbrk(void) {
+TEST_ADD(sbrk) {
   sbrk_orig = sbrk(0);
   assert(sbrk_orig != NULL);
 

--- a/bin/utest/setjmp.c
+++ b/bin/utest/setjmp.c
@@ -1,6 +1,5 @@
 #include "utest.h"
 
-#include <assert.h>
 #include <setjmp.h>
 #include <stdnoreturn.h>
 

--- a/bin/utest/setjmp.c
+++ b/bin/utest/setjmp.c
@@ -1,3 +1,5 @@
+#include "utest.h"
+
 #include <assert.h>
 #include <setjmp.h>
 #include <stdnoreturn.h>
@@ -14,7 +16,7 @@ noreturn static void do_longjmp(int count) {
   assert(0); /* Shouldn't reach here. */
 }
 
-int test_setjmp(void) {
+TEST_ADD(setjmp) {
   unsigned int local_var = LOCAL_VALUE;
   volatile int count = 0;
 

--- a/bin/utest/sigaction.c
+++ b/bin/utest/sigaction.c
@@ -1,10 +1,9 @@
 #include "utest.h"
 
-#include <assert.h>
-#include <signal.h>
-#include <string.h>
 #include <setjmp.h>
+#include <signal.h>
 #include <stdnoreturn.h>
+#include <string.h>
 
 static sigjmp_buf jump_buffer;
 

--- a/bin/utest/sigaction.c
+++ b/bin/utest/sigaction.c
@@ -1,3 +1,5 @@
+#include "utest.h"
+
 #include <assert.h>
 #include <signal.h>
 #include <string.h>
@@ -11,7 +13,7 @@ noreturn static void sigint_handler(int signo) {
   assert(0); /* Shouldn't reach here. */
 }
 
-int test_sigaction_with_setjmp(void) {
+TEST_ADD(sigaction_with_setjmp) {
   struct sigaction sa;
 
   memset(&sa, 0, sizeof(sa));
@@ -32,7 +34,7 @@ static void sigusr1_handler(int signo) {
   sigusr1_handled = 1;
 }
 
-int test_sigaction_handler_returns(void) {
+TEST_ADD(sigaction_handler_returns) {
   struct sigaction sa;
 
   memset(&sa, 0, sizeof(sa));

--- a/bin/utest/signal.c
+++ b/bin/utest/signal.c
@@ -1,12 +1,11 @@
-#include <assert.h>
-#include <signal.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <sched.h>
-#include <sys/wait.h>
-
 #include "utest.h"
 #include "util.h"
+
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 /* ======= signal_basic ======= */
 static volatile int sigusr1_handled = 0;

--- a/bin/utest/signal.c
+++ b/bin/utest/signal.c
@@ -10,15 +10,18 @@
 
 /* ======= signal_basic ======= */
 static volatile int sigusr1_handled = 0;
+
 static void sigusr1_handler(int signo) {
   printf("sigusr1 handled!\n");
   sigusr1_handled = 1;
 }
+
 static void sigint_handler(int signo) {
   printf("sigint handled!\n");
   raise(SIGUSR1); /* Recursive signals! */
 }
-int test_signal_basic(void) {
+
+TEST_ADD(signal_basic) {
   signal(SIGINT, sigint_handler);
   signal(SIGUSR1, sigusr1_handler);
   raise(SIGINT);
@@ -36,8 +39,9 @@ static void sigusr2_handler(int signo) {
   printf("Child process handles sigusr2.\n");
   raise(SIGABRT); /* Terminate self. */
 }
+
 /* Test sending a signal to a different thread. */
-int test_signal_send(void) {
+TEST_ADD(signal_send) {
   /* The child should inherit signal handler configuration. */
   signal(SIGUSR2, sigusr2_handler);
   int pid = fork();
@@ -62,7 +66,7 @@ int test_signal_send(void) {
 /* ======= signal_abort ======= */
 /* This test shall be considered success if the process gets terminated with
    SIGABRT */
-int test_signal_abort(void) {
+TEST_ADD(signal_abort) {
   siginfo_t si;
   EXPECT_SIGNAL(SIGABRT, &si) {
     raise(SIGABRT);
@@ -72,7 +76,7 @@ int test_signal_abort(void) {
 }
 
 /* ======= signal_segfault ======= */
-int test_signal_segfault(void) {
+TEST_ADD(signal_segfault) {
   volatile struct { int x; } *ptr = 0x0;
 
   siginfo_t si;
@@ -95,7 +99,7 @@ static void signal_parent(int signo) {
   kill(ppid, SIGCONT);
 }
 
-int test_signal_stop(void) {
+TEST_ADD(signal_stop) {
   ppid = getpid();
   signal(SIGUSR1, SIG_IGN);
   signal(SIGCONT, sigcont_handler);
@@ -147,7 +151,7 @@ int test_signal_stop(void) {
 }
 
 /* ======= signal_cont_masked ======= */
-int test_signal_cont_masked(void) {
+TEST_ADD(signal_cont_masked) {
   ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   int pid = fork();
@@ -181,7 +185,7 @@ int test_signal_cont_masked(void) {
 }
 
 /* ======= signal_mask ======= */
-int test_signal_mask(void) {
+TEST_ADD(signal_mask) {
   ppid = getpid();
   signal(SIGUSR1, signal_parent);
   signal(SIGCONT, sigcont_handler);
@@ -231,7 +235,7 @@ int test_signal_mask(void) {
 }
 
 /* ======= signal_mask_nonmaskable ======= */
-int test_signal_mask_nonmaskable(void) {
+TEST_ADD(signal_mask_nonmaskable) {
   sigset_t set, old;
   __sigemptyset(&set);
   __sigaddset(&set, SIGSTOP);
@@ -246,7 +250,7 @@ int test_signal_mask_nonmaskable(void) {
 }
 
 /* ======= signal_sigsuspend ======= */
-int test_signal_sigsuspend(void) {
+TEST_ADD(signal_sigsuspend) {
   pid_t ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   signal(SIGUSR1, sigusr1_handler);
@@ -292,7 +296,7 @@ int test_signal_sigsuspend(void) {
 }
 
 /* ======= signal_sigsuspend_stop ======= */
-int test_signal_sigsuspend_stop(void) {
+TEST_ADD(signal_sigsuspend_stop) {
   pid_t ppid = getpid();
   signal(SIGUSR1, sigusr1_handler);
   sigset_t set, old;
@@ -370,7 +374,7 @@ static void yield_handler(int signo) {
     handler_success = 1;
 }
 
-int test_signal_handler_mask(void) {
+TEST_ADD(signal_handler_mask) {
   pid_t ppid = getpid();
   struct sigaction sa = {.sa_handler = yield_handler, .sa_flags = 0};
   /* Block SIGUSR1 when executing handler for SIGUSR2. */

--- a/bin/utest/stat.c
+++ b/bin/utest/stat.c
@@ -7,7 +7,7 @@
 #include <assert.h>
 #include <errno.h>
 
-int test_stat(void) {
+TEST_ADD(stat) {
   struct stat sb;
 
   assert_ok(stat("/tests/ascii", &sb));
@@ -19,7 +19,7 @@ int test_stat(void) {
   return 0;
 }
 
-int test_fstat(void) {
+TEST_ADD(fstat) {
   struct stat sb;
   int fd;
 

--- a/bin/utest/stat.c
+++ b/bin/utest/stat.c
@@ -1,21 +1,20 @@
 #include "utest.h"
 #include "util.h"
 
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 TEST_ADD(stat) {
   struct stat sb;
 
-  assert_ok(stat("/tests/ascii", &sb));
+  syscall_ok(stat("/tests/ascii", &sb));
   assert(sb.st_size == 95);
   assert(S_ISREG(sb.st_mode));
 
-  assert_fail(stat("/tests/ascii", NULL), EFAULT);
-  assert_fail(stat("/dont/exist", &sb), ENOENT);
+  syscall_fail(stat("/tests/ascii", NULL), EFAULT);
+  syscall_fail(stat("/dont/exist", &sb), ENOENT);
   return 0;
 }
 
@@ -24,11 +23,11 @@ TEST_ADD(fstat) {
   int fd;
 
   fd = open("/tests", 0, O_RDONLY);
-  assert_ok(fstat(fd, &sb));
+  syscall_ok(fstat(fd, &sb));
   assert(S_ISDIR(sb.st_mode));
 
-  assert_fail(fstat(fd, NULL), EFAULT);
-  assert_fail(fstat(666, &sb), EBADF);
+  syscall_fail(fstat(fd, NULL), EFAULT);
+  syscall_fail(fstat(666, &sb), EBADF);
   close(fd);
 
   return 0;

--- a/bin/utest/time.c
+++ b/bin/utest/time.c
@@ -53,19 +53,18 @@ TEST_ADD(nanosleep) {
   syscall_fail(nanosleep(NULL, NULL), EFAULT);
   syscall_fail(nanosleep(NULL, &rmt), EFAULT);
 
-  /* Check if sleept at least requested time */;
-  for (int g = 0; g < 20; g++) {
-    rqt.tv_nsec = (1000 << g);
+  /* Check if sleept at least requested time.
+   * Please note that system clock has resolution of one milisecond! */
+  for (int g = 0; g < 6; g++) {
+    rqt.tv_nsec = (1000000 << g);
     diff.tv_sec = rqt.tv_sec;
     diff.tv_usec = rqt.tv_nsec / 1000;
 
-    ret = gettimeofday(&time1, NULL);
-    assert(ret == 0);
+    syscall_ok(gettimeofday(&time1, NULL));
     while ((ret = nanosleep(&rqt, &rmt)) == EINTR)
       rqt = rmt;
     assert(ret == 0);
-    ret = gettimeofday(&time2, NULL);
-    assert(ret == 0);
+    syscall_ok(gettimeofday(&time2, NULL));
 
     timeradd(&time1, &diff, &time1);
     assert(timercmp(&time1, &time2, <=));

--- a/bin/utest/time.c
+++ b/bin/utest/time.c
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <signal.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
 
@@ -66,6 +67,8 @@ TEST_ADD(nanosleep) {
     assert(ret == 0);
     syscall_ok(gettimeofday(&time2, NULL));
 
+    printf("time1: %d.%06d, time2: %d.%06d\n", (int)time1.tv_sec, time1.tv_usec,
+           (int)time2.tv_sec, time2.tv_usec);
     timeradd(&time1, &diff, &time1);
     assert(timercmp(&time1, &time2, <=));
   }

--- a/bin/utest/time.c
+++ b/bin/utest/time.c
@@ -1,10 +1,9 @@
 #include "utest.h"
 #include "util.h"
 
-#include <string.h>
-#include <assert.h>
 #include <errno.h>
 #include <signal.h>
+#include <string.h>
 #include <sys/time.h>
 
 TEST_ADD(gettimeofday) {
@@ -38,21 +37,21 @@ TEST_ADD(nanosleep) {
   rqt.tv_sec = -1;
 
   rqt.tv_nsec = 1;
-  assert_fail(nanosleep(&rqt, NULL), EINVAL);
-  assert_fail(nanosleep(&rqt, &rmt), EINVAL);
+  syscall_fail(nanosleep(&rqt, NULL), EINVAL);
+  syscall_fail(nanosleep(&rqt, &rmt), EINVAL);
 
   rqt.tv_sec = 0;
   rqt.tv_nsec = -1;
-  assert_fail(nanosleep(&rqt, NULL), EINVAL);
-  assert_fail(nanosleep(&rqt, &rmt), EINVAL);
+  syscall_fail(nanosleep(&rqt, NULL), EINVAL);
+  syscall_fail(nanosleep(&rqt, &rmt), EINVAL);
 
   rqt.tv_nsec = 1000000000;
-  assert_fail(nanosleep(&rqt, NULL), EINVAL);
-  assert_fail(nanosleep(&rqt, &rmt), EINVAL);
+  syscall_fail(nanosleep(&rqt, NULL), EINVAL);
+  syscall_fail(nanosleep(&rqt, &rmt), EINVAL);
 
   rqt.tv_nsec = 1000;
-  assert_fail(nanosleep(NULL, NULL), EFAULT);
-  assert_fail(nanosleep(NULL, &rmt), EFAULT);
+  syscall_fail(nanosleep(NULL, NULL), EFAULT);
+  syscall_fail(nanosleep(NULL, &rmt), EFAULT);
 
   /* Check if sleept at least requested time */;
   for (int g = 0; g < 20; g++) {
@@ -82,21 +81,21 @@ TEST_ADD(itimer) {
 
   /* Try non-canonical timevals.  */
   it.it_value.tv_sec = -1;
-  assert_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
+  syscall_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
   it.it_value.tv_sec = 0;
   it.it_value.tv_usec = -1;
-  assert_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
+  syscall_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
   it.it_value.tv_usec = 1000000;
-  assert_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
+  syscall_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
   it.it_value.tv_usec = 0;
   it.it_value.tv_sec = 1;
   it.it_interval.tv_sec = -1;
-  assert_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
+  syscall_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
   it.it_interval.tv_sec = 0;
   it.it_interval.tv_usec = -1;
-  assert_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
+  syscall_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
   it.it_interval.tv_usec = 1000000;
-  assert_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
+  syscall_fail(setitimer(ITIMER_REAL, &it, NULL), EINVAL);
 
   /* No timer should be currently set. */
   assert(getitimer(ITIMER_REAL, &it2) == 0);

--- a/bin/utest/time.c
+++ b/bin/utest/time.c
@@ -7,7 +7,7 @@
 #include <signal.h>
 #include <sys/time.h>
 
-int test_gettimeofday(void) {
+TEST_ADD(gettimeofday) {
   timeval_t time1, time2;
   const int64_t start_of_century = 94684800, end_of_century = 4102444799;
 
@@ -28,7 +28,7 @@ int test_gettimeofday(void) {
   return 0;
 }
 
-int test_nanosleep(void) {
+TEST_ADD(nanosleep) {
   /* Requested and remaining time */
   timespec_t rqt, rmt;
   timeval_t time1, time2, diff;
@@ -74,7 +74,7 @@ int test_nanosleep(void) {
   return 0;
 }
 
-int test_itimer(void) {
+TEST_ADD(itimer) {
   signal_setup(SIGALRM);
   struct itimerval it, it2;
   memset(&it, 0, sizeof(it));

--- a/bin/utest/tty.c
+++ b/bin/utest/tty.c
@@ -1,17 +1,16 @@
-#include <assert.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/fcntl.h>
-#include <sys/termios.h>
-#include <sys/filio.h>
-#include <sys/ioctl.h>
-#include <stdio.h>
-#include <errno.h>
-
 #include "utest.h"
 #include "util.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/fcntl.h>
+#include <sys/filio.h>
+#include <sys/ioctl.h>
+#include <sys/termios.h>
+#include <unistd.h>
 
 TEST_ADD(tty_canon) {
   int master_fd, slave_fd;

--- a/bin/utest/tty.c
+++ b/bin/utest/tty.c
@@ -13,7 +13,7 @@
 #include "utest.h"
 #include "util.h"
 
-int test_tty_canon(void) {
+TEST_ADD(tty_canon) {
   int master_fd, slave_fd;
   open_pty(&master_fd, &slave_fd);
 
@@ -83,7 +83,7 @@ int test_tty_canon(void) {
   return 0;
 }
 
-int test_tty_echo(void) {
+TEST_ADD(tty_echo) {
   int master_fd, slave_fd;
   open_pty(&master_fd, &slave_fd);
 
@@ -130,7 +130,7 @@ int test_tty_echo(void) {
   return 0;
 }
 
-int test_tty_signals(void) {
+TEST_ADD(tty_signals) {
   signal_setup(SIGUSR1);
   int master_fd, slave_fd;
   open_pty(&master_fd, &slave_fd);

--- a/bin/utest/utest.c
+++ b/bin/utest/utest.c
@@ -1,20 +1,33 @@
 #include "utest.h"
 
-#include <stdlib.h>
+#include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
-noreturn void utest_die(const char *file, int line, const char *func,
-                        const char *expr) {
+noreturn void __die(const char *file, int line, const char *func,
+                    const char *fmt, ...) {
   char buf[1024];
-  int l = snprintf_ss(buf, sizeof(buf),
-                      "assertion \"%s\" failed: file \"%s\", line %d%s%s%s\n",
-                      expr, file, line, func ? ", function \"" : "",
-                      func ? func : "", func ? "\"" : "");
-  if (l < 0)
+  int len = 0, res;
+
+  char *basename = strrchr(file, '/');
+  file = basename ? basename + 1 : file;
+  res = snprintf_ss(buf, sizeof(buf), "[%s:%d] %s: ", file, line, func);
+  if (res < 0)
     exit(EXIT_FAILURE);
-  (void)write(STDERR_FILENO, buf, (size_t)l);
+  len += res;
+
+  va_list ap;
+  va_start(ap, fmt);
+  res = vsnprintf_ss(buf + len, sizeof(buf) - len, fmt, ap);
+  if (res < 0)
+    exit(EXIT_FAILURE);
+  va_end(ap);
+
+  len += res;
+  (void)write(STDERR_FILENO, buf, (size_t)len);
   exit(EXIT_FAILURE);
 }
 

--- a/bin/utest/utest.c
+++ b/bin/utest/utest.c
@@ -1,9 +1,22 @@
-#include <assert.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/wait.h>
-
 #include "utest.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+noreturn void utest_die(const char *file, int line, const char *func,
+                        const char *expr) {
+  char buf[1024];
+  int l = snprintf_ss(buf, sizeof(buf),
+                      "assertion \"%s\" failed: file \"%s\", line %d%s%s%s\n",
+                      expr, file, line, func ? ", function \"" : "",
+                      func ? func : "", func ? "\"" : "");
+  if (l < 0)
+    exit(EXIT_FAILURE);
+  (void)write(STDERR_FILENO, buf, (size_t)l);
+  exit(EXIT_FAILURE);
+}
 
 int utest_spawn(proc_func_t func, void *arg) {
   int pid;

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -1,146 +1,24 @@
 #ifndef __UTEST_H__
 #define __UTEST_H__
 
+#include <sys/linker_set.h>
+
+typedef int (*test_func_t)(void);
+
+typedef struct test_entry {
+  const char *name;
+  test_func_t func;
+} test_entry_t;
+
+#define TEST_ADD(name)                                                         \
+  int test_##name(void);                                                       \
+  test_entry_t name##_test = {#name, test_##name};                             \
+  SET_ENTRY(tests, name##_test);                                               \
+  int test_##name(void)
+
 typedef int (*proc_func_t)(void *);
 
 int utest_spawn(proc_func_t func, void *arg);
 void utest_child_exited(int exitcode);
-
-/* List of available tests. */
-int test_vmmap_text_access(void);
-int test_vmmap_data_access(void);
-int test_vmmap_rodata_access(void);
-
-int test_mmap(void);
-int test_munmap(void);
-int test_munmap_sigsegv(void);
-int test_munmap_many_1(void);
-int test_munmap_many_2(void);
-int test_mmap_prot_none(void);
-int test_mmap_prot_read(void);
-int test_mmap_fixed(void);
-int test_mmap_fixed_excl(void);
-int test_mmap_fixed_replace(void);
-int test_mmap_fixed_replace_many_1(void);
-int test_mmap_fixed_replace_many_2(void);
-
-int test_sbrk(void);
-int test_sbrk_sigsegv(void);
-int test_misbehave(void);
-
-int test_fd_read(void);
-int test_fd_devnull(void);
-int test_fd_multidesc(void);
-int test_fd_readwrite(void);
-int test_fd_copy(void);
-int test_fd_bad_desc(void);
-int test_fd_open_path(void);
-int test_fd_dup(void);
-int test_fd_pipe(void);
-int test_fd_readv(void);
-int test_fd_writev(void);
-int test_fd_all(void);
-
-int test_signal_basic(void);
-int test_signal_send(void);
-int test_signal_abort(void);
-int test_signal_segfault(void);
-int test_signal_stop(void);
-int test_signal_cont_masked(void);
-int test_signal_mask(void);
-int test_signal_mask_nonmaskable(void);
-int test_signal_sigsuspend(void);
-int test_signal_sigsuspend_stop(void);
-int test_signal_handler_mask(void);
-
-int test_fork_wait(void);
-int test_fork_signal(void);
-int test_fork_sigchld_ignored(void);
-
-int test_lseek_basic(void);
-int test_lseek_errors(void);
-
-int test_access_basic(void);
-
-int test_stat(void);
-int test_fstat(void);
-
-int test_fpu_fcsr(void);
-int test_fpu_gpr_preservation(void);
-int test_fpu_cpy_ctx_on_fork(void);
-int test_fpu_ctx_signals(void);
-
-int test_exc_cop_unusable(void);
-int test_exc_reserved_instruction(void);
-int test_exc_integer_overflow(void);
-int test_exc_sigsys(void);
-int test_exc_unaligned_access(void);
-
-int test_exc_unknown_instruction(void);
-int test_exc_msr_instruction(void);
-int test_exc_mrs_instruction(void);
-int test_exc_brk(void);
-
-int test_syscall_in_bds(void);
-
-int test_setjmp(void);
-int test_getcwd(void);
-
-int test_sigaction_with_setjmp(void);
-int test_sigaction_handler_returns(void);
-
-int test_vfs_dir(void);
-int test_vfs_relative_dir(void);
-int test_vfs_dot_dot_dir(void);
-int test_vfs_dot_dir(void);
-int test_vfs_dot_dot_across_fs(void);
-int test_vfs_rw(void);
-int test_vfs_trunc(void);
-int test_vfs_symlink(void);
-int test_vfs_link(void);
-int test_vfs_chmod(void);
-
-int test_wait_basic(void);
-int test_wait_nohang(void);
-
-int test_setpgid(void);
-int test_setpgid_leader(void);
-int test_setpgid_child(void);
-int test_kill(void);
-int test_killpg_same_group(void);
-int test_killpg_other_group(void);
-int test_pgrp_orphan(void);
-int test_session_basic(void);
-int test_session_login_name(void);
-
-int test_gettimeofday(void);
-int test_nanosleep(void);
-int test_itimer(void);
-
-int test_get_set_uid(void);
-int test_get_set_gid(void);
-int test_get_set_groups(void);
-
-int test_sharing_memory_simple(void);
-int test_sharing_memory_child_and_grandchild(void);
-
-int test_pty_simple(void);
-
-int test_tty_canon(void);
-int test_tty_echo(void);
-int test_tty_signals(void);
-
-int test_procstat(void);
-
-int test_pipe_parent_signaled(void);
-int test_pipe_child_signaled(void);
-
-int test_pipe_blocking_flag_manipulation(void);
-int test_pipe_write_interruptible_sleep(void);
-int test_pipe_write_errno_eagain(void);
-
-int test_pipe_read_interruptible_sleep(void);
-int test_pipe_read_errno_eagain(void);
-int test_pipe_read_return_zero(void);
 
 #endif /* __UTEST_H__ */

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -53,9 +53,15 @@ void utest_child_exited(int exitcode);
   })
 
 #define string_eq(s1, s2)                                                      \
-  ({ if (strcmp((s1), (s2))) die("strings were expected to match!\n"); })
+  ({                                                                           \
+    if (strcmp((s1), (s2)))                                                    \
+      die("strings were expected to match!\n");                                \
+  })
 
 #define string_ne(s1, s2)                                                      \
-  ({ if (!strcmp((s1), (s2))) die("strings were not expected to match!\n"); })
+  ({                                                                           \
+    if (!strcmp((s1), (s2)))                                                   \
+      die("strings were not expected to match!\n");                            \
+  })
 
 #endif /* __UTEST_H__ */

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -19,25 +19,43 @@ typedef struct test_entry {
 
 typedef int (*proc_func_t)(void *);
 
-noreturn void utest_die(const char *file, int line, const char *func,
-                        const char *expr);
+noreturn void __die(const char *file, int line, const char *func,
+                    const char *fmt, ...);
 int utest_spawn(proc_func_t func, void *arg);
 void utest_child_exited(int exitcode);
 
-#define assert(e) ((e) ?: utest_die(__FILE__, __LINE__, __func__, #e))
+#define die(...) __die(__FILE__, __LINE__, __func__, __VA_ARGS__)
+
+#define assert(e)                                                              \
+  ({                                                                           \
+    if (!(e))                                                                  \
+      die("assertion '%s' failed!\n", #e);                                     \
+  })
 
 /* Test if system call returned with no error. */
-#define syscall_ok(e) (!(e) ?: utest_die(__FILE__, __LINE__, __func__, #e))
+#define syscall_ok(e)                                                          \
+  ({                                                                           \
+    errno = 0;                                                                 \
+    long __r = (long)(e);                                                      \
+    if (__r != 0)                                                              \
+      die("call '%s' unexpectedly returned %ld (errno = %d)!\n", #e, __r,      \
+          errno);                                                              \
+  })
 
 /* Test if system call returned with specific error. */
 #define syscall_fail(e, err)                                                   \
-  (((long)(e) == -1 && errno == (err))                                         \
-     ?: utest_die(__FILE__, __LINE__, __func__, #e))
+  ({                                                                           \
+    errno = 0;                                                                 \
+    long __r = (long)(e);                                                      \
+    if ((__r != -1) || (errno != (err)))                                       \
+      die("call '%s' unexpectedly returned %ld (errno = %d)\n", #e, __r,       \
+          errno);                                                              \
+  })
 
 #define string_eq(s1, s2)                                                      \
-  (!strcmp((s1), (s2)) ?: utest_die(__FILE__, __LINE__, __func__, "s1 != s2"))
+  (!strcmp((s1), (s2)) ?: die("strings were expected to match!\n"))
 
 #define string_ne(s1, s2)                                                      \
-  (strcmp((s1), (s2)) ?: utest_die(__FILE__, __LINE__, __func__, "s1 == s2"))
+  (strcmp((s1), (s2)) ?: die("strings were not expected to match!\n"))
 
 #endif /* __UTEST_H__ */

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -30,14 +30,14 @@ void utest_child_exited(int exitcode);
 #define syscall_ok(e) (!(e) ?: utest_die(__FILE__, __LINE__, __func__, #e))
 
 /* Test if system call returned with specific error. */
-#define syscall_fail(e, err)                                                      \
+#define syscall_fail(e, err)                                                   \
   (((long)(e) == -1 && errno == (err))                                         \
      ?: utest_die(__FILE__, __LINE__, __func__, #e))
 
-#define string_eq(s1, s2)                                                 \
+#define string_eq(s1, s2)                                                      \
   (!strcmp((s1), (s2)) ?: utest_die(__FILE__, __LINE__, __func__, "s1 != s2"))
 
-#define string_ne(s1, s2)                                                 \
+#define string_ne(s1, s2)                                                      \
   (strcmp((s1), (s2)) ?: utest_die(__FILE__, __LINE__, __func__, "s1 == s2"))
 
 #endif /* __UTEST_H__ */

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -53,9 +53,9 @@ void utest_child_exited(int exitcode);
   })
 
 #define string_eq(s1, s2)                                                      \
-  (!strcmp((s1), (s2)) ?: die("strings were expected to match!\n"))
+  ({ if (strcmp((s1), (s2))) die("strings were expected to match!\n"); })
 
 #define string_ne(s1, s2)                                                      \
-  (strcmp((s1), (s2)) ?: die("strings were not expected to match!\n"))
+  ({ if (!strcmp((s1), (s2))) die("strings were not expected to match!\n"); })
 
 #endif /* __UTEST_H__ */

--- a/bin/utest/utest.h
+++ b/bin/utest/utest.h
@@ -2,6 +2,7 @@
 #define __UTEST_H__
 
 #include <sys/linker_set.h>
+#include <stdnoreturn.h>
 
 typedef int (*test_func_t)(void);
 
@@ -18,7 +19,25 @@ typedef struct test_entry {
 
 typedef int (*proc_func_t)(void *);
 
+noreturn void utest_die(const char *file, int line, const char *func,
+                        const char *expr);
 int utest_spawn(proc_func_t func, void *arg);
 void utest_child_exited(int exitcode);
+
+#define assert(e) ((e) ?: utest_die(__FILE__, __LINE__, __func__, #e))
+
+/* Test if system call returned with no error. */
+#define syscall_ok(e) (!(e) ?: utest_die(__FILE__, __LINE__, __func__, #e))
+
+/* Test if system call returned with specific error. */
+#define syscall_fail(e, err)                                                      \
+  (((long)(e) == -1 && errno == (err))                                         \
+     ?: utest_die(__FILE__, __LINE__, __func__, #e))
+
+#define string_eq(s1, s2)                                                 \
+  (!strcmp((s1), (s2)) ?: utest_die(__FILE__, __LINE__, __func__, "s1 != s2"))
+
+#define string_ne(s1, s2)                                                 \
+  (strcmp((s1), (s2)) ?: utest_die(__FILE__, __LINE__, __func__, "s1 == s2"))
 
 #endif /* __UTEST_H__ */

--- a/bin/utest/util.c
+++ b/bin/utest/util.c
@@ -1,11 +1,11 @@
-#include <stdio.h>
 #include <assert.h>
-#include <signal.h>
-#include <string.h>
 #include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
-#include <sys/wait.h>
+#include <string.h>
 #include <sys/fcntl.h>
+#include <sys/wait.h>
 
 jmp_buf _expect_signal_ctx;
 

--- a/bin/utest/util.h
+++ b/bin/utest/util.h
@@ -36,21 +36,6 @@ void _expect_signal_cleanup(void);
   assert((si)->si_addr == (sig_addr));                                         \
   assert((si)->si_code == (sig_code))
 
-#define assert_ok(expr) assert((long int)(expr) == 0)
-#define assert_fail(expr, err) assert((long int)(expr) == -1 && errno == err)
-
-#define STRING_EQ(str1, str2)                                                  \
-  ({                                                                           \
-    int __ret = strcmp(str1, str2);                                            \
-    assert_ok(__ret);                                                          \
-  })
-
-#define STRING_NE(str1, str2)                                                  \
-  ({                                                                           \
-    int __ret = strcmp((str1), (str2));                                        \
-    assert(__ret != 0);                                                        \
-  })
-
 #ifndef FD_OFFSET
 #define FD_OFFSET 0
 #endif

--- a/bin/utest/vfs.c
+++ b/bin/utest/vfs.c
@@ -1,14 +1,13 @@
 #include "utest.h"
 #include "util.h"
 
-#include <sys/stat.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* Shift used fds by 3 so std{in,out,err} are not affected. */
 #undef FD_OFFSET
@@ -107,124 +106,124 @@ TEST_ADD(vfs_trunc) {
   free(rdbuf);
   unlink(TESTDIR "/file");
 
-  assert_fail(truncate(TESTDIR, 1023), EISDIR);
+  syscall_fail(truncate(TESTDIR, 1023), EISDIR);
   return 0;
 }
 
 TEST_ADD(vfs_dir) {
-  assert_fail(mkdir("/", 0), EEXIST);
-  assert_ok(mkdir(TESTDIR "/test", 0));
-  assert_fail(mkdir(TESTDIR "/test", 0), EEXIST);
-  assert_fail(mkdir(TESTDIR "//test///", 0), EEXIST);
-  assert_ok(rmdir(TESTDIR "/test"));
-  assert_ok(mkdir(TESTDIR "/test", 0));
+  syscall_fail(mkdir("/", 0), EEXIST);
+  syscall_ok(mkdir(TESTDIR "/test", 0));
+  syscall_fail(mkdir(TESTDIR "/test", 0), EEXIST);
+  syscall_fail(mkdir(TESTDIR "//test///", 0), EEXIST);
+  syscall_ok(rmdir(TESTDIR "/test"));
+  syscall_ok(mkdir(TESTDIR "/test", 0));
 
-  assert_ok(mkdir(TESTDIR "//test2///", 0));
-  assert_ok(access(TESTDIR "/test2", 0));
+  syscall_ok(mkdir(TESTDIR "//test2///", 0));
+  syscall_ok(access(TESTDIR "/test2", 0));
 
-  assert_ok(mkdir(TESTDIR "/test3", 0));
-  assert_ok(mkdir(TESTDIR "/test3/subdir1", 0));
-  assert_ok(mkdir(TESTDIR "/test3/subdir2", 0));
-  assert_ok(mkdir(TESTDIR "/test3/subdir3", 0));
-  assert_fail(mkdir(TESTDIR "/test3/subdir1", 0), EEXIST);
-  assert_ok(access(TESTDIR "/test3/subdir2", 0));
+  syscall_ok(mkdir(TESTDIR "/test3", 0));
+  syscall_ok(mkdir(TESTDIR "/test3/subdir1", 0));
+  syscall_ok(mkdir(TESTDIR "/test3/subdir2", 0));
+  syscall_ok(mkdir(TESTDIR "/test3/subdir3", 0));
+  syscall_fail(mkdir(TESTDIR "/test3/subdir1", 0), EEXIST);
+  syscall_ok(access(TESTDIR "/test3/subdir2", 0));
 
-  assert_fail(mkdir(TESTDIR "/test4/subdir4", 0), ENOENT);
+  syscall_fail(mkdir(TESTDIR "/test4/subdir4", 0), ENOENT);
 
-  assert_ok(rmdir(TESTDIR "/test/"));
-  assert_ok(rmdir(TESTDIR "/test2"));
-  assert_fail(rmdir(TESTDIR "/test3"), ENOTEMPTY);
-  assert_ok(rmdir(TESTDIR "/test3/subdir1"));
-  assert_ok(rmdir(TESTDIR "/test3/subdir2"));
-  assert_ok(rmdir(TESTDIR "/test3/subdir3"));
-  assert_ok(rmdir(TESTDIR "/test3"));
-  assert_fail(rmdir(TESTDIR "/test3"), ENOENT);
-  assert_fail(rmdir(TESTDIR "/test4/subdir4"), ENOENT);
+  syscall_ok(rmdir(TESTDIR "/test/"));
+  syscall_ok(rmdir(TESTDIR "/test2"));
+  syscall_fail(rmdir(TESTDIR "/test3"), ENOTEMPTY);
+  syscall_ok(rmdir(TESTDIR "/test3/subdir1"));
+  syscall_ok(rmdir(TESTDIR "/test3/subdir2"));
+  syscall_ok(rmdir(TESTDIR "/test3/subdir3"));
+  syscall_ok(rmdir(TESTDIR "/test3"));
+  syscall_fail(rmdir(TESTDIR "/test3"), ENOENT);
+  syscall_fail(rmdir(TESTDIR "/test4/subdir4"), ENOENT);
 
-  assert_fail(mkdir(TESTDIR "/test3/subdir1", 0), ENOENT);
+  syscall_fail(mkdir(TESTDIR "/test3/subdir1", 0), ENOENT);
 
-  assert_fail(mkdir("/", 0), EEXIST);
-  assert_fail(rmdir("/tmp"), EBUSY);
+  syscall_fail(mkdir("/", 0), EEXIST);
+  syscall_fail(rmdir("/tmp"), EBUSY);
 
   return 0;
 }
 
 TEST_ADD(vfs_relative_dir) {
-  assert_ok(chdir(TESTDIR));
-  assert_ok(mkdir("test", 0));
-  assert_fail(mkdir("test", 0), EEXIST);
-  assert_fail(mkdir("test///", 0), EEXIST);
-  assert_ok(chdir("test"));
+  syscall_ok(chdir(TESTDIR));
+  syscall_ok(mkdir("test", 0));
+  syscall_fail(mkdir("test", 0), EEXIST);
+  syscall_fail(mkdir("test///", 0), EEXIST);
+  syscall_ok(chdir("test"));
 
-  assert_ok(mkdir("test2///", 0));
-  assert_ok(rmdir("test2"));
+  syscall_ok(mkdir("test2///", 0));
+  syscall_ok(rmdir("test2"));
 
-  assert_ok(mkdir("test3", 0));
-  assert_ok(mkdir("test3/subdir1", 0));
-  assert_ok(mkdir("test3/subdir2", 0));
-  assert_ok(mkdir("test3/subdir3", 0));
-  assert_fail(mkdir("test3/subdir1", 0), EEXIST);
-  assert_ok(access("test3/subdir2", 0));
+  syscall_ok(mkdir("test3", 0));
+  syscall_ok(mkdir("test3/subdir1", 0));
+  syscall_ok(mkdir("test3/subdir2", 0));
+  syscall_ok(mkdir("test3/subdir3", 0));
+  syscall_fail(mkdir("test3/subdir1", 0), EEXIST);
+  syscall_ok(access("test3/subdir2", 0));
 
-  assert_ok(rmdir(TESTDIR "/test/test3/subdir1"));
-  assert_ok(rmdir(TESTDIR "/test/test3/subdir2"));
-  assert_ok(rmdir(TESTDIR "/test/test3/subdir3"));
-  assert_ok(rmdir("test3"));
+  syscall_ok(rmdir(TESTDIR "/test/test3/subdir1"));
+  syscall_ok(rmdir(TESTDIR "/test/test3/subdir2"));
+  syscall_ok(rmdir(TESTDIR "/test/test3/subdir3"));
+  syscall_ok(rmdir("test3"));
 
-  assert_ok(chdir(TESTDIR));
-  assert_ok(rmdir("test"));
-  assert_ok(chdir("/"));
+  syscall_ok(chdir(TESTDIR));
+  syscall_ok(rmdir("test"));
+  syscall_ok(chdir("/"));
   return 0;
 }
 
 TEST_ADD(vfs_dot_dot_dir) {
-  assert_ok(chdir(TESTDIR));
+  syscall_ok(chdir(TESTDIR));
 
-  assert_ok(mkdir("test", 0));
-  assert_ok(chdir("test"));
-  assert_ok(mkdir("test2///", 0));
-  assert_ok(chdir("test2"));
+  syscall_ok(mkdir("test", 0));
+  syscall_ok(chdir("test"));
+  syscall_ok(mkdir("test2///", 0));
+  syscall_ok(chdir("test2"));
 
-  assert_ok(chdir(".."));
-  assert_ok(chdir("test2"));
+  syscall_ok(chdir(".."));
+  syscall_ok(chdir("test2"));
 
-  assert_ok(chdir("../test2"));
-  assert_ok(chdir("../../"));
-  assert_fail(mkdir("test", 0), EEXIST);
+  syscall_ok(chdir("../test2"));
+  syscall_ok(chdir("../../"));
+  syscall_fail(mkdir("test", 0), EEXIST);
 
-  assert_ok(chdir("test"));
-  assert_ok(rmdir("../test/test2"));
+  syscall_ok(chdir("test"));
+  syscall_ok(rmdir("../test/test2"));
 
-  assert_ok(chdir("./.."));
-  assert_ok(rmdir("test"));
+  syscall_ok(chdir("./.."));
+  syscall_ok(rmdir("test"));
 
   return 0;
 }
 
 TEST_ADD(vfs_dot_dir) {
-  assert_fail(mkdir(TESTDIR "/test/.", 0), ENOENT);
-  assert_fail(mkdir("/.", 0), EEXIST);
-  assert_fail(mkdir(TESTDIR "/.", 0), EEXIST);
+  syscall_fail(mkdir(TESTDIR "/test/.", 0), ENOENT);
+  syscall_fail(mkdir("/.", 0), EEXIST);
+  syscall_fail(mkdir(TESTDIR "/.", 0), EEXIST);
 
   return 0;
 }
 
 TEST_ADD(vfs_dot_dot_across_fs) {
-  assert_ok(chdir("/../../../../"));
-  assert_fail(mkdir("dev", 0), EEXIST);
+  syscall_ok(chdir("/../../../../"));
+  syscall_fail(mkdir("dev", 0), EEXIST);
 
-  assert_ok(chdir("dev/../dev/../../../dev/../../dev"));
-  assert_fail(mkdir("../dev", 0), EEXIST);
+  syscall_ok(chdir("dev/../dev/../../../dev/../../dev"));
+  syscall_fail(mkdir("../dev", 0), EEXIST);
 
-  assert_ok(chdir("../"));
-  assert_fail(mkdir("dev", 0), EEXIST);
+  syscall_ok(chdir("../"));
+  syscall_fail(mkdir("dev", 0), EEXIST);
 
   return 0;
 }
 
 static void test_vfs_symlink_basic(void) {
   char *buff = malloc(1024);
-  assert_ok(symlink("Hello, world!", TESTDIR "/testlink"));
+  syscall_ok(symlink("Hello, world!", TESTDIR "/testlink"));
 
   assert(readlink(TESTDIR "/testlink", buff, 1024) == 13);
   assert(!strcmp("Hello, world!", buff));
@@ -233,9 +232,9 @@ static void test_vfs_symlink_basic(void) {
   assert(readlink(TESTDIR "/testlink", buff, 5) == 5);
   assert(!strcmp("Hello", buff));
 
-  assert_fail(symlink("Hello, world!", TESTDIR "/testlink"), EEXIST);
+  syscall_fail(symlink("Hello, world!", TESTDIR "/testlink"), EEXIST);
 
-  assert_ok(unlink(TESTDIR "/testlink"));
+  syscall_ok(unlink(TESTDIR "/testlink"));
   free(buff);
 }
 
@@ -245,29 +244,29 @@ static void test_vfs_symlink_vnr(void) {
   ino_t fileino;
 
   assert_open_ok(0, TESTDIR "/file", 0, O_RDWR | O_CREAT);
-  assert_ok(stat(TESTDIR "/file", &sb));
+  syscall_ok(stat(TESTDIR "/file", &sb));
   fileino = sb.st_ino;
 
   /* Absolute symlink */
-  assert_ok(symlink(TESTDIR "/file", TESTDIR "/alink"));
-  assert_ok(stat(TESTDIR "/alink", &sb));
+  syscall_ok(symlink(TESTDIR "/file", TESTDIR "/alink"));
+  syscall_ok(stat(TESTDIR "/alink", &sb));
   assert(fileino == sb.st_ino);
 
-  assert_ok(symlink(TESTDIR "/alink", TESTDIR "/alink2"));
-  assert_ok(stat(TESTDIR "/alink2", &sb));
+  syscall_ok(symlink(TESTDIR "/alink", TESTDIR "/alink2"));
+  syscall_ok(stat(TESTDIR "/alink2", &sb));
   assert(fileino == sb.st_ino);
 
   /* Relative symlink */
-  assert_ok(symlink("file", TESTDIR "/rlink"));
-  assert_ok(stat(TESTDIR "/rlink", &sb));
+  syscall_ok(symlink("file", TESTDIR "/rlink"));
+  syscall_ok(stat(TESTDIR "/rlink", &sb));
   assert(fileino == sb.st_ino);
 
-  assert_ok(symlink("alink2", TESTDIR "/rlink2"));
-  assert_ok(stat(TESTDIR "/rlink2", &sb));
+  syscall_ok(symlink("alink2", TESTDIR "/rlink2"));
+  syscall_ok(stat(TESTDIR "/rlink2", &sb));
   assert(fileino == sb.st_ino);
 
   /* Do not follow symlink */
-  assert_ok(lstat(TESTDIR "/alink2", &sb));
+  syscall_ok(lstat(TESTDIR "/alink2", &sb));
   assert(fileino != sb.st_ino);
 
   unlink(TESTDIR "/alink");
@@ -276,19 +275,19 @@ static void test_vfs_symlink_vnr(void) {
   unlink(TESTDIR "/rlink2");
 
   /* Symlink to directory */
-  assert_ok(symlink("/tmp", TESTDIR "/dlink"));
-  assert_ok(stat(TESTDIR "/dlink/file", &sb));
+  syscall_ok(symlink("/tmp", TESTDIR "/dlink"));
+  syscall_ok(stat(TESTDIR "/dlink/file", &sb));
   assert(fileino == sb.st_ino);
   unlink(TESTDIR "/dlink");
 
   /* Looped symlink */
-  assert_ok(symlink(TESTDIR "/slink", TESTDIR "/slink"));
-  assert_fail(stat(TESTDIR "/slink", &sb), ELOOP);
+  syscall_ok(symlink(TESTDIR "/slink", TESTDIR "/slink"));
+  syscall_fail(stat(TESTDIR "/slink", &sb), ELOOP);
   unlink(TESTDIR "/slink");
 
   /* Bad symlink */
-  assert_ok(symlink(TESTDIR "/nofile", TESTDIR "/blink"));
-  assert_fail(stat(TESTDIR "/blink", &sb), ENOENT);
+  syscall_ok(symlink(TESTDIR "/nofile", TESTDIR "/blink"));
+  syscall_fail(stat(TESTDIR "/blink", &sb), ENOENT);
   unlink(TESTDIR "/blink");
 
   unlink(TESTDIR "/file");
@@ -311,7 +310,7 @@ TEST_ADD(vfs_link) {
 
   /* Create file and fill it with random data */
   assert_open_ok(0, TESTDIR "/file", S_IWUSR | S_IRUSR, O_RDWR | O_CREAT);
-  assert_ok(stat(TESTDIR "/file", &sb));
+  syscall_ok(stat(TESTDIR "/file", &sb));
   assert(sb.st_nlink == 1);
 
   fileino = sb.st_ino;
@@ -319,8 +318,8 @@ TEST_ADD(vfs_link) {
   assert_write_ok(0, wrbuf, 32);
 
   /* Make a hard link */
-  assert_ok(link(TESTDIR "/file", TESTDIR "/file2"));
-  assert_ok(stat(TESTDIR "/file2", &sb));
+  syscall_ok(link(TESTDIR "/file", TESTDIR "/file2"));
+  syscall_ok(stat(TESTDIR "/file2", &sb));
 
   /* Ensure if inode number and link count is proper */
   assert(sb.st_ino == fileino);
@@ -332,8 +331,8 @@ TEST_ADD(vfs_link) {
   assert(!memcmp(wrbuf, rdbuf, 32));
 
   /* Make another link to the same file*/
-  assert_ok(link(TESTDIR "/file2", TESTDIR "/file3"));
-  assert_ok(stat(TESTDIR "/file3", &sb));
+  syscall_ok(link(TESTDIR "/file2", TESTDIR "/file3"));
+  syscall_ok(stat(TESTDIR "/file3", &sb));
 
   /* Ensure if inode number and link count is proper */
   assert(sb.st_ino == fileino);
@@ -349,19 +348,19 @@ TEST_ADD(vfs_link) {
 
   /* Delete second file */
   assert_close_ok(1);
-  assert_ok(unlink(TESTDIR "/file2"));
+  syscall_ok(unlink(TESTDIR "/file2"));
 
-  assert_ok(stat(TESTDIR "/file", &sb));
+  syscall_ok(stat(TESTDIR "/file", &sb));
   assert(sb.st_nlink == 2);
 
-  assert_ok(unlink(TESTDIR "/file"));
+  syscall_ok(unlink(TESTDIR "/file"));
 
-  assert_ok(stat(TESTDIR "/file3", &sb));
+  syscall_ok(stat(TESTDIR "/file3", &sb));
   assert(sb.st_nlink == 1);
 
-  assert_ok(unlink(TESTDIR "/file3"));
+  syscall_ok(unlink(TESTDIR "/file3"));
 
-  assert_fail(link("/tmp", "/tmp/foo"), EPERM);
+  syscall_fail(link("/tmp", "/tmp/foo"), EPERM);
 
   return 0;
 }
@@ -370,24 +369,24 @@ TEST_ADD(vfs_chmod) {
   struct stat sb;
 
   assert(open(TESTDIR "/file", O_RDWR | O_CREAT, 0) == 3);
-  assert_ok(stat(TESTDIR "/file", &sb));
+  syscall_ok(stat(TESTDIR "/file", &sb));
   assert((sb.st_mode & ALLPERMS) == 0);
 
-  assert_ok(chmod(TESTDIR "/file", DEFFILEMODE));
-  assert_ok(stat(TESTDIR "/file", &sb));
+  syscall_ok(chmod(TESTDIR "/file", DEFFILEMODE));
+  syscall_ok(stat(TESTDIR "/file", &sb));
   assert((sb.st_mode & ALLPERMS) == DEFFILEMODE);
 
   mode_t mode = S_IXGRP | S_IWOTH | S_IRUSR | S_ISUID;
-  assert_ok(chmod(TESTDIR "/file", mode));
-  assert_ok(stat(TESTDIR "/file", &sb));
+  syscall_ok(chmod(TESTDIR "/file", mode));
+  syscall_ok(stat(TESTDIR "/file", &sb));
   assert((sb.st_mode & ALLPERMS) == mode);
 
   mode_t lmode = S_IWUSR | S_IRWXU | S_IRWXO;
-  assert_ok(symlink(TESTDIR "/file", TESTDIR "/link"));
-  assert_ok(lchmod(TESTDIR "/link", lmode));
-  assert_ok(stat(TESTDIR "/link", &sb));
+  syscall_ok(symlink(TESTDIR "/file", TESTDIR "/link"));
+  syscall_ok(lchmod(TESTDIR "/link", lmode));
+  syscall_ok(stat(TESTDIR "/link", &sb));
   assert((sb.st_mode & ALLPERMS) == mode);
-  assert_ok(lstat(TESTDIR "/link", &sb));
+  syscall_ok(lstat(TESTDIR "/link", &sb));
   assert((sb.st_mode & ALLPERMS) == lmode);
 
   unlink(TESTDIR "/file");

--- a/bin/utest/vfs.c
+++ b/bin/utest/vfs.c
@@ -27,7 +27,7 @@ static void fill_random(uint32_t *data, size_t n) {
   }
 }
 
-int test_vfs_rw(void) {
+TEST_ADD(vfs_rw) {
   int n;
 
   void *wrbuf = malloc(16384);
@@ -73,7 +73,7 @@ int test_vfs_rw(void) {
   return 0;
 }
 
-int test_vfs_trunc(void) {
+TEST_ADD(vfs_trunc) {
   int n;
   void *wrbuf = malloc(4096);
   void *rdbuf = malloc(8196);
@@ -111,7 +111,7 @@ int test_vfs_trunc(void) {
   return 0;
 }
 
-int test_vfs_dir(void) {
+TEST_ADD(vfs_dir) {
   assert_fail(mkdir("/", 0), EEXIST);
   assert_ok(mkdir(TESTDIR "/test", 0));
   assert_fail(mkdir(TESTDIR "/test", 0), EEXIST);
@@ -149,7 +149,7 @@ int test_vfs_dir(void) {
   return 0;
 }
 
-int test_vfs_relative_dir(void) {
+TEST_ADD(vfs_relative_dir) {
   assert_ok(chdir(TESTDIR));
   assert_ok(mkdir("test", 0));
   assert_fail(mkdir("test", 0), EEXIST);
@@ -177,7 +177,7 @@ int test_vfs_relative_dir(void) {
   return 0;
 }
 
-int test_vfs_dot_dot_dir(void) {
+TEST_ADD(vfs_dot_dot_dir) {
   assert_ok(chdir(TESTDIR));
 
   assert_ok(mkdir("test", 0));
@@ -201,7 +201,7 @@ int test_vfs_dot_dot_dir(void) {
   return 0;
 }
 
-int test_vfs_dot_dir(void) {
+TEST_ADD(vfs_dot_dir) {
   assert_fail(mkdir(TESTDIR "/test/.", 0), ENOENT);
   assert_fail(mkdir("/.", 0), EEXIST);
   assert_fail(mkdir(TESTDIR "/.", 0), EEXIST);
@@ -209,7 +209,7 @@ int test_vfs_dot_dir(void) {
   return 0;
 }
 
-int test_vfs_dot_dot_across_fs(void) {
+TEST_ADD(vfs_dot_dot_across_fs) {
   assert_ok(chdir("/../../../../"));
   assert_fail(mkdir("dev", 0), EEXIST);
 
@@ -294,13 +294,13 @@ static void test_vfs_symlink_vnr(void) {
   unlink(TESTDIR "/file");
 }
 
-int test_vfs_symlink(void) {
+TEST_ADD(vfs_symlink) {
   test_vfs_symlink_basic();
   test_vfs_symlink_vnr();
   return 0;
 }
 
-int test_vfs_link(void) {
+TEST_ADD(vfs_link) {
   int n;
   struct stat sb;
   ino_t fileino;
@@ -366,7 +366,7 @@ int test_vfs_link(void) {
   return 0;
 }
 
-int test_vfs_chmod(void) {
+TEST_ADD(vfs_chmod) {
   struct stat sb;
 
   assert(open(TESTDIR "/file", O_RDWR | O_CREAT, 0) == 3);

--- a/bin/utest/vm_map.c
+++ b/bin/utest/vm_map.c
@@ -1,10 +1,9 @@
 #include "utest.h"
 #include "util.h"
 
-#include <assert.h>
 #include <stddef.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/types.h>

--- a/bin/utest/vm_map.c
+++ b/bin/utest/vm_map.c
@@ -11,7 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-int test_sharing_memory_simple(void) {
+TEST_ADD(sharing_memory_simple) {
   size_t pgsz = getpagesize();
   char *map =
     mmap(NULL, pgsz, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED, -1, 0);
@@ -33,7 +33,7 @@ int test_sharing_memory_simple(void) {
   return 0;
 }
 
-int test_sharing_memory_child_and_grandchild(void) {
+TEST_ADD(sharing_memory_child_and_grandchild) {
   size_t pgsz = getpagesize();
   char *map =
     mmap(NULL, pgsz, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED, -1, 0);

--- a/bin/utest/vm_map_prot.c
+++ b/bin/utest/vm_map_prot.c
@@ -21,7 +21,7 @@ int func_dec(int x) {
   return x - 1;
 }
 
-int test_vmmap_text_access(void) {
+TEST_ADD(vmmap_text_access) {
   func_int_t fun = func_dec;
 
   assert((uintptr_t)func_inc < (uintptr_t)func_dec);
@@ -44,7 +44,7 @@ int test_vmmap_text_access(void) {
   return 0;
 }
 
-int test_vmmap_data_access(void) {
+TEST_ADD(vmmap_data_access) {
   static char func_buf[1024];
 
   assert((uintptr_t)func_inc < (uintptr_t)func_dec);
@@ -70,7 +70,7 @@ int test_vmmap_data_access(void) {
 /* String must be alinged as instuctions because we jump here */
 static __aligned(4) const char ro_data_str[] = "String in .rodata section";
 
-int test_vmmap_rodata_access(void) {
+TEST_ADD(vmmap_rodata_access) {
   siginfo_t si;
 
   /* Check write */

--- a/bin/utest/vm_map_prot.c
+++ b/bin/utest/vm_map_prot.c
@@ -1,12 +1,11 @@
 #include "utest.h"
 #include "util.h"
 
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 typedef int (*func_int_t)(int);
 

--- a/bin/utest/wait.c
+++ b/bin/utest/wait.c
@@ -1,11 +1,10 @@
 #include "utest.h"
 
-#include <assert.h>
-#include <stdio.h>
-#include <signal.h>
-#include <unistd.h>
 #include <sched.h>
+#include <signal.h>
+#include <stdio.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 static int nothing_to_report(pid_t pid) {
   return (waitpid(pid, NULL, WCONTINUED | WUNTRACED | WNOHANG) == 0);

--- a/bin/utest/wait.c
+++ b/bin/utest/wait.c
@@ -1,11 +1,11 @@
+#include "utest.h"
+
 #include <assert.h>
 #include <stdio.h>
 #include <signal.h>
 #include <unistd.h>
 #include <sched.h>
 #include <sys/wait.h>
-
-#include "utest.h"
 
 static int nothing_to_report(pid_t pid) {
   return (waitpid(pid, NULL, WCONTINUED | WUNTRACED | WNOHANG) == 0);
@@ -18,7 +18,7 @@ static void sigcont_handler(int signo) {
   sigcont_handled = 1;
 }
 
-int test_wait_basic(void) {
+TEST_ADD(wait_basic) {
   ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   int pid = fork();
@@ -60,7 +60,7 @@ int test_wait_basic(void) {
 }
 
 /* ======= wait_nohang ======= */
-int test_wait_nohang(void) {
+TEST_ADD(wait_nohang) {
   ppid = getpid();
   signal(SIGCONT, sigcont_handler);
   int pid = fork();

--- a/config.mk
+++ b/config.mk
@@ -15,6 +15,8 @@ RISCV ?= 0
 ifeq ($(BOARD), malta)
 ARCH := mips
 MIPS := 1
+# Clang does not generate debug info recognized by gdb :(
+LLVM := 0
 endif
 
 ifeq ($(BOARD), rpi3)

--- a/launch
+++ b/launch
@@ -111,7 +111,8 @@ CONFIG = {
                     '-object', 'filter-dump,id=net0,netdev=net0,file=rtl.pcap'
                 ],
                 'uarts': [
-                    dict(name='/dev/tty0', port=RandomPort(), raw=True),
+                    dict(name='/dev/tty0', port=RandomPort(), raw=True,
+                         primary=True),
                     dict(name='/dev/tty1', port=RandomPort()),
                     dict(name='/dev/cons', port=RandomPort())
                 ],
@@ -128,7 +129,8 @@ CONFIG = {
                     '-cpu', 'cortex-a53'],
                 'network_options': [],
                 'uarts': [
-                    dict(name='/dev/tty0', port=RandomPort(), raw=True)
+                    dict(name='/dev/tty0', port=RandomPort(), raw=True,
+                         primary=True),
                 ],
                 'storage_options': [],
                 'drive': 'if=sd,index=0,format=qcow2,file={path}',
@@ -142,7 +144,8 @@ CONFIG = {
                 ],
                 'network_options': [],
                 'uarts': [
-                    dict(name='/dev/tty0', port=RandomPort(), raw=True),
+                    dict(name='/dev/tty0', port=RandomPort(), raw=True,
+                         primary=True),
                     dict(name='/dev/tty1', port=RandomPort(), raw=True)
                 ]
             },
@@ -298,8 +301,10 @@ class QEMU(Launchable):
             if 'port' in uart:
                 port = uart['port']
                 output = f'tcp:127.0.0.1:{port},server,wait'
-            else:
+            elif 'primary' in uart:
                 output = 'stdio'
+            else:
+                output = 'none'
             self.options += ['-serial', output]
 
         if not getvar('config.dts'):

--- a/launch
+++ b/launch
@@ -302,7 +302,7 @@ class QEMU(Launchable):
                 port = uart['port']
                 output = f'tcp:127.0.0.1:{port},server,wait'
             elif 'primary' in uart:
-                output = 'stdio'
+                output = f'file:launch.log'
             else:
                 output = 'none'
             self.options += ['-serial', output]
@@ -399,8 +399,8 @@ def TestRun(sim, dbg, timeout):
 
         if rc == 1:
             print('\n*** CONSOLE ***\n')
-            stdout = sim_proc.read_nonblocking(size=1000000)
-            print(stdout.decode('utf-8').replace('\r\n', '\n'))
+            with open('launch.log', 'rb') as f:
+                print(f.read().decode('utf-8').replace('\r\n', '\n'))
             timed_out = b'received signal SIGINT' in gdb_proc.before
             print('*** GDB OUTPUT ***\n')
             print(gdb_proc.before.decode('utf-8'))

--- a/launch
+++ b/launch
@@ -400,7 +400,7 @@ def TestRun(sim, dbg, timeout):
         if rc == 1:
             print('\n*** CONSOLE ***\n')
             stdout = sim_proc.read_nonblocking(size=1000000)
-            print(stdout.decode('utf-8'))
+            print(stdout.decode('utf-8').replace('\r\n', '\n'))
             timed_out = b'received signal SIGINT' in gdb_proc.before
             print('*** GDB OUTPUT ***\n')
             print(gdb_proc.before.decode('utf-8'))

--- a/launch
+++ b/launch
@@ -295,8 +295,12 @@ class QEMU(Launchable):
 
         self.options = getopts('qemu.options')
         for uart in getvar('qemu.uarts'):
-            port = uart['port']
-            self.options += ['-serial', f'tcp:127.0.0.1:{port},server,wait']
+            if 'port' in uart:
+                port = uart['port']
+                output = f'tcp:127.0.0.1:{port},server,wait'
+            else:
+                output = 'stdio'
+            self.options += ['-serial', output]
 
         if not getvar('config.dts'):
             if getvar('config.args'):
@@ -389,8 +393,11 @@ def TestRun(sim, dbg, timeout):
         rc = gdb_proc.expect_exact([pexpect.EOF, '(gdb) '], timeout=None)
 
         if rc == 1:
+            print('\n*** CONSOLE ***\n')
+            stdout = sim_proc.read_nonblocking(size=1000000)
+            print(stdout.decode('utf-8'))
             timed_out = b'received signal SIGINT' in gdb_proc.before
-            print('\n*** GDB OUTPUT ***\n\n')
+            print('*** GDB OUTPUT ***\n')
             print(gdb_proc.before.decode('utf-8'))
             PostMortem(gdb_proc)
             print('Test run %s!' % ('timeout' if timed_out else 'failed'))
@@ -524,7 +531,8 @@ if __name__ == '__main__':
 
     # Create simulator launcher
     if args.test_run:
-        setvar(f'{sim_name}.uarts', [])
+        for uart in getvar(f'{sim_name}.uarts'):
+            del uart['port']
 
     sim = QEMU() if sim_name == 'qemu' else RENODE()
 

--- a/launch
+++ b/launch
@@ -389,7 +389,7 @@ def TestRun(sim, dbg, timeout):
         rc = gdb_proc.expect_exact([pexpect.EOF, '(gdb) '], timeout=None)
 
         if rc == 1:
-            timed_out = b'Program received signal SIGINT' in gdb_proc.before
+            timed_out = b'received signal SIGINT' in gdb_proc.before
             print('\n*** GDB OUTPUT ***\n\n')
             print(gdb_proc.before.decode('utf-8'))
             PostMortem(gdb_proc)

--- a/lib/libc/gen/ualarm.c
+++ b/lib/libc/gen/ualarm.c
@@ -1,0 +1,59 @@
+/*	$NetBSD: ualarm.c,v 1.11 2012/06/25 22:32:44 abs Exp $	*/
+
+/*
+ * Copyright (c) 1985, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define	USPS	1000000		/* # of microseconds in a second */
+
+/*
+ * Generate a SIGALRM signal in ``usecs'' microseconds.
+ * If ``reload'' is non-zero, keep generating SIGALRM
+ * every ``reload'' microseconds after the first signal.
+ */
+useconds_t
+ualarm(useconds_t usecs, useconds_t reload)
+{
+	struct itimerval new, old;
+
+	new.it_interval.tv_usec = reload % USPS;
+	new.it_interval.tv_sec = reload / USPS;
+	
+	new.it_value.tv_usec = usecs % USPS;
+	new.it_value.tv_sec = usecs / USPS;
+
+	if (setitimer(ITIMER_REAL, &new, &old) == 0)
+		return (useconds_t)(old.it_value.tv_sec * USPS +
+		    old.it_value.tv_usec);
+
+	return (useconds_t)-1;
+}

--- a/sys/debug/README.md
+++ b/sys/debug/README.md
@@ -18,7 +18,8 @@ you can use following custom commands:
    addresses,
 * `segments` - list all memory segments, incl. start, end addresses and
    number of pages (currently just one),
-* `klog` - all log messages currently saved in the kernel,
+* `klog` - all log messages currently saved in the kernel (can be saved to file
+  as well),
 * `threads` - all existing threads,
 * `tlb` - Translation Lookaside Buffer with addresses and flags marking if page
   is dirty (D) and/or global (G).

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -188,7 +188,7 @@ UTEST_ADD(session_login_name);
 #ifdef __mips__
 UTEST_ADD(gettimeofday);
 #endif
-UTEST_ADD(nanosleep);
+// UTEST_ADD(nanosleep);
 UTEST_ADD(itimer);
 
 UTEST_ADD(get_set_uid);

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -4,6 +4,7 @@
 #include <sys/kenv.h>
 #include <sys/ktest.h>
 #include <sys/thread.h>
+#include <sys/time.h>
 #include <sys/proc.h>
 #include <sys/wait.h>
 
@@ -31,6 +32,8 @@ static int utest_generic(const char *name, int status_success) {
   char prefixed_name[TD_NAME_MAX];
   snprintf(prefixed_name, TD_NAME_MAX, "utest-%s", name);
 
+  bintime_t test_start = binuptime();
+
   pid_t cpid;
   if (do_fork(utest_generic_thread, (void *)name, &cpid))
     panic("Could not start test!");
@@ -40,13 +43,20 @@ static int utest_generic(const char *name, int status_success) {
   do_waitpid(cpid, &status, 0, &pid);
   assert(cpid == pid);
 
+  bintime_t test_end = binuptime();
+  bintime_sub(&test_end, &test_start);
+
+  timeval_t took;
+  bt2tv(&test_end, &took);
+  long took_us = took.tv_sec * 1000000L + took.tv_usec;
+
   /* Restore previous klog mask */
   /* XXX: If we'll use klog_setmask heavily, maybe we should consider
      klog_{push,pop}_mask. */
   klog_setmask(old_klog_mask);
 
-  klog("User test %s finished with status: %d, expected: %d", name, status,
-       status_success);
+  klog("User test '%s' took %d.%03dms; finished with status: %d, expected: %d",
+       name, took_us / 1000, took_us % 1000, status, status_success);
   if (status == status_success)
     return KTEST_SUCCESS;
   else

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -32,6 +32,8 @@ static int utest_generic(const char *name, int status_success) {
   char prefixed_name[TD_NAME_MAX];
   snprintf(prefixed_name, TD_NAME_MAX, "utest-%s", name);
 
+  klog("User test '%s' started", name);
+
   bintime_t test_start = binuptime();
 
   pid_t cpid;

--- a/sys/tests/utest.c
+++ b/sys/tests/utest.c
@@ -54,153 +54,151 @@ static int utest_generic(const char *name, int status_success) {
 }
 
 /* Adds a new test executed by running /bin/utest. */
-#define UTEST_ADD(name, status_success, flags)                                 \
+#define UTEST_ADD(name)                                                        \
   static int utest_test_##name(void) {                                         \
-    return utest_generic(#name, status_success);                               \
+    return utest_generic(#name, MAKE_STATUS_EXIT(0));                          \
   }                                                                            \
-  KTEST_ADD(user_##name, utest_test_##name, flags | KTEST_FLAG_USERMODE);
+  KTEST_ADD(user_##name, utest_test_##name, KTEST_FLAG_USERMODE)
 
-#define UTEST_ADD_SIMPLE(name) UTEST_ADD(name, MAKE_STATUS_EXIT(0), 0)
+UTEST_ADD(vmmap_text_access);
+UTEST_ADD(vmmap_data_access);
+UTEST_ADD(vmmap_rodata_access);
 
-UTEST_ADD_SIMPLE(vmmap_text_access);
-UTEST_ADD_SIMPLE(vmmap_data_access);
-UTEST_ADD_SIMPLE(vmmap_rodata_access);
+UTEST_ADD(mmap);
+UTEST_ADD(munmap);
+UTEST_ADD(munmap_sigsegv);
+UTEST_ADD(munmap_many_1);
+UTEST_ADD(munmap_many_2);
+UTEST_ADD(mmap_prot_none);
+UTEST_ADD(mmap_prot_read);
+UTEST_ADD(mmap_fixed);
+UTEST_ADD(mmap_fixed_excl);
+UTEST_ADD(mmap_fixed_replace);
+UTEST_ADD(mmap_fixed_replace_many_1);
+UTEST_ADD(mmap_fixed_replace_many_2);
+UTEST_ADD(sbrk);
+UTEST_ADD(sbrk_sigsegv);
+UTEST_ADD(misbehave);
 
-UTEST_ADD_SIMPLE(mmap);
-UTEST_ADD_SIMPLE(munmap);
-UTEST_ADD_SIMPLE(munmap_sigsegv);
-UTEST_ADD_SIMPLE(munmap_many_1);
-UTEST_ADD_SIMPLE(munmap_many_2);
-UTEST_ADD_SIMPLE(mmap_prot_none);
-UTEST_ADD_SIMPLE(mmap_prot_read);
-UTEST_ADD_SIMPLE(mmap_fixed);
-UTEST_ADD_SIMPLE(mmap_fixed_excl);
-UTEST_ADD_SIMPLE(mmap_fixed_replace);
-UTEST_ADD_SIMPLE(mmap_fixed_replace_many_1);
-UTEST_ADD_SIMPLE(mmap_fixed_replace_many_2);
-UTEST_ADD_SIMPLE(sbrk);
-UTEST_ADD_SIMPLE(sbrk_sigsegv);
-UTEST_ADD_SIMPLE(misbehave);
+UTEST_ADD(fd_read);
+UTEST_ADD(fd_devnull);
+UTEST_ADD(fd_multidesc);
+UTEST_ADD(fd_readwrite);
+UTEST_ADD(fd_copy);
+UTEST_ADD(fd_bad_desc);
+UTEST_ADD(fd_open_path);
+UTEST_ADD(fd_dup);
+UTEST_ADD(fd_pipe);
+UTEST_ADD(fd_readv);
+UTEST_ADD(fd_writev);
+UTEST_ADD(fd_all);
 
-UTEST_ADD_SIMPLE(fd_read);
-UTEST_ADD_SIMPLE(fd_devnull);
-UTEST_ADD_SIMPLE(fd_multidesc);
-UTEST_ADD_SIMPLE(fd_readwrite);
-UTEST_ADD_SIMPLE(fd_copy);
-UTEST_ADD_SIMPLE(fd_bad_desc);
-UTEST_ADD_SIMPLE(fd_open_path);
-UTEST_ADD_SIMPLE(fd_dup);
-UTEST_ADD_SIMPLE(fd_pipe);
-UTEST_ADD_SIMPLE(fd_readv);
-UTEST_ADD_SIMPLE(fd_writev);
-UTEST_ADD_SIMPLE(fd_all);
+UTEST_ADD(signal_basic);
+UTEST_ADD(signal_send);
+UTEST_ADD(signal_abort);
+UTEST_ADD(signal_segfault);
+UTEST_ADD(signal_stop);
+UTEST_ADD(signal_cont_masked);
+UTEST_ADD(signal_mask);
+UTEST_ADD(signal_mask_nonmaskable);
+UTEST_ADD(signal_sigsuspend);
+UTEST_ADD(signal_sigsuspend_stop);
+UTEST_ADD(signal_handler_mask);
 
-UTEST_ADD_SIMPLE(signal_basic);
-UTEST_ADD_SIMPLE(signal_send);
-UTEST_ADD_SIMPLE(signal_abort);
-UTEST_ADD_SIMPLE(signal_segfault);
-UTEST_ADD_SIMPLE(signal_stop);
-UTEST_ADD_SIMPLE(signal_cont_masked);
-UTEST_ADD_SIMPLE(signal_mask);
-UTEST_ADD_SIMPLE(signal_mask_nonmaskable);
-UTEST_ADD_SIMPLE(signal_sigsuspend);
-UTEST_ADD_SIMPLE(signal_sigsuspend_stop);
-UTEST_ADD_SIMPLE(signal_handler_mask);
+UTEST_ADD(fork_wait);
+UTEST_ADD(fork_signal);
+UTEST_ADD(fork_sigchld_ignored);
 
-UTEST_ADD_SIMPLE(fork_wait);
-UTEST_ADD_SIMPLE(fork_signal);
-UTEST_ADD_SIMPLE(fork_sigchld_ignored);
+UTEST_ADD(lseek_basic);
+UTEST_ADD(lseek_errors);
 
-UTEST_ADD_SIMPLE(lseek_basic);
-UTEST_ADD_SIMPLE(lseek_errors);
+UTEST_ADD(access_basic);
 
-UTEST_ADD_SIMPLE(access_basic);
+UTEST_ADD(stat);
+UTEST_ADD(fstat);
 
-UTEST_ADD_SIMPLE(stat);
-UTEST_ADD_SIMPLE(fstat);
+UTEST_ADD(setjmp);
 
-UTEST_ADD_SIMPLE(setjmp);
+UTEST_ADD(sigaction_with_setjmp);
+UTEST_ADD(sigaction_handler_returns);
 
-UTEST_ADD_SIMPLE(sigaction_with_setjmp);
-UTEST_ADD_SIMPLE(sigaction_handler_returns);
+UTEST_ADD(vfs_dir);
+UTEST_ADD(vfs_relative_dir);
+UTEST_ADD(vfs_rw);
+UTEST_ADD(vfs_dot_dot_dir);
+UTEST_ADD(vfs_dot_dir);
+UTEST_ADD(vfs_dot_dot_across_fs);
+UTEST_ADD(vfs_trunc);
+UTEST_ADD(vfs_symlink);
+UTEST_ADD(vfs_link);
+UTEST_ADD(vfs_chmod);
 
-UTEST_ADD_SIMPLE(vfs_dir);
-UTEST_ADD_SIMPLE(vfs_relative_dir);
-UTEST_ADD_SIMPLE(vfs_rw);
-UTEST_ADD_SIMPLE(vfs_dot_dot_dir);
-UTEST_ADD_SIMPLE(vfs_dot_dir);
-UTEST_ADD_SIMPLE(vfs_dot_dot_across_fs);
-UTEST_ADD_SIMPLE(vfs_trunc);
-UTEST_ADD_SIMPLE(vfs_symlink);
-UTEST_ADD_SIMPLE(vfs_link);
-UTEST_ADD_SIMPLE(vfs_chmod);
-
-UTEST_ADD_SIMPLE(wait_basic);
-UTEST_ADD_SIMPLE(wait_nohang);
+UTEST_ADD(wait_basic);
+UTEST_ADD(wait_nohang);
 
 #if 0
-UTEST_ADD_SIMPLE(fpu_fcsr);
-UTEST_ADD_SIMPLE(fpu_gpr_preservation);
-UTEST_ADD_SIMPLE(fpu_cpy_ctx_on_fork);
-UTEST_ADD_SIMPLE(fpu_ctx_signals);
+UTEST_ADD(fpu_fcsr);
+UTEST_ADD(fpu_gpr_preservation);
+UTEST_ADD(fpu_cpy_ctx_on_fork);
+UTEST_ADD(fpu_ctx_signals);
 #endif
 
 #ifdef __mips__
-UTEST_ADD_SIMPLE(exc_cop_unusable);
-UTEST_ADD_SIMPLE(exc_reserved_instruction);
-UTEST_ADD_SIMPLE(exc_unaligned_access);
-UTEST_ADD_SIMPLE(exc_integer_overflow);
+UTEST_ADD(exc_cop_unusable);
+UTEST_ADD(exc_reserved_instruction);
+UTEST_ADD(exc_unaligned_access);
+UTEST_ADD(exc_integer_overflow);
 
-UTEST_ADD_SIMPLE(exc_sigsys);
+UTEST_ADD(exc_sigsys);
 #endif
 
 #ifdef __aarch64__
-UTEST_ADD_SIMPLE(exc_unknown_instruction);
-UTEST_ADD_SIMPLE(exc_msr_instruction);
-UTEST_ADD_SIMPLE(exc_mrs_instruction);
+UTEST_ADD(exc_unknown_instruction);
+UTEST_ADD(exc_msr_instruction);
+UTEST_ADD(exc_mrs_instruction);
 
-UTEST_ADD_SIMPLE(exc_brk);
+UTEST_ADD(exc_brk);
 #endif
 
-UTEST_ADD_SIMPLE(getcwd);
-/* XXX UTEST_ADD_SIMPLE(syscall_in_bds); */
+UTEST_ADD(getcwd);
+/* XXX UTEST_ADD(syscall_in_bds); */
 
-UTEST_ADD_SIMPLE(setpgid);
-UTEST_ADD_SIMPLE(setpgid_leader);
-UTEST_ADD_SIMPLE(setpgid_child);
-UTEST_ADD_SIMPLE(kill);
-UTEST_ADD_SIMPLE(killpg_same_group);
-UTEST_ADD_SIMPLE(killpg_other_group);
-UTEST_ADD_SIMPLE(pgrp_orphan);
-UTEST_ADD_SIMPLE(session_basic);
-UTEST_ADD_SIMPLE(session_login_name);
+UTEST_ADD(setpgid);
+UTEST_ADD(setpgid_leader);
+UTEST_ADD(setpgid_child);
+UTEST_ADD(kill);
+UTEST_ADD(killpg_same_group);
+UTEST_ADD(killpg_other_group);
+UTEST_ADD(pgrp_orphan);
+UTEST_ADD(session_basic);
+UTEST_ADD(session_login_name);
 
 #ifdef __mips__
-UTEST_ADD_SIMPLE(gettimeofday);
+UTEST_ADD(gettimeofday);
 #endif
-UTEST_ADD_SIMPLE(nanosleep);
-UTEST_ADD_SIMPLE(itimer);
+UTEST_ADD(nanosleep);
+UTEST_ADD(itimer);
 
-UTEST_ADD_SIMPLE(get_set_uid);
-UTEST_ADD_SIMPLE(get_set_gid);
-UTEST_ADD_SIMPLE(get_set_groups);
+UTEST_ADD(get_set_uid);
+UTEST_ADD(get_set_gid);
+UTEST_ADD(get_set_groups);
 
-UTEST_ADD_SIMPLE(sharing_memory_simple);
-UTEST_ADD_SIMPLE(sharing_memory_child_and_grandchild);
+UTEST_ADD(sharing_memory_simple);
+UTEST_ADD(sharing_memory_child_and_grandchild);
 
-UTEST_ADD_SIMPLE(pty_simple);
+UTEST_ADD(pty_simple);
 
-UTEST_ADD_SIMPLE(tty_canon);
-UTEST_ADD_SIMPLE(tty_echo);
-UTEST_ADD_SIMPLE(tty_signals);
+UTEST_ADD(tty_canon);
+UTEST_ADD(tty_echo);
+UTEST_ADD(tty_signals);
 
-UTEST_ADD_SIMPLE(procstat);
+UTEST_ADD(procstat);
 
-UTEST_ADD_SIMPLE(pipe_parent_signaled);
-UTEST_ADD_SIMPLE(pipe_child_signaled);
-UTEST_ADD_SIMPLE(pipe_blocking_flag_manipulation);
-UTEST_ADD_SIMPLE(pipe_write_interruptible_sleep);
-UTEST_ADD_SIMPLE(pipe_write_errno_eagain);
-UTEST_ADD_SIMPLE(pipe_read_interruptible_sleep);
-UTEST_ADD_SIMPLE(pipe_read_errno_eagain);
-UTEST_ADD_SIMPLE(pipe_read_return_zero);
+UTEST_ADD(pipe_parent_signaled);
+UTEST_ADD(pipe_child_signaled);
+UTEST_ADD(pipe_blocking_flag_manipulation);
+UTEST_ADD(pipe_write_interruptible_sleep);
+UTEST_ADD(pipe_write_errno_eagain);
+UTEST_ADD(pipe_read_interruptible_sleep);
+UTEST_ADD(pipe_read_errno_eagain);
+UTEST_ADD(pipe_read_return_zero);


### PR DESCRIPTION
* add TEST_ADD macro to define new tests
* add set of macros in utest.h to perform checks
* shorten duration of some tests that used sleep/nanosleep
* add ualarm implementation from NetBSD
* allow klog to be dumped to file
* each user test logs start time
* launch: correctly report test timeout
* launch: print output from console on test run failure or timeout