### PR TITLE
[clock] synchronize now

### DIFF
--- a/sys/kern/clock.c
+++ b/sys/kern/clock.c
@@ -6,12 +6,12 @@
 #include <sys/timer.h>
 #include <sys/kgprof.h>
 
-static systime_t now = 0;
+static _Atomic(systime_t) now = 0;
 static timer_t *clock = NULL;
 static timer_t *profclock = NULL;
 
 systime_t getsystime(void) {
-  return now;
+  return atomic_load(&now);
 }
 
 static void prof_clock(timer_t *tm, void *arg) {
@@ -20,7 +20,7 @@ static void prof_clock(timer_t *tm, void *arg) {
 
 static void clock_cb(timer_t *tm, void *arg) {
   bintime_t bin = binuptime();
-  now = bt2st(&bin);
+  atomic_store(&now, bt2st(&bin));
   if (profclock == NULL)
     prof_clock(tm, arg);
   callout_process(now);


### PR DESCRIPTION
Use explicitly atomics for now.

Pathological scenario reported by sanitizer:

thread1:                        thread2:
    - gettime                           - clock_cb
        - return now           <race>           - now = bt2st(bin)

Found-by: KCSAN