### PR TITLE
Workaround for /sbin/init

### DIFF
--- a/contrib/sinit/patches/series
+++ b/contrib/sinit/patches/series
@@ -1,1 +1,2 @@
+sinit.patch
 config.patch

--- a/contrib/sinit/patches/sinit.patch
+++ b/contrib/sinit/patches/sinit.patch
@@ -1,14 +1,12 @@
 Index: sinit/sinit/sinit.c
 ===================================================================
---- sinit.orig/sinit/sinit.c	2023-06-04 17:28:33.209715149 +0200
-+++ sinit/sinit/sinit.c	2023-06-04 17:29:49.403045971 +0200
-@@ -37,7 +37,8 @@
+--- sinit.orig/sinit/sinit.c	2023-06-04 17:29:56.303045745 +0200
++++ sinit/sinit/sinit.c	2023-06-04 21:49:07.799201063 +0200
+@@ -37,6 +37,7 @@
  
  	if (getpid() != 1)
  		return 1;
--	chdir("/");
 +	setsid();
-+  	chdir("/");
+ 	chdir("/");
  	sigfillset(&set);
  	sigprocmask(SIG_BLOCK, &set, NULL);
- 	spawn(rcinitcmd);

--- a/contrib/sinit/patches/sinit.patch
+++ b/contrib/sinit/patches/sinit.patch
@@ -1,0 +1,14 @@
+Index: sinit/sinit/sinit.c
+===================================================================
+--- sinit.orig/sinit/sinit.c	2023-06-04 17:28:33.209715149 +0200
++++ sinit/sinit/sinit.c	2023-06-04 17:29:49.403045971 +0200
+@@ -37,7 +37,8 @@
+ 
+ 	if (getpid() != 1)
+ 		return 1;
+-	chdir("/");
++	setsid();
++  	chdir("/");
+ 	sigfillset(&set);
+ 	sigprocmask(SIG_BLOCK, &set, NULL);
+ 	spawn(rcinitcmd);

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -80,6 +80,13 @@ static __noreturn void start_init(__unused void *arg) {
   if (init == NULL)
     init = "/sbin/init";
 
+  /* XXX If /sbin/init is started then the kernel shouldn't create a session
+  nor open file descriptors for it (i.e. give init a controlling terminal).
+  Session creation is on the side of /sbin/init, and acquiring controlling terminal
+  takes place in the `getty` process - init's child.
+
+  Otherwise, if init gets the controlling terminal, then we won't be able to get it
+  in any other process. This results in e.g. `ksh` not having a full job control. */
   if (strcmp("/sbin/init", init))
     open_fds();
 

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -82,11 +82,12 @@ static __noreturn void start_init(__unused void *arg) {
 
   /* XXX If /sbin/init is started then the kernel shouldn't create a session
   nor open file descriptors for it (i.e. give init a controlling terminal).
-  Session creation is on the side of /sbin/init, and acquiring controlling terminal
-  takes place in the `getty` process - init's child.
+  Session creation is on the side of /sbin/init, and acquiring controlling
+  terminal takes place in the `getty` process - init's child.
 
-  Otherwise, if init gets the controlling terminal, then we won't be able to get it
-  in any other process. This results in e.g. `ksh` not having a full job control. */
+  Otherwise, if init gets the controlling terminal, then we won't be able to get
+  it in any other process. This results in e.g. `ksh` not having a full job
+  control. */
   if (strcmp("/sbin/init", init))
     open_fds();
 

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -42,8 +42,11 @@ static void mount_fs(void) {
 
 static void open_fds(void) {
   proc_t *p = proc_self();
+  int error, _stdin, _stdout, _stderr;
 
-  int _stdin, _stdout, _stderr;
+  error = session_enter(p);
+  assert(error == 0);
+
   do_open(p, "/dev/uart", O_RDONLY, 0, &_stdin);
   do_open(p, "/dev/uart", O_WRONLY, 0, &_stdout);
   do_open(p, "/dev/uart", O_WRONLY, 0, &_stderr);
@@ -55,7 +58,6 @@ static void open_fds(void) {
 
 static __noreturn void start_init(__unused void *arg) {
   proc_t *p = proc_self();
-  int error;
 
   thread_t *td = thread_self();
 
@@ -67,8 +69,6 @@ static __noreturn void start_init(__unused void *arg) {
   init_devices();
 
   assert(p->p_pid == 1);
-  error = session_enter(p);
-  assert(error == 0);
 
   char *test = kenv_get("test");
   if (test) {

--- a/sys/kern/main.c
+++ b/sys/kern/main.c
@@ -40,6 +40,19 @@ static void mount_fs(void) {
   do_fchmodat(p, AT_FDCWD, "/tmp", ACCESSPERMS | S_ISTXT, 0);
 }
 
+static void open_fds(void) {
+  proc_t *p = proc_self();
+
+  int _stdin, _stdout, _stderr;
+  do_open(p, "/dev/uart", O_RDONLY, 0, &_stdin);
+  do_open(p, "/dev/uart", O_WRONLY, 0, &_stdout);
+  do_open(p, "/dev/uart", O_WRONLY, 0, &_stderr);
+
+  assert(_stdin == 0);
+  assert(_stdout == 1);
+  assert(_stderr == 2);
+}
+
 static __noreturn void start_init(__unused void *arg) {
   proc_t *p = proc_self();
   int error;
@@ -57,23 +70,18 @@ static __noreturn void start_init(__unused void *arg) {
   error = session_enter(p);
   assert(error == 0);
 
-  /* ... and initialize file descriptors required by the standard library. */
-  int _stdin, _stdout, _stderr;
-  do_open(p, "/dev/uart", O_RDONLY, 0, &_stdin);
-  do_open(p, "/dev/uart", O_WRONLY, 0, &_stdout);
-  do_open(p, "/dev/uart", O_WRONLY, 0, &_stderr);
-
-  assert(_stdin == 0);
-  assert(_stdout == 1);
-  assert(_stderr == 2);
-
   char *test = kenv_get("test");
-  if (test)
+  if (test) {
+    open_fds();
     ktest_main(test);
+  }
 
   char *init = kenv_get("init");
   if (init == NULL)
     init = "/sbin/init";
+
+  if (strcmp("/sbin/init", init))
+    open_fds();
 
   kern_execve(init, kenv_get_init(), (char *[]){NULL});
 


### PR DESCRIPTION
This PR changes the way `/sbin/init` is started from kernel space:
* kernel does not open 0, 1, 2 file descriptors for `/sbin/init`, which means that`/sbin/init` doesn't get a controlling terminal
* session is created in `/sbin/init` process