### PR TITLE
Add pselect syscall as a wrapper of kevent

### DIFF
--- a/lib/libc/sys/select.c
+++ b/lib/libc/sys/select.c
@@ -21,9 +21,14 @@ int pselect(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
         return -1;
     }
 
-    kq = kqueue1(O_CLOEXEC);
-    if (kq < 0)
+    if (sigmask && sigprocmask(SIG_SETMASK, sigmask, &sigs))
         return -1;
+
+    kq = kqueue1(O_CLOEXEC);
+    if (kq < 0) {
+        ret = -1;
+        goto restore_sigs;
+    }
 
     events = malloc(2 * nfds * sizeof(struct kevent));
     if (!events) {
@@ -44,9 +49,6 @@ int pselect(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
     if (writefds != NULL)
         FD_ZERO(writefds);
 
-    if (sigmask && sigprocmask(SIG_SETMASK, sigmask, &sigs))
-        return -1;
-
     ret = kevent(kq, events, nevents, events, nevents, timeout);
     if (ret == -1)
         goto end;
@@ -65,10 +67,11 @@ int pselect(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
 
 end:
     free(events);
-    if (sigmask && sigprocmask(SIG_SETMASK, &sigs, NULL))
-        ret = -1;
 close_kq:
     close(kq);
+restore_sigs:
+    if (sigmask && sigprocmask(SIG_SETMASK, &sigs, NULL))
+        ret = -1;
     return ret;
 }
 

--- a/lib/libc/sys/select.c
+++ b/lib/libc/sys/select.c
@@ -7,9 +7,9 @@
 #include <errno.h>
 #include <signal.h>
 
-int pselect(int nfds, fd_set *readfds, fd_set *writefds,
-            fd_set *exceptfds, const struct timespec *timeout,
-            const sigset_t *sigmask) {
+int pselect(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
+            fd_set *restrict exceptfds, const struct timespec *restrict timeout,
+            const sigset_t *restrict sigmask) {
     int kq;
     int ret;
     struct kevent *events;

--- a/lib/libc/sys/select.c
+++ b/lib/libc/sys/select.c
@@ -5,27 +5,20 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
+#include <signal.h>
 
-int select(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
-           fd_set *restrict exceptfds, struct timeval *restrict timeout) {
+int pselect(int nfds, fd_set *readfds, fd_set *writefds,
+            fd_set *exceptfds, const struct timespec *timeout,
+            const sigset_t *sigmask) {
     int kq;
     int ret;
-    struct timespec timeout_ts;
     struct kevent *events;
     int nevents = 0;
+    sigset_t sigs;
 
     if (nfds < 0) {
         errno = EINVAL;
         return -1;
-    }
-
-    if (timeout != NULL) {
-        if (timeout->tv_sec < 0 || timeout->tv_usec < 0 || timeout->tv_usec >= 1000000) {
-            errno = EINVAL;
-            return -1;
-        }
-
-        tv2ts(timeout, &timeout_ts);
     }
 
     kq = kqueue1(O_CLOEXEC);
@@ -50,8 +43,11 @@ int select(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
         FD_ZERO(readfds);
     if (writefds != NULL)
         FD_ZERO(writefds);
-    
-    ret = kevent(kq, events, nevents, events, nevents, timeout == NULL ? NULL : &timeout_ts);
+
+    if (sigmask && sigprocmask(SIG_SETMASK, sigmask, &sigs))
+        return -1;
+
+    ret = kevent(kq, events, nevents, events, nevents, timeout);
     if (ret == -1)
         goto end;
 
@@ -69,7 +65,26 @@ int select(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
 
 end:
     free(events);
+    if (sigmask && sigprocmask(SIG_SETMASK, &sigs, NULL))
+        ret = -1;
 close_kq:
     close(kq);
     return ret;
+}
+
+int select(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
+           fd_set *restrict exceptfds, struct timeval *restrict timeout) {
+    struct timespec timeout_ts;
+    
+    if (timeout != NULL) {
+        if (timeout->tv_sec < 0 || timeout->tv_usec < 0 || timeout->tv_usec >= 1000000) {
+            errno = EINVAL;
+            return -1;
+        }
+
+        tv2ts(timeout, &timeout_ts);
+    }
+
+    return pselect(nfds, readfds, writefds, exceptfds,
+                   timeout == NULL ? NULL : &timeout_ts , NULL);
 }


### PR DESCRIPTION
This PR provides `pselect` syscall implementation. Since the operation of `pselect` and `select` is almost identical, I reorganized the `lib/libc/sys/select.c` file, so that:
* `pselect` contains all the core implementation
* `select` converts its `struct timeval` argument to `struct timespec` and calls `pselect`