### PR TITLE
[sleepq] Add a mutex to the sleepq wait interface.

### DIFF
--- a/include/sys/sleepq.h
+++ b/include/sys/sleepq.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/queue.h>
 
+typedef struct mtx mtx_t;
 typedef struct thread thread_t;
 typedef struct sleepq sleepq_t;
 
@@ -23,11 +24,14 @@ void sleepq_destroy(sleepq_t *sq);
  *
  * \param wchan unique sleep queue identifier
  * \param waitpt caller associated with sleep action
+ * \param mtx mutex to release before falling asleep and reacquire
+ * upon waking up
  */
-void sleepq_wait(void *wchan, const void *waitpt);
+void sleepq_wait(void *wchan, const void *waitpt, mtx_t *mtx);
 
 /*! \brief Same as \a sleepq_wait but allows the sleep to be interrupted. */
-#define sleepq_wait_intr(wchan, waitpt) sleepq_wait_timed((wchan), (waitpt), 0)
+#define sleepq_wait_intr(wchan, waitpt, mtx)                                   \
+  sleepq_wait_timed((wchan), (waitpt), (mtx), 0)
 
 /*! \brief Performs interruptible sleep with timeout.
  *
@@ -37,7 +41,8 @@ void sleepq_wait(void *wchan, const void *waitpt);
  *
  * \param timeout in system ticks, if 0 waits indefinitely
  * \returns how the thread was actually woken up */
-int sleepq_wait_timed(void *wchan, const void *waitpt, systime_t timeout);
+int sleepq_wait_timed(void *wchan, const void *waitpt, mtx_t *mtx,
+                      systime_t timeout);
 
 /*! \brief Wakes up highest priority thread waiting on \a wchan.
  *

--- a/sys/drv/rtc.c
+++ b/sys/drv/rtc.c
@@ -80,7 +80,7 @@ static int rtc_time_read(devnode_t *dev, uio_t *uio) {
   rtc_state_t *rtc = dev->data;
   tm_t t;
 
-  sleepq_wait(rtc, NULL);
+  sleepq_wait(rtc, NULL, NULL);
   rtc_gettime(rtc->regs, &t);
   int count = snprintf(rtc->asctime, RTC_ASCTIME_SIZE, "%d %d %d %d %d %d",
                        t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour,

--- a/sys/kern/callout.c
+++ b/sys/kern/callout.c
@@ -55,7 +55,7 @@ static void callout_thread(void *arg) {
 
     WITH_INTR_DISABLED {
       while (TAILQ_EMPTY(&delegated)) {
-        sleepq_wait(&delegated, NULL);
+        sleepq_wait(&delegated, NULL, NULL);
       }
 
       elem = TAILQ_FIRST(&delegated);
@@ -211,6 +211,6 @@ bool callout_drain(callout_t *handle) {
   if (!callout_is_pending(handle) && !callout_is_active(handle))
     return false;
   while (callout_is_pending(handle) || callout_is_active(handle))
-    sleepq_wait(handle, NULL);
+    sleepq_wait(handle, NULL, NULL);
   return true;
 }

--- a/sys/kern/condvar.c
+++ b/sys/kern/condvar.c
@@ -15,7 +15,7 @@ void cv_wait(condvar_t *cv, mtx_t *m) {
     /* If we got interrupted here and an interrupt filter called
      * cv_signal, we would have a lost wakeup, so we need interrupts
      * to be disabled. Same goes for cv_wait_timed. */
-    sleepq_wait(cv, __caller(0));
+    sleepq_wait(cv, __caller(0), NULL);
   }
   _mtx_lock(m, __caller(0));
 }
@@ -25,7 +25,7 @@ int cv_wait_timed(condvar_t *cv, mtx_t *m, systime_t timeout) {
   WITH_INTR_DISABLED {
     cv->waiters++;
     mtx_unlock(m);
-    status = sleepq_wait_timed(cv, __caller(0), timeout);
+    status = sleepq_wait_timed(cv, __caller(0), NULL, timeout);
   }
   _mtx_lock(m, __caller(0));
   return status;

--- a/sys/kern/interrupt.c
+++ b/sys/kern/interrupt.c
@@ -275,7 +275,7 @@ static void intr_thread(void *arg) {
       if (!TAILQ_EMPTY(&ie->ie_handlers))
         ie_enable(ie);
 
-      sleepq_wait(ie, NULL);
+      sleepq_wait(ie, NULL, NULL);
     }
   }
 }

--- a/sys/kern/signal.c
+++ b/sys/kern/signal.c
@@ -195,7 +195,7 @@ int do_sigsuspend(proc_t *p, const sigset_t *mask) {
   }
 
   int error;
-  error = sleepq_wait_intr(&td->td_sigmask, "sigsuspend()");
+  error = sleepq_wait_intr(&td->td_sigmask, "sigsuspend()", NULL);
   assert(error == EINTR);
 
   return ERESTARTNOHAND;

--- a/sys/kern/time.c
+++ b/sys/kern/time.c
@@ -89,7 +89,7 @@ int do_clock_nanosleep(clockid_t clk, int flags, timespec_t *rqtp,
   }
 
   do {
-    error = sleepq_wait_timed((void *)(&rmt_start), __caller(0), timo);
+    error = sleepq_wait_timed((void *)(&rmt_start), __caller(0), NULL, timo);
     if (error == ETIMEDOUT)
       goto timedout;
 

--- a/sys/tests/sleepq.c
+++ b/sys/tests/sleepq.c
@@ -12,7 +12,7 @@ static void test_thread(void *expected) {
     WITH_NO_PREEMPTION {
       wakeups++;
     }
-    sleepq_wait(&test_thread, NULL);
+    sleepq_wait(&test_thread, NULL, NULL);
   }
 }
 

--- a/sys/tests/sleepq_abort.c
+++ b/sys/tests/sleepq_abort.c
@@ -35,7 +35,7 @@ static volatile int interrupted;
  * when waiters can't.
  * Therefore there should be only one waiter active at once */
 static void waiter_routine(void *_arg) {
-  int rsn = sleepq_wait_intr(&some_val, __caller(0));
+  int rsn = sleepq_wait_intr(&some_val, __caller(0), NULL);
 
   if (rsn == EINTR)
     interrupted++;

--- a/sys/tests/sleepq_timed.c
+++ b/sys/tests/sleepq_timed.c
@@ -34,7 +34,7 @@ static thread_t *waker;
 
 static void waiter_routine(void *_arg) {
   systime_t before_sleep = getsystime();
-  int status = sleepq_wait_timed(&wchan, __caller(0), SLEEP_TICKS);
+  int status = sleepq_wait_timed(&wchan, __caller(0), NULL, SLEEP_TICKS);
   systime_t after_sleep = getsystime();
   systime_t diff = after_sleep - before_sleep;
 

--- a/sys/tests/thread_stats.c
+++ b/sys/tests/thread_stats.c
@@ -53,12 +53,12 @@ static void thread_wake_function(void *arg) {
 }
 
 static void thread_sleep_function(void *arg) {
-  sleepq_wait(arg, "Thread stats test sleepq");
+  sleepq_wait(arg, "Thread stats test sleepq", NULL);
   bintime_t end = *(bintime_t *)arg;
   bintime_add_frac(&end, test_time_frac);
   bintime_t now = binuptime();
   while (bintime_cmp(&now, &end, <)) {
-    sleepq_wait(arg, "Thread stats test sleepq");
+    sleepq_wait(arg, "Thread stats test sleepq", NULL);
     now = binuptime();
   }
 }

--- a/sys/tests/turnstile_adjust.c
+++ b/sys/tests/turnstile_adjust.c
@@ -83,7 +83,7 @@ static int test_turnstile_adjust(void) {
   for (int i = 0; i < T; i++) {
     WITH_NO_PREEMPTION {
       sched_add(threads[i]);
-      sleepq_wait(threads[i], "thread start");
+      sleepq_wait(threads[i], "thread start", NULL);
     }
   }
 


### PR DESCRIPTION
As the current sleepq interface lacks any mechanism to lock the destination chain before calling the appropriate wait function, we at least need a way to release a provided lock before falling asleep.
The `sleepq_lock` mechanism will be introduced as part of merging #1367.

Required by `sigtimedwait` (see #1320).