### PR TITLE
sbase: add getconf and hostname

### DIFF
--- a/contrib/sbase/Makefile
+++ b/contrib/sbase/Makefile
@@ -196,7 +196,7 @@ $(BUILDDIR)sbase/getconf.o: $(BUILDDIR)/sbase/getconf.h
 $(BUILDDIR)/sbase/getconf.h: sbase/getconf.sh
 	./sbase/getconf.sh > $@
 
-CFLAGS.sbase/getconf.c += -I$(BUILDDIR)/sbase
+CFLAGS.sbase/getconf.c += -I$(BUILDDIR)/sbase -Wno-error=type-limits
 
 include $(TOPDIR)/build/build.prog.mk
 

--- a/contrib/sbase/Makefile
+++ b/contrib/sbase/Makefile
@@ -103,6 +103,7 @@ BIN = \
 	getconf \
 	grep \
 	head \
+	hostname \
 	join \
 	kill \
 	link \
@@ -172,7 +173,6 @@ BIN_DISABLED = \
 	du \
 	ed \
 	flock \
-	hostname \
 	logger \
 	mknod \
 	tftp

--- a/contrib/sbase/Makefile
+++ b/contrib/sbase/Makefile
@@ -100,6 +100,7 @@ BIN = \
 	false \
 	find \
 	fold \
+	getconf \
 	grep \
 	head \
 	join \
@@ -171,7 +172,6 @@ BIN_DISABLED = \
 	du \
 	ed \
 	flock \
-	getconf \
 	hostname \
 	logger \
 	mknod \
@@ -190,6 +190,13 @@ SOURCES = $(PROGRAM).c $(addprefix sbase/,$(BIN:=.c)) $(addprefix sbase/,$(LIBUT
 FORMAT-EXCLUDE = $(SOURCES) $(addprefix sbase/,$(HDR))
 
 WFLAGS += -Wno-error=sign-compare -Wno-error=implicit-fallthrough
+
+$(BUILDDIR)sbase/getconf.o: $(BUILDDIR)/sbase/getconf.h
+
+$(BUILDDIR)/sbase/getconf.h: sbase/getconf.sh
+	./sbase/getconf.sh > $@
+
+CFLAGS.sbase/getconf.c += -I$(BUILDDIR)/sbase
 
 include $(TOPDIR)/build/build.prog.mk
 

--- a/include/sys/syslimits.h
+++ b/include/sys/syslimits.h
@@ -69,5 +69,6 @@
  * IEEE Std 1003.1c-95, adopted in X/Open CAE Specification Issue 5 Version 2
  */
 #define LOGIN_NAME_MAX 17 /* max login name length incl. NUL */
+#define HOST_NAME_MAX 255 /* max hostname length w/o NUL */
 
 #endif /* !_SYS_SYSLIMITS_H_ */

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -122,6 +122,7 @@ pid_t getpgid(pid_t);
 int lchown(const char *, uid_t, gid_t);
 int lockf(int, int, off_t);
 void *sbrk(intptr_t);
+int sethostname(const char *, size_t);
 int setpgrp(pid_t, pid_t);
 int setregid(gid_t, gid_t);
 int setreuid(uid_t, uid_t);

--- a/lib/libc/gen/gethostname.c
+++ b/lib/libc/gen/gethostname.c
@@ -1,0 +1,6 @@
+#include <string.h>
+
+int gethostname(char *name, size_t namelen) {
+  strlcpy(name, "localhost", namelen);
+  return 0;
+}

--- a/lib/libc/gen/sethostname.c
+++ b/lib/libc/gen/sethostname.c
@@ -1,0 +1,7 @@
+#include <errno.h>
+#include <unistd.h>
+
+int sethostname(const char *name, size_t namelen) {
+  errno = ENOTSUP;
+  return -1;
+}


### PR DESCRIPTION
This PR adds the following missing tools from suckless sbase:
* `hostname` with `gethostname` and `sethostname` function stubs
* `getconf`