### PR TITLE
Add clangd files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ tags
 etags
 *.taghl
 
+# lsp files
+compile_commands.json
+.cache/clangd/
+
 # generated assembly files
 assym.h
 


### PR DESCRIPTION
I want to add clangd files to `.gitignore` to make working easier when using LSP.

Besides that change I am wondering if it is easy to add support for clangd in Mimiker. We currently have support for ctags and generate files for them. Clangd requires a file `compile_commands.json` which describes how to build the project (it can be generated with [`bear`](https://github.com/rizsotto/Bear) and I think we can consider adding some rule that will do that to Makefile). 