### PR TITLE
Update python files

### DIFF
--- a/launch
+++ b/launch
@@ -261,7 +261,7 @@ class Launchable():
         cmd = ' '.join([self.cmd] + list(map(shlex.quote, self.options)))
         self.window = session.new_window(
             attach=False, window_name=self.name, window_shell=cmd)
-        self.pid = int(self.window.attached_pane.pane_index)
+        self.pid = int(self.window.attached_pane._info['pane_pid'])
 
     def spawn(self, dimensions=None, cpulimit=None):
         def set_cpu_limit():

--- a/launch
+++ b/launch
@@ -258,10 +258,27 @@ class Launchable():
         self.options = []
 
     def start(self, session):
+        from libtmux.common import get_libtmux_version
+
+        def has_newer_version(version, expect):
+            vn = map(int, version.split("."))
+            en = map(int, expect.split("."))
+
+            for v, e in zip(vn, en):
+                if v < e:
+                    return False
+                if v > e:
+                    return True
+            # If we reached here versions are equal
+            return True
+
         cmd = ' '.join([self.cmd] + list(map(shlex.quote, self.options)))
         self.window = session.new_window(
             attach=False, window_name=self.name, window_shell=cmd)
-        self.pid = int(self.window.attached_pane._info['pane_pid'])
+        if has_newer_version(str(get_libtmux_version()), "0.17.0"):
+            self.pid = int(self.window.attached_pane.pane_index)
+        else:
+            self.pid = int(self.window.attached_pane._info['pane_pid'])
 
     def spawn(self, dimensions=None, cpulimit=None):
         def set_cpu_limit():

--- a/launch
+++ b/launch
@@ -261,7 +261,7 @@ class Launchable():
         cmd = ' '.join([self.cmd] + list(map(shlex.quote, self.options)))
         self.window = session.new_window(
             attach=False, window_name=self.name, window_shell=cmd)
-        self.pid = int(self.window.attached_pane._info['pane_pid'])
+        self.pid = int(self.window.attached_pane.pane_index)
 
     def spawn(self, dimensions=None, cpulimit=None):
         def set_cpu_limit():

--- a/launch
+++ b/launch
@@ -258,27 +258,10 @@ class Launchable():
         self.options = []
 
     def start(self, session):
-        from libtmux.common import get_libtmux_version
-
-        def has_newer_version(version, expect):
-            vn = map(int, version.split("."))
-            en = map(int, expect.split("."))
-
-            for v, e in zip(vn, en):
-                if v < e:
-                    return False
-                if v > e:
-                    return True
-            # If we reached here versions are equal
-            return True
-
         cmd = ' '.join([self.cmd] + list(map(shlex.quote, self.options)))
         self.window = session.new_window(
             attach=False, window_name=self.name, window_shell=cmd)
-        if has_newer_version(str(get_libtmux_version()), "0.17.0"):
-            self.pid = int(self.window.attached_pane.pane_index)
-        else:
-            self.pid = int(self.window.attached_pane._info['pane_pid'])
+        self.pid = int(self.window.attached_pane._info['pane_pid'])
 
     def spawn(self, dimensions=None, cpulimit=None):
         def set_cpu_limit():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pycodestyle
-pexpect
-fdt
-texttable
-libtmux
+pycodestyle == 2.10.0
+pexpect == 4.8.0
+fdt == 0.3.3
+texttable == 1.6.7
+libtmux == 0.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pycodestyle == 2.10.0
 pexpect == 4.8.0
 fdt == 0.3.3
 texttable == 1.6.7
-libtmux == 0.21.1
+libtmux == 0.15.8

--- a/verify-pycodestyle.sh
+++ b/verify-pycodestyle.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-PYFILES=$(find . \( -name 'toolchain' -prune \)\
-              -o \( -name '.*.py' -prune \) \
-              -o \( -name 'mimiker-env' -prune \) \
-              -o \( -name '*.py' -printf '%P\n' \))
+PYFILES=$(find . \( -name "toolchain" -prune \)\
+              -o \( -name ".*.py" -prune \) \
+              -o \( -name "$(basename $VIRTUAL_ENV)" -prune \) \
+              -o \( -name "*.py" -printf "%P\n" \))
 PYEXTRA="launch"
 
 pycodestyle ${PYEXTRA} ${PYFILES}

--- a/verify-pycodestyle.sh
+++ b/verify-pycodestyle.sh
@@ -2,6 +2,7 @@
 
 PYFILES=$(find . \( -name 'toolchain' -prune \)\
               -o \( -name '.*.py' -prune \) \
+              -o \( -name 'mimiker-env' -prune \) \
               -o \( -name '*.py' -printf '%P\n' \))
 PYEXTRA="launch"
 


### PR DESCRIPTION
~I had a problem with launch script due to an update of API made in `libtmux v0.17.0`. (Accessing pane id is done in a different way now.) I have updated the launch script to determine which version is used and to access pane id using the right way.~

1. Ignore python files in current python venv
2. Pin versions of packages in `requirements.txt` (proposed versions work for me. Tested on Python 3.9 and 3.10.)