### PR TITLE
proc: Free `p_args` from proper kmalloc pool

### DIFF
--- a/sys/kern/proc.c
+++ b/sys/kern/proc.c
@@ -531,7 +531,7 @@ static void proc_reap(proc_t *p) {
   TAILQ_REMOVE(CHILDREN(p->p_parent), p, p_child);
   TAILQ_REMOVE(&zombie_list, p, p_zombie);
   kfree(M_STR, p->p_elfpath);
-  kfree(M_TEMP, p->p_args);
+  kfree(M_STR, p->p_args);
   TAILQ_REMOVE(PROC_HASH_CHAIN(p->p_pid), p, p_hash);
   pool_free(P_PROC, p);
 }


### PR DESCRIPTION
`p_args` was freed different poll than it was allocated on.