### PR TITLE
git: ignore changes in submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ sysroot
 
 # python env
 mimiker-env/
+
+#
+contrib/*/build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "contrib/lua/lua"]
 	path = contrib/lua/lua
 	url = https://github.com/lua/lua.git
+	ignore = dirty
 [submodule "contrib/atto/atto"]
 	path = contrib/atto/atto
 	url = https://github.com/hughbarney/atto.git
@@ -10,3 +11,4 @@
 [submodule "contrib/sinit/sinit"]
 	path = contrib/sinit/sinit
 	url = git://git.suckless.org/sinit
+	ignore = dirty


### PR DESCRIPTION
After building Mimiker git status shows changes in submodules. I they shouldn't be visible.