### PR TITLE
Improve pmap protect

### DIFF
--- a/include/aarch64/pmap.h
+++ b/include/aarch64/pmap.h
@@ -55,15 +55,53 @@ static __no_profile inline bool pde_valid_p(pde_t *pdep) {
 
 void *phys_to_dmap(paddr_t addr);
 
-static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
+static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
+  switch (lvl) {
+    case 0:
+      return L0_INDEX(va);
+    case 1:
+      return L1_INDEX(va);
+    case 2:
+      return L2_INDEX(va);
+    case 3:
+      return L3_INDEX(va);
+  }
+  panic("Invalid level: %d", lvl);
+}
+
+static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
   pde_t *pde = phys_to_dmap(pd_pa);
-  if (lvl == 0)
-    return pde + L0_INDEX(va);
-  if (lvl == 1)
-    return pde + L1_INDEX(va);
-  if (lvl == 2)
-    return pde + L2_INDEX(va);
-  return pde + L3_INDEX(va);
+  return pde + index;
+}
+
+static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
+  return pde_ptr_idx(pd_pa, pde_index(lvl, va));
+}
+
+static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
+  switch (lvl) {
+    case 0:
+      return index < L0_ENTRIES;
+    case 1:
+    case 2:
+    case 3:
+      return index < Ln_ENTRIES;
+  }
+  panic("Invalid level: %d", lvl);
+}
+
+static __no_profile inline size_t pde_size(int lvl) {
+  switch (lvl) {
+    case 0:
+      return L0_SIZE;
+    case 1:
+      return L1_SIZE;
+    case 2:
+      return L2_SIZE;
+    case 3:
+      return L3_SIZE;
+  }
+  panic("Invalid level: %d", lvl);
 }
 
 /*

--- a/include/aarch64/pmap.h
+++ b/include/aarch64/pmap.h
@@ -69,15 +69,6 @@ static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
   panic("Invalid level: %d", lvl);
 }
 
-static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
-  pde_t *pde = phys_to_dmap(pd_pa);
-  return pde + index;
-}
-
-static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
-  return pde_ptr_idx(pd_pa, pde_index(lvl, va));
-}
-
 static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
   switch (lvl) {
     case 0:

--- a/include/aarch64/pmap.h
+++ b/include/aarch64/pmap.h
@@ -65,8 +65,9 @@ static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
       return L2_INDEX(va);
     case 3:
       return L3_INDEX(va);
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
@@ -77,8 +78,9 @@ static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
     case 2:
     case 3:
       return index < Ln_ENTRIES;
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 static __no_profile inline size_t pde_size(int lvl) {
@@ -91,8 +93,9 @@ static __no_profile inline size_t pde_size(int lvl) {
       return L2_SIZE;
     case 3:
       return L3_SIZE;
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 /*

--- a/include/mips/pmap.h
+++ b/include/mips/pmap.h
@@ -89,8 +89,9 @@ static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
       return PDE_INDEX(va);
     case 1:
       return PTE_INDEX(va);
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
@@ -101,8 +102,9 @@ static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
     case 2:
     case 3:
       return index < PT_ENTRIES;
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 static __no_profile inline size_t pde_size(int lvl) {
@@ -111,8 +113,9 @@ static __no_profile inline size_t pde_size(int lvl) {
       return PAGESIZE * PT_ENTRIES;
     case 1:
       return PAGESIZE;
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 /*

--- a/include/mips/pmap.h
+++ b/include/mips/pmap.h
@@ -93,15 +93,6 @@ static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
   panic("Invalid level: %d", lvl);
 }
 
-static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
-  pde_t *pde = phys_to_dmap(pd_pa);
-  return pde + index;
-}
-
-static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
-  return pde_ptr_idx(pd_pa, pde_index(lvl, va));
-}
-
 static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
   switch (lvl) {
     case 0:

--- a/include/riscv/pmap.h
+++ b/include/riscv/pmap.h
@@ -62,8 +62,9 @@ static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
     case 2:
       return L2_INDEX(va);
 #endif
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
@@ -74,8 +75,9 @@ static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
     case 2:
 #endif
       return index < Ln_ENTRIES;
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 static __no_profile inline size_t pde_size(int lvl) {
@@ -88,8 +90,9 @@ static __no_profile inline size_t pde_size(int lvl) {
     case 2:
       return L2_SIZE;
 #endif
+    default:
+      panic("Invalid level: %d", lvl);
   }
-  panic("Invalid level: %d", lvl);
 }
 
 /*

--- a/include/riscv/pmap.h
+++ b/include/riscv/pmap.h
@@ -52,17 +52,53 @@ static __no_profile inline bool pde_valid_p(pde_t *pdep) {
 
 void *phys_to_dmap(paddr_t addr);
 
-static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
-  pde_t *pde = phys_to_dmap(pd_pa);
-  if (lvl == 0)
-    return pde + L0_INDEX(va);
-#if __riscv_xlen == 32
-  return pde + L1_INDEX(va);
-#else
-  if (lvl == 1)
-    return pde + L1_INDEX(va);
-  return pde + L2_INDEX(va);
+static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
+  switch (lvl) {
+    case 0:
+      return L0_INDEX(va);
+    case 1:
+      return L1_INDEX(va);
+#if __riscv_xlen == 64
+    case 2:
+      return L2_INDEX(va);
 #endif
+  }
+  panic("Invalid level: %d", lvl);
+}
+
+static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
+  pde_t *pde = phys_to_dmap(pd_pa);
+  return pde + index;
+}
+
+static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
+  return pde_ptr_idx(pd_pa, pde_index(lvl, va));
+}
+
+static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
+  switch (lvl) {
+    case 0:
+    case 1:
+#if __riscv_xlen == 64
+    case 2:
+#endif
+      return index < Ln_ENTRIES;
+  }
+  panic("Invalid level: %d", lvl);
+}
+
+static __no_profile inline size_t pde_size(int lvl) {
+  switch (lvl) {
+    case 0:
+      return L0_SIZE;
+    case 1:
+      return L1_SIZE;
+#if __riscv_xlen == 64
+    case 2:
+      return L2_SIZE;
+#endif
+  }
+  panic("Invalid level: %d", lvl);
 }
 
 /*

--- a/include/riscv/pmap.h
+++ b/include/riscv/pmap.h
@@ -66,15 +66,6 @@ static __no_profile inline size_t pde_index(int lvl, vaddr_t va) {
   panic("Invalid level: %d", lvl);
 }
 
-static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
-  pde_t *pde = phys_to_dmap(pd_pa);
-  return pde + index;
-}
-
-static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
-  return pde_ptr_idx(pd_pa, pde_index(lvl, va));
-}
-
 static __no_profile inline bool pde_valid_index(int lvl, size_t index) {
   switch (lvl) {
     case 0:

--- a/include/sys/_pmap.h
+++ b/include/sys/_pmap.h
@@ -68,7 +68,6 @@ extern paddr_t dmap_paddr_end;
 static inline bool pde_valid_p(pde_t *pdep);
 paddr_t pde_alloc(pmap_t *pmap);
 pde_t pde_make(int lvl, paddr_t pa);
-static inline pde_t *pde_ptr(paddr_t pd, int lvl, vaddr_t va);
 
 static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
   pde_t *pde = phys_to_dmap(pd_pa);

--- a/include/sys/_pmap.h
+++ b/include/sys/_pmap.h
@@ -70,6 +70,15 @@ paddr_t pde_alloc(pmap_t *pmap);
 pde_t pde_make(int lvl, paddr_t pa);
 static inline pde_t *pde_ptr(paddr_t pd, int lvl, vaddr_t va);
 
+static __no_profile inline pde_t *pde_ptr_idx(paddr_t pd_pa, size_t index) {
+  pde_t *pde = phys_to_dmap(pd_pa);
+  return pde + index;
+}
+
+static __no_profile inline pde_t *pde_ptr(paddr_t pd_pa, int lvl, vaddr_t va) {
+  return pde_ptr_idx(pd_pa, pde_index(lvl, va));
+}
+
 /*
  * Page table.
  */

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -237,9 +237,8 @@ void pmap_kremove(vaddr_t va, size_t size) {
     for (size_t off = 0; off < size; off += PAGESIZE) {
       pte_t *ptep = pmap_lookup_pte(pmap, va + off);
       assert(ptep);
-      *ptep = PTE_EMPTY_KERNEL;
+      pmap_write_pte(pmap, ptep, PTE_EMPTY_KERNEL, va + off);
     }
-    tlb_invalidate_asid(pmap->asid);
   }
 }
 
@@ -292,9 +291,8 @@ void pmap_remove(pmap_t *pmap, vaddr_t start, vaddr_t end) {
         paddr_t pa = pte_frame(*ptep);
         vm_page_t *pg = vm_page_find(pa);
         pv_remove(pmap, va, pg);
-        *ptep = PTE_EMPTY_USER;
+        pmap_write_pte(pmap, ptep, PTE_EMPTY_USER, va);
       }
-      tlb_invalidate_asid(pmap->asid);
     }
   }
 }

--- a/sys/gen/pmap.c
+++ b/sys/gen/pmap.c
@@ -321,8 +321,8 @@ static inline size_t next_vaddr(int lvl) {
   return PAGESIZE;
 }
 
-static void pmap_protect_range(int lvl, paddr_t pd_pa, vaddr_t va, vaddr_t end,
-                               vm_prot_t prot) {
+static void pmap_protect_walk(int lvl, paddr_t pd_pa, vaddr_t va, vaddr_t end,
+                              vm_prot_t prot) {
 
   for (size_t pde_i = pde_index(lvl, va);
        pde_valid_index(lvl, pde_i) && va < end;
@@ -339,7 +339,7 @@ static void pmap_protect_range(int lvl, paddr_t pd_pa, vaddr_t va, vaddr_t end,
       pte_t pte = pte_protect(*ptep, prot);
       *ptep = pte;
     } else {
-      pmap_protect_range(lvl + 1, pa, va, end, prot);
+      pmap_protect_walk(lvl + 1, pa, va, end, prot);
     }
   }
 }
@@ -353,7 +353,7 @@ void pmap_protect(pmap_t *pmap, vaddr_t start, vaddr_t end, vm_prot_t prot) {
        end);
 
   WITH_MTX_LOCK (&pmap->mtx) {
-    pmap_protect_range(0, pmap->pde, start, end, prot);
+    pmap_protect_walk(0, pmap->pde, start, end, prot);
     tlb_invalidate_asid(pmap->asid);
   }
 }


### PR DESCRIPTION
Optimizing `pmap_protect` to traverse pmap structure effectively instead of looking up every pte starting from root.

The `pmap_protect_walk` function is called recursively at each pmap level. On the last level it modifies the protection of pte.

Below I provide some statistics about function calls created using KFT, to show that this change really matters.

**Before**
```
     function: count avg time
 vm_map_clone:   146   158477
vm_page_fault:  3910     7901
 pmap_protect:  1041    19849
```
**After**
```
     function: count avg time
 vm_map_clone:   146    64040
vm_page_fault:  3668     7554
 pmap_protect:  1041     6674
```
