### PR TITLE
Fix error returned from getresuid and getresgid 

### DIFF
--- a/bin/utest/cred.c
+++ b/bin/utest/cred.c
@@ -25,7 +25,8 @@ int test_get_set_uid(void) {
   error = setresuid(ruid, euid, suid);
   assert(error == 0);
 
-  getresuid(&ruid, &euid, &suid);
+  error = getresuid(&ruid, &euid, &suid);
+  assert(error == 0);
   assert(ruid == 1 && euid == 2 && suid == 3);
 
   /* we can only change to value that is one of real, effective or saved */
@@ -33,7 +34,8 @@ int test_get_set_uid(void) {
   error = setresuid(ruid, euid, suid);
   assert(error == 0);
 
-  getresuid(&ruid, &euid, &suid);
+  error = getresuid(&ruid, &euid, &suid);
+  assert(error == 0);
   assert(ruid == 1 && euid == 3 && suid == 3);
 
   /* we cannnot change to value that is not one of real, effective or saved */
@@ -41,7 +43,8 @@ int test_get_set_uid(void) {
   error = setresuid(ruid, euid, suid);
   assert(error < 0 && errno == EPERM);
 
-  getresuid(&ruid, &euid, &suid);
+  error = getresuid(&ruid, &euid, &suid);
+  assert(error == 0);
   assert(ruid == 1 && euid == 3 && suid == 3);
 
   return 0;
@@ -66,7 +69,8 @@ int test_get_set_gid(void) {
   error = setresgid(rgid, egid, sgid);
   assert(error == 0);
 
-  getresgid(&rgid, &egid, &sgid);
+  error = getresgid(&rgid, &egid, &sgid);
+  assert(error == 0);
   assert(rgid == 1 && egid == 2 && sgid == 3);
 
   /* dropping privileges */
@@ -77,7 +81,8 @@ int test_get_set_gid(void) {
   error = setresgid(rgid, egid, sgid);
   assert(error == 0);
 
-  getresgid(&rgid, &egid, &sgid);
+  error = getresgid(&rgid, &egid, &sgid);
+  assert(error == 0);
   assert(rgid == 1 && egid == 3 && sgid == 3);
 
   /* we cannnot change to value that is not one of real, effective or saved */
@@ -85,7 +90,8 @@ int test_get_set_gid(void) {
   error = setresgid(rgid, egid, sgid);
   assert(error < 0 && errno == EPERM);
 
-  getresgid(&rgid, &egid, &sgid);
+  error = getresgid(&rgid, &egid, &sgid);
+  assert(error == 0);
   assert(rgid == 1 && egid == 3 && sgid == 3);
 
   return 0;
@@ -94,10 +100,12 @@ int test_get_set_gid(void) {
 int test_get_set_groups(void) {
   gid_t rgrp[NGROUPS_MAX], gidset[NGROUPS_MAX] = {0, 1, 2, 3, 4, 5};
   int r, ngroups = 6;
+  int error;
   uid_t euid;
 
   /* check if we are a root at start */
-  getresuid(NULL, &euid, NULL);
+  error = getresuid(NULL, &euid, NULL);
+  assert(error == 0);
   assert(euid == 0);
   r = getgroups(0, NULL);
   assert(r == 0);

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -663,14 +663,22 @@ static int sys_getresuid(proc_t *p, getresuid_args_t *args, register_t *res) {
   uid_t *usr_euid = SCARG(args, euid);
   uid_t *usr_suid = SCARG(args, suid);
 
-  klog("getresuid()");
+  klog("getresuid(%p, %p, %p)", usr_ruid, usr_euid, usr_suid);
 
   uid_t ruid, euid, suid;
   do_getresuid(p, &ruid, &euid, &suid);
 
-  int err1 = copyout(&ruid, usr_ruid, sizeof(uid_t));
-  int err2 = copyout(&euid, usr_euid, sizeof(uid_t));
-  int err3 = copyout(&suid, usr_suid, sizeof(uid_t));
+  int err1, err2, err3;
+  err1 = err2 = err3 = 0;
+
+  if (usr_ruid != NULL)
+    err1 = copyout(&ruid, usr_ruid, sizeof(uid_t));
+
+  if (usr_euid != NULL)
+    err2 = copyout(&euid, usr_euid, sizeof(uid_t));
+
+  if (usr_suid != NULL)
+    err3 = copyout(&suid, usr_suid, sizeof(uid_t));
 
   return err1 ? err1 : (err2 ? err2 : err3);
 }
@@ -680,14 +688,22 @@ static int sys_getresgid(proc_t *p, getresgid_args_t *args, register_t *res) {
   gid_t *usr_egid = SCARG(args, egid);
   gid_t *usr_sgid = SCARG(args, sgid);
 
-  klog("getresgid()");
+  klog("getresgid(%p, %p, %p)", usr_rgid, usr_egid, usr_sgid);
 
   gid_t rgid, egid, sgid;
   do_getresgid(p, &rgid, &egid, &sgid);
 
-  int err1 = copyout(&rgid, usr_rgid, sizeof(gid_t));
-  int err2 = copyout(&egid, usr_egid, sizeof(gid_t));
-  int err3 = copyout(&sgid, usr_sgid, sizeof(gid_t));
+  int err1, err2, err3;
+  err1 = err2 = err3 = 0;
+
+  if (usr_rgid != NULL)
+    err1 = copyout(&rgid, usr_rgid, sizeof(gid_t));
+
+  if (usr_egid != NULL)
+    err2 = copyout(&egid, usr_egid, sizeof(gid_t));
+
+  if (usr_sgid != NULL)
+    err3 = copyout(&sgid, usr_sgid, sizeof(gid_t));
 
   return err1 ? err1 : (err2 ? err2 : err3);
 }


### PR DESCRIPTION
`getresuid` and `getresgid` return EFAULT when some address passed as argument is invalid. NULL value is also treated as invalid addres. This PR allows to pass NULL value as an argument for these syscalls (to retrieve only uids or gids for which non-NULL address is provided).

In manual entry ([getresuid(2)](https://www.freebsd.org/cgi/man.cgi?query=getresuid&sektion=2&n=1)) there is not specified what should happen if we pass NULL addres to these functions. Maybe that is the reason why we had choose to return error in such cases in the past.