### PR TITLE
[ktest] fix thread name buffer size

### DIFF
--- a/sys/tests/sleepq_timed.c
+++ b/sys/tests/sleepq_timed.c
@@ -66,7 +66,7 @@ static int test_sleepq_timed(void) {
   waker =
     thread_create("test-sleepq-waker", waker_routine, NULL, prio_kthread(0));
   for (int i = 0; i < THREADS; i++) {
-    char name[20];
+    char name[32];
     snprintf(name, sizeof(name), "test-sleepq-waiter-%d", i);
     waiters[i] =
       thread_create(name, waiter_routine, NULL, prio_kthread(0) + RQ_PPQ);


### PR DESCRIPTION
>    char name[20];
>    snprintf(name, sizeof(name), "test-sleepq-waiter-%d", i);

thread name written by snprintf has 20+ characters. name has space for 20 characters including \0. As a result thread name is always truncated to test-sleep-waiter-.