### PR TITLE
tty: add TIOCNOTTY ioctl

### DIFF
--- a/contrib/sinit/patches/series
+++ b/contrib/sinit/patches/series
@@ -1,1 +1,2 @@
+sinit.patch
 config.patch

--- a/contrib/sinit/patches/sinit.patch
+++ b/contrib/sinit/patches/sinit.patch
@@ -1,0 +1,24 @@
+Index: sinit/sinit/sinit.c
+===================================================================
+--- sinit.orig/sinit/sinit.c
++++ sinit/sinit/sinit.c
+@@ -6,6 +6,8 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <fcntl.h>
++#include <sys/ioctl.h>
+ 
+ #define LEN(x)	(sizeof (x) / sizeof *(x))
+ #define TIMEO	30
+@@ -40,6 +42,10 @@ main(void)
+ 	chdir("/");
+ 	sigfillset(&set);
+ 	sigprocmask(SIG_BLOCK, &set, NULL);
++	/* Disassociate the controlling terminal from init. File descriptors
++	0, 1 and 2 are already opened and attached to /dev/tty (which is the
++	controlling terminal), so we can call TIOCNOTTY on one of them */
++	ioctl(0, TIOCNOTTY, (void *)0);
+ 	spawn(rcinitcmd);
+ 	while (1) {
+ 		alarm(TIMEO);

--- a/include/sys/ttycom.h
+++ b/include/sys/ttycom.h
@@ -76,6 +76,7 @@ typedef char linedn_t[TTLINEDNAMELEN];
 #define TIOCPTSNAME _IOW('t', 105, char *)        /* get slave device path */
 #define TIOCSTART _IO('t', 110)                   /* start output, like ^Q */
 #define TIOCSTOP _IO('t', 111)                    /* stop output, like ^S */
+#define TIOCNOTTY _IO('t', 113)                   /* void tty association */
 #define TIOCGPGRP _IOR('t', 119, int)             /* get pgrp of tty */
 #define TIOCSPGRP _IOW('t', 118, int)             /* set pgrp of tty */
 #define TIOCGQSIZE _IOR('t', 129, int)            /* get queue size */


### PR DESCRIPTION
This PR adds `TIOCNOTTY` ioctl, which is used to disassociate the controlling terminal from a process. This ioctl should be used in `sinit.c`, so that a controlling terminal can be disassociated in the init process and later acquired in `getty` (related PR: https://github.com/cahirwpz/mimiker/pull/1390).