### PR TITLE
Increase timeouts due to test environment changes

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "mips kernel+ramdisk"
-      - run: ./run_tests.py --board malta --timeout=90 --times=50
+      - run: ./run_tests.py --board malta --timeout=100 --times=50
 
   kernel_tests_aarch64:
     name: Tests AArch64
@@ -129,4 +129,4 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "riscv64 kernel+ramdisk"
-      - run: ./run_tests.py --board sifive_u --timeout=90 --times=50
+      - run: ./run_tests.py --board sifive_u --timeout=100 --times=50

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "mips kernel+ramdisk"
-      - run: ./run_tests.py --board malta --timeout=80 --times=50
+      - run: ./run_tests.py --board malta --timeout=90 --times=50
 
   kernel_tests_aarch64:
     name: Tests AArch64
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "aarch64 kernel+ramdisk"
-      - run: ./run_tests.py --board rpi3 --times=50
+      - run: ./run_tests.py --board rpi3 --timeout=60 --times=50
 
   kernel_tests_riscv64:
     name: Tests RISC-V 64-bit
@@ -129,4 +129,4 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "riscv64 kernel+ramdisk"
-      - run: ./run_tests.py --board sifive_u --timeout=80 --times=50
+      - run: ./run_tests.py --board sifive_u --timeout=90 --times=50


### PR DESCRIPTION
GitHub Actions runners were moved to another server with single core performance lower than the previous one. Previously they were run in virtualized environment with 4 cores and 8 hardware threads. Now they're running on 12 cores and 24 hardware threads machine.

Though total performance is higher on newer server, according to https://www.cpubenchmark.net/compare/3106vs2051/Intel-Xeon-Silver-4110-vs-Intel-Xeon-E5-2620-v2 single core performance is ~17% lower. Hence the timeouts have to be adjusted accordingly.